### PR TITLE
Job state generalization refactors (2/?)

### DIFF
--- a/src/BlmRotations.test.ts
+++ b/src/BlmRotations.test.ts
@@ -306,3 +306,78 @@ it("has different F1 modifiers at different AF/UI states", testWithConfig({}, ()
 		},
 	]);
 }));
+
+
+it("accepts the standard aoe rotation", testWithConfig({}, () => {
+	[
+		SkillName.HighBlizzard2, // no eno
+		SkillName.Freeze, // UI3
+		SkillName.HighFire2, // UI3
+		// it's optimal for dps to skip these, but we're testing resource consumption here
+		SkillName.HighFire2, // AF3
+		SkillName.HighFire2, // AF3
+		// hard clip triplecast
+		SkillName.Triplecast,
+		SkillName.Flare, // AF3
+
+	].forEach(applySkill);
+	// wait for cast time + damage application
+	controller.step(4);
+	expect(checkEnochian()).toBeTruthy();
+	expect((controller.game as BLMState).resources.get(ResourceType.Mana).availableAmount()).toEqual(2380);
+	expect((controller.game as BLMState).resources.get(ResourceType.UmbralHeart).availableAmount()).toEqual(0);
+	[
+		SkillName.Flare, // AF3
+		SkillName.FlareStar, // Flare
+		SkillName.Manafont,
+		SkillName.Triplecast,
+		SkillName.Flare, // AF3
+		SkillName.Flare, // AF3
+		SkillName.FlareStar, // Flare
+	].forEach(applySkill);
+	controller.step(4);
+	expect(checkEnochian()).toBeTruthy();
+	expect((controller.game as BLMState).resources.get(ResourceType.Mana).availableAmount()).toEqual(0);
+	compareDamageTables([
+		{
+			skillName: SkillName.Flare,
+			displayedModifiers: [PotencyModifierType.AF3],
+			hitCount: 4,
+		},
+		{
+			skillName: SkillName.FlareStar,
+			displayedModifiers: [PotencyModifierType.AF3],
+			hitCount: 2,
+		},
+		{
+			skillName: SkillName.HighFire2,
+			displayedModifiers: [PotencyModifierType.AF3],
+			hitCount: 2,
+		},
+		{
+			skillName: SkillName.HighFire2,
+			displayedModifiers: [PotencyModifierType.UI3],
+			hitCount: 1,
+		},
+		{
+			skillName: SkillName.Freeze,
+			displayedModifiers: [PotencyModifierType.UI3],
+			hitCount: 1,
+		},
+		{
+			skillName: SkillName.HighBlizzard2,
+			displayedModifiers: [],
+			hitCount: 1,
+		},
+		{
+			skillName: SkillName.Manafont,
+			displayedModifiers: [],
+			hitCount: 1,
+		},
+		{
+			skillName: SkillName.Triplecast,
+			displayedModifiers: [],
+			hitCount: 2,
+		},
+	]);
+}));

--- a/src/BlmRotations.test.ts
+++ b/src/BlmRotations.test.ts
@@ -20,6 +20,7 @@ import {TickMode} from "./Controller/Common";
 import {DEFAULT_CONFIG, GameConfig} from "./Game/GameConfig";
 import {PotencyModifierType} from "./Game/Potency";
 import {ResourceType, SkillName} from "./Game/Common";
+import {BLMState} from "./Game/Jobs/BLM";
 import {DamageStatisticsData, mockDamageStatUpdateFn} from "./Components/DamageStatistics";
 
 
@@ -142,7 +143,7 @@ const compareDamageTables = (expectedDamageEntries: Array<ShortDamageEntry>) => 
 	expect(actualDamageEntries).toEqual(expectedDamageEntries);
 };
 
-const checkEnochian = () => controller.game.hasEnochian();;
+const checkEnochian = () => (controller.game as BLMState).hasEnochian();;
 
 it("accepts the standard rotation", testWithConfig({}, () => {
 	[

--- a/src/Components/PlaybackControl.js
+++ b/src/Components/PlaybackControl.js
@@ -159,15 +159,15 @@ export class TimeControl extends React.Component {
 }
 
 function ConfigSummary(props) {
-	let gcd = controller.gameConfig.adjustedGCD(false);
+	let gcd = controller.gameConfig.adjustedGCD();
 	let gcdAfterTax = controller.gameConfig.getAfterTaxGCD(gcd).toFixed(3);
 	let castTimesTableDesc = localize({
 		en: "Unlike GCDs that have 2 digits of precision, cast times have 3. See About this tool/Implementation notes.",
 		zh: "不同于GCD那样精确到小数点后2位，咏唱时间会精确到小数点后3位。详见 关于/实现细节"
 	});
-	let preTaxFn = t => { return controller.gameConfig.adjustedCastTime(t, false).toFixed(3); }
+	let preTaxFn = t => { return controller.gameConfig.adjustedCastTime(t).toFixed(3); }
 	let afterTaxFn = t => {
-		let preTax = controller.gameConfig.adjustedCastTime(t, false);
+		let preTax = controller.gameConfig.adjustedCastTime(t);
 		return controller.gameConfig.getAfterTaxCastTime(preTax).toFixed(3);
 	};
 	let castTimesChart =<div>
@@ -213,7 +213,7 @@ function ConfigSummary(props) {
 		zh: "醒梦buff期间，每次跳蓝后多久跳醒梦（由随机种子决定）"
 	});
 	// TODO specialize for BLM
-	let thunderTickOffset = controller.game.jobState.thunderTickOffset.toFixed(3);
+	let thunderTickOffset = controller.game.thunderTickOffset.toFixed(3);
 	let thunderOffsetDesc = localize({
 		en: "the random time offset of thunder DoT ticks relative to mp ticks",
 		zh: "雷DoT期间，每次跳蓝后多久跳雷（由随机种子决定）"
@@ -304,7 +304,7 @@ function getTaxPreview(level, baseCastTime, spsStr, fpsStr) {
 	if (isNaN(sps) || isNaN(fps)) {
 		return "n/a";
 	}
-	let adjustedCastTime = XIVMath.preTaxCastTime(level, sps, baseCastTime, false);
+	let adjustedCastTime = XIVMath.preTaxCastTime(level, sps, baseCastTime);
 	return (XIVMath.afterFpsTax(fps, adjustedCastTime) - adjustedCastTime + XIVMath.afterFpsTax(fps, FIXED_BASE_CASTER_TAX)).toFixed(3);
 }
 

--- a/src/Components/Skills.js
+++ b/src/Components/Skills.js
@@ -10,7 +10,7 @@ import {updateTimelineView} from "./Timeline";
 import * as ReactDOMServer from 'react-dom/server';
 import {getCurrentThemeColors} from "./ColorTheme";
 import {TraitName, Traits} from '../Game/Traits';
-import {skillInfosMap} from "../Game/Skills";
+import {skillMap} from "../Game/Skills";
 
 // Imports of Game/Jobs/* must come after Game/Skills is initialized.
 import "../Game/Jobs/BLM";
@@ -21,7 +21,7 @@ export const skillIcons = new Map();
 
 // Only import necessary skills
 // TODO: change this if we serve multiple jobs off the same site
-skillInfosMap.get(ShellInfo.job).forEach(
+skillMap.get(ShellInfo.job).forEach(
 	(skillInfo) => skillIcons.set(skillInfo.name, require(`./Asset/Skills/${skillInfo.assetPath}`)),
 );
 

--- a/src/Components/Skills.tsx
+++ b/src/Components/Skills.tsx
@@ -10,7 +10,7 @@ import {updateTimelineView} from "./Timeline";
 import * as ReactDOMServer from 'react-dom/server';
 import {getCurrentThemeColors} from "./ColorTheme";
 import {TraitName, Traits} from '../Game/Traits';
-import {skillMap} from "../Game/Skills";
+import {getAllSkills} from "../Game/Skills";
 
 // Imports of Game/Jobs/* must come after Game/Skills is initialized.
 import "../Game/Jobs/BLM";
@@ -21,7 +21,7 @@ export const skillIcons = new Map();
 
 // Only import necessary skills
 // TODO: change this if we serve multiple jobs off the same site
-skillMap.get(ShellInfo.job)!.forEach(
+getAllSkills(ShellInfo.job)!.forEach(
 	(skillInfo) => skillIcons.set(skillInfo.name, require(`./Asset/Skills/${skillInfo.assetPath}`)),
 );
 

--- a/src/Controller/Common.ts
+++ b/src/Controller/Common.ts
@@ -27,6 +27,9 @@ export const enum ShellJob {
 	PCT = "PCT",
 }
 
+// can't get this automatically from a const enum
+export const ALL_JOBS = [ShellJob.BLM, ShellJob.PCT];
+
 export const enum Expansion {
 	EW = "EW",
 	DT = "DT"

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -8,6 +8,7 @@ import {
 	TickMode
 } from "./Common";
 import {GameState, newGameState} from "../Game/GameState";
+import {BLMState} from "../Game/Jobs/BLM";
 import {Debug, LevelSync, ProcMode, ResourceType, SkillName, SkillReadyStatus, WarningType} from "../Game/Common";
 import {DEFAULT_CONFIG, GameConfig} from "../Game/GameConfig"
 // @ts-ignore
@@ -600,8 +601,8 @@ class Controller {
 			mana: game.resources.get(ResourceType.Mana).availableAmount(),
 			timeTillNextManaTick: game.resources.timeTillReady(ResourceType.Mana),
 			enochianCountdown: enoCountdown,
-			astralFire: game.getFireStacks(),
-			umbralIce: game.getIceStacks(),
+			astralFire: (game as BLMState).getFireStacks(),
+			umbralIce: (game as BLMState).getIceStacks(),
 			umbralHearts: game.resources.get(ResourceType.UmbralHeart).availableAmount(),
 			paradox: game.resources.get(ResourceType.Paradox).availableAmount(),
 			astralSoul: game.resources.get(ResourceType.AstralSoul).availableAmount(),
@@ -781,8 +782,8 @@ class Controller {
 				&& !this.game.resources.get(ResourceType.Paradox).available(1))
 			{
 				// and vice versa
-				if (this.game.getFireStacks() > 0) skillName = SkillName.Fire;
-				else if (this.game.getIceStacks() > 0) skillName = SkillName.Blizzard;
+				if ((this.game as BLMState).getFireStacks() > 0) skillName = SkillName.Fire;
+				else if ((this.game as BLMState).getIceStacks() > 0) skillName = SkillName.Blizzard;
 			}
 			status = this.game.getSkillAvailabilityStatus(skillName);
 			this.lastAttemptedSkill = "";
@@ -813,8 +814,8 @@ class Controller {
 
 			if (!this.#bCalculatingHistoricalState) { // this block is run when NOT viewing historical state (aka run when receiving input)
 				let newStatus = this.game.getSkillAvailabilityStatus(skillName); // refresh to get re-captured recast time
-				let skillInfo = this.game.skillsList.get(skillName).info;
-				let isGCD = skillInfo.cdName === ResourceType.cd_GCD;
+				let skill = this.game.skillsList.get(skillName);
+				let isGCD = skill.cdName === ResourceType.cd_GCD;
 				let isSpellCast = status.castTime > 0 && !status.instantCast;
 				let snapshotTime = isSpellCast ? status.castTime - GameConfig.getSlidecastWindow(status.castTime) : 0;
 				this.timeline.addElement({

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -7,8 +7,8 @@ import {
 	ShellVersion,
 	TickMode
 } from "./Common";
-import {GameState, newGameState} from "../Game/GameState";
-import {BLMState} from "../Game/Jobs/BLM";
+import {GameState} from "../Game/GameState";
+import {newGameState, BLMState} from "../Game/Jobs/BLM";
 import {Debug, LevelSync, ProcMode, ResourceType, SkillName, SkillReadyStatus, WarningType} from "../Game/Common";
 import {DEFAULT_CONFIG, GameConfig} from "../Game/GameConfig"
 // @ts-ignore

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -7,7 +7,7 @@ import {
 	ShellVersion,
 	TickMode
 } from "./Common";
-import {GameState} from "../Game/GameState";
+import {GameState, newGameState} from "../Game/GameState";
 import {Debug, LevelSync, ProcMode, ResourceType, SkillName, SkillReadyStatus, WarningType} from "../Game/Common";
 import {DEFAULT_CONFIG, GameConfig} from "../Game/GameConfig"
 // @ts-ignore
@@ -93,7 +93,7 @@ class Controller {
 		this.#presetLinesManager = new PresetLinesManager();
 
 		this.gameConfig = new GameConfig(DEFAULT_CONFIG);
-		this.game = new GameState(this.gameConfig);
+		this.game = newGameState(this.gameConfig);
 
 		this.record = new Record();
 		this.record.config = this.gameConfig;
@@ -174,7 +174,7 @@ class Controller {
 
 			// create environment
 			let cfg = inRecord.config ?? this.gameConfig;
-			this.game = new GameState(cfg);
+			this.game = newGameState(cfg);
 			this.record = new Record();
 			this.record.config = cfg;
 			this.#lastDamageApplicationTime = -cfg.countdown;
@@ -211,7 +211,7 @@ class Controller {
 
 		this.#sandboxEnvironment(()=>{
 			let tmpRecord = this.record;
-			this.game = new GameState(this.gameConfig);
+			this.game = newGameState(this.gameConfig);
 			this.record = new Record();
 			this.record.config = this.gameConfig;
 			this.#lastDamageApplicationTime = -this.gameConfig.countdown;
@@ -269,7 +269,7 @@ class Controller {
 
 	#requestRestart() {
 		this.lastAttemptedSkill = ""
-		this.game = new GameState(this.gameConfig);
+		this.game = newGameState(this.gameConfig);
 		this.#playPause({shouldLoop: false});
 		this.timeline.reset();
 		this.record.unselectAll();

--- a/src/Controller/DamageStatistics.ts
+++ b/src/Controller/DamageStatistics.ts
@@ -171,7 +171,7 @@ function expandNode(node: ActionNode) : ExpandedNode {
 	}
 	if (node.type === ActionType.Skill && node.skillName) {
 		if (AFUISkills.has(node.skillName)) {
-			console.assert(node.getPotencies().length > 0);
+			console.assert(node.getPotencies().length > 0, "no potencies for " + node.skillName);
 			// use the one that's not enochian or pot (then must be one of af123, ui123)
 			let mainPotency = node.getPotencies()[0];
 			res.basePotency = mainPotency.base;

--- a/src/Controller/DamageStatistics.ts
+++ b/src/Controller/DamageStatistics.ts
@@ -293,7 +293,7 @@ export function calculateSelectedStats(props: {
 			const checked = getSkillOrDotInclude(node.skillName);
 			// gcd count
 			let skillInfo = ctl.game.skillsList.get(node.skillName);
-			if (skillInfo.info.cdName === ResourceType.cd_GCD && checked) {
+			if (skillInfo.cdName === ResourceType.cd_GCD && checked) {
 				if (node.hitBoss(bossIsUntargetable)) selected.gcdSkills.applied++;
 				else if (!node.resolved()) selected.gcdSkills.pending++;
 			}
@@ -358,7 +358,7 @@ export function calculateDamageStats(props: {
 
 			// gcd count
 			let skillInfo = ctl.game.skillsList.get(node.skillName);
-			if (skillInfo.info.cdName === ResourceType.cd_GCD && checked) {
+			if (skillInfo.cdName === ResourceType.cd_GCD && checked) {
 				if (node.hitBoss(bossIsUntargetable)) {
 					gcdSkills.applied++;
 				} else if (!node.resolved()) {

--- a/src/Game/GameConfig.ts
+++ b/src/Game/GameConfig.ts
@@ -1,4 +1,4 @@
-import {Debug, SkillName, ProcMode, LevelSync, FIXED_BASE_CASTER_TAX} from "./Common";
+import {Debug, SkillName, ProcMode, LevelSync, ResourceType, FIXED_BASE_CASTER_TAX} from "./Common";
 import {ResourceOverride} from "./Resources";
 import {ShellInfo, ShellVersion} from "../Controller/Common";
 import {XIVMath} from "./XIVMath";

--- a/src/Game/GameConfig.ts
+++ b/src/Game/GameConfig.ts
@@ -110,13 +110,13 @@ export class GameConfig {
 	}
 
 	// returns GCD before FPS tax
-	adjustedGCD(hasLL: boolean) {
-		return XIVMath.preTaxGcd(this.level, this.spellSpeed, hasLL);
+	adjustedGCD(baseGCD: number = 2.5, speedBuff?: ResourceType) {
+		return XIVMath.preTaxGcd(this.level, this.spellSpeed, baseGCD, speedBuff);
 	}
 
 	// returns cast time before FPS and caster tax
-	adjustedCastTime(inCastTime : number, hasLL: boolean) {
-		return XIVMath.preTaxCastTime(this.level, this.spellSpeed, inCastTime, hasLL);
+	adjustedCastTime(inCastTime : number, speedBuff?: ResourceType) {
+		return XIVMath.preTaxCastTime(this.level, this.spellSpeed, inCastTime, speedBuff);
 	}
 
 	getSkillAnimationLock(skillName : SkillName) : number {

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -92,7 +92,7 @@ export class GameState {
 
 		// skill CDs (also a form of resource)
 		this.cooldowns = new CoolDownState(this);
-		this.cooldowns.set(new CoolDown(ResourceType.cd_GCD, config.getAfterTaxGCD(config.adjustedGCD(false)), 1, 1));
+		this.cooldowns.set(new CoolDown(ResourceType.cd_GCD, config.getAfterTaxGCD(config.adjustedGCD()), 1, 1));
 		this.cooldowns.set(new CoolDown(ResourceType.cd_Sprint, 60, 1, 1));
 
 		// EVENTS QUEUE (events decide future changes to resources)
@@ -379,8 +379,8 @@ export class GameState {
 		let ll = this.resources.get(ResourceType.LeyLines);
 		if (ll.available(1)) {
 			// should be approximately 0.85
-			const num = this.config.getAfterTaxGCD(this.config.adjustedGCD(true));
-			const denom = this.config.getAfterTaxGCD(this.config.adjustedGCD(false));
+			const num = this.config.getAfterTaxGCD(this.config.adjustedGCD(2.5, ResourceType.LL));
+			const denom = this.config.getAfterTaxGCD(this.config.adjustedGCD(2.5, ResourceType.LL));
 			return num / denom;
 		} else {
 			return 1;
@@ -420,7 +420,7 @@ export class GameState {
 		let llCovered = this.resources.get(ResourceType.LeyLines).available(1);
 		let capturedCastTime = this.captureSpellCastTimeAFUI(
 			skillInfo.aspect,
-			this.config.adjustedCastTime(skillInfo.baseCastTime, llCovered));
+			this.config.adjustedCastTime(skillInfo.baseCastTime, llCovered ? ResourceType.LeyLines : undefined));
 		if (llCovered && skillInfo.cdName===ResourceType.cd_GCD) {
 			props.node.addBuff(BuffType.LeyLines);
 		}
@@ -692,7 +692,7 @@ export class GameState {
 		let llCovered = this.resources.get(ResourceType.LeyLines).available(1);
 		let capturedCastTime = this.captureSpellCastTimeAFUI(
 			skill.info.aspect,
-			this.config.adjustedCastTime(skill.info.baseCastTime, llCovered));
+			this.config.adjustedCastTime(skill.info.baseCastTime, llCovered ? ResourceType.LeyLines : undefined));
 		let instantCastAvailable = this.resources.get(ResourceType.Triplecast).available(1)
 			|| this.resources.get(ResourceType.Swiftcast).available(1)
 			|| skillName===SkillName.Paradox

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -181,7 +181,6 @@ export abstract class GameState {
 			this.cooldowns.tick(timeToTick);
 			if (Debug.consoleLogEvents) console.log("====== tick " + timeToTick + " now at " + this.time);
 
-			const newEventsToQueue: Event[] = [];
 			// make a deep copy of events to advance for this round...
 			const eventsToExecuteOld = [];
 			for (let i = 0; i < this.eventsQueue.length; i++)
@@ -204,8 +203,6 @@ export abstract class GameState {
 			});
 			// remove the executed events from the master list
 			this.eventsQueue.splice(0, executedEvents);
-			// add newly queued events
-			this.eventsQueue.concat(newEventsToQueue);
 		}
 		if (Debug.consoleLogEvents) {
 			console.log(this.toString());

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -64,6 +64,8 @@ export abstract class GameState {
 		this.cooldowns.set(new CoolDown(ResourceType.cd_GCD, config.getAfterTaxGCD(config.adjustedGCD()), 1, 1));
 		this.cooldowns.set(new CoolDown(ResourceType.cd_Sprint, 60, 1, 1));
 
+		this.cooldowns.set(new CoolDown(ResourceType.Never, 0, 0, 0)); // dummy cooldown for invalid skills
+
 		// EVENTS QUEUE (events decide future changes to resources)
 		// which might include:
 		// - damage calc (enqueues damage application)

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -325,9 +325,11 @@ const makeGCD_BLM = (name: SkillName, unlockLevel: number, params: {
 		(state, node) => {
 			// put this before the spell's onConfirm to ensure F3P and other buffs aren't prematurely consumed
 			// fire spells: attempt to consume umbral hearts
+			// flare is handled separately because it wipes all hearts
 			if (
 				state.getFireStacks() > 0 &&
-				aspect === Aspect.Fire && name !== SkillName.Despair && name !== SkillName.FlareStar &&
+				aspect === Aspect.Fire &&
+				![SkillName.Despair, SkillName.FlareStar, SkillName.Flare].includes(name) &&
 				!(name === SkillName.Fire3 && state.hasResourceAvailable(ResourceType.Firestarter))
 			) {
 				state.tryConsumeResource(ResourceType.UmbralHeart)

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -11,7 +11,7 @@ import {
 	makeAbility,
 	makeSpell,
 	makeResourceAbility,
-	skillMap,
+	getSkill,
 	SkillAutoReplace,
 	Spell,
 	Ability,
@@ -477,7 +477,7 @@ const applyThunderDoT = (game: PlayerState, node: ActionNode, skillName: SkillNa
 
 const addThunderPotencies = (game: PlayerState, node: ActionNode, skillName: SkillName.Thunder3 | SkillName.HighThunder) => {
 	let mods = getPotencyModifiersFromResourceState(game.resources, Aspect.Lightning);
-	let thunder = skillMap.get(ShellJob.BLM)!.get(skillName)!;
+	let thunder = getSkill(ShellJob.BLM, skillName);
 
 	// initial potency
 	let pInitial = new Potency({

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -4,34 +4,37 @@ import {controller} from "../../Controller/Controller";
 
 import {ShellJob} from "../../Controller/Common";
 import {SkillName, Aspect, ResourceType, WarningType} from "../Common";
-import {makeAbility, makeGCD, SkillAutoReplace, SkillInfo} from "../Skills";
+import {
+	makeAbility,
+	makeSpell,
+	makeResourceAbility,
+	validateOrSkillError,
+	SkillAutoReplace,
+	Skill,
+	ValidateAttemptFn,
+	EffectFn,
+} from "../Skills";
 import {Traits, TraitName} from "../Traits";
-import {JobState, GameState} from "../GameState";
+import {JobState, PlayerState, GameState} from "../GameState";
 import {CoolDown, CoolDownState, DoTBuff, Event, Resource, ResourceState} from "../Resources"
 import {GameConfig} from "../GameConfig";
 
 type RNG = any;
 
 // === JOB GAUGE AND STATE ===
-export class BLMState implements JobState {
+export class BLMState extends GameState {
 	gameState: GameState;
 	config: GameConfig;
 	rng: RNG;
 	nonProcRng: RNG; // use this for things other than procs (actor tick offsets, for example)
 	resources: ResourceState;
 	cooldowns: CoolDownState;
-	eventsQueue: Event[];
+	eventsQueue: Event<BLMState>[];
 
 	thunderTickOffset: number;
 
-	constructor(gameState: GameState) {
-		this.gameState = gameState;
-		this.config = gameState.config;
-		this.rng = gameState.rng;
-		this.nonProcRng = gameState.nonProcRng;
-		this.resources = gameState.resources;
-		this.cooldowns = gameState.cooldowns;
-		this.eventsQueue = gameState.eventsQueue;
+	constructor(config: GameConfig) {
+		super(config);
 
 		this.thunderTickOffset = this.nonProcRng() * 3.0;
 
@@ -84,10 +87,6 @@ export class BLMState implements JobState {
 		].forEach((cd) => this.cooldowns.set(cd));
 	}
 
-	addEvent(evt: Event) {
-		this.gameState.addEvent(evt);
-	}
-
 	registerRecurringEvents() {
 		// thunder DoT tick
 		let recurringThunderTick = () => {
@@ -130,6 +129,169 @@ export class BLMState implements JobState {
 		};
 		recurringPolyglotGain(this.resources.get(ResourceType.Polyglot));
 	}
+
+	getFireStacks() { return this.resources.get(ResourceType.AstralFire).availableAmount(); }
+	getIceStacks() { return this.resources.get(ResourceType.UmbralIce).availableAmount(); }
+	getUmbralHearts() { return this.resources.get(ResourceType.UmbralHeart).availableAmount(); }
+	getMP() { return this.resources.get(ResourceType.Mana).availableAmount(); }
+
+	gainThunderhead() {
+		let thunderhead = this.resources.get(ResourceType.Thunderhead);
+		// [6/29/24] note: from screen recording it looks more like: button press (0.1s) gain buff (30.0s) lose buff
+		// see: https://drive.google.com/file/d/11KEAEjgezCKxhvUsaLTjugKAH_D1glmy/view?usp=sharing
+		let duration = 30;
+		if (thunderhead.available(1)) { // already has a proc; reset its timer
+			thunderhead.overrideTimer(this, duration);
+		} else { // there's currently no proc. gain one.
+			thunderhead.gain(1);
+			this.resources.addResourceEvent({
+				rscType: ResourceType.Thunderhead,
+				name: "drop thunderhead",
+				delay: duration,
+				fnOnRsc: (rsc: Resource) => {
+					rsc.consume(1);
+				}
+			});
+		}
+	}
+
+	// call this whenever gaining af or ui from a different af/ui/unaspected state
+	switchToAForUI(rscType: ResourceType.AstralFire | ResourceType.UmbralIce, numStacksToGain: number) {
+		console.assert(numStacksToGain > 0);
+
+		let af = this.resources.get(ResourceType.AstralFire);
+		let ui = this.resources.get(ResourceType.UmbralIce);
+		let uh = this.resources.get(ResourceType.UmbralHeart);
+		let paradox = this.resources.get(ResourceType.Paradox);
+		let as = this.resources.get(ResourceType.AstralSoul);
+
+		if (rscType===ResourceType.AstralFire)
+		{
+			if (af.availableAmount() === 0) {
+				this.gainThunderhead();
+			}
+			af.gain(numStacksToGain);
+
+			if (Traits.hasUnlocked(TraitName.AspectMasteryV, this.config.level)) {
+				if (ui.available(3) && uh.available(3)) {
+					paradox.gain(1);
+				}  
+			}
+
+			ui.consume(ui.availableAmount());
+		}
+		else if (rscType===ResourceType.UmbralIce)
+		{
+			if (ui.availableAmount() === 0) {
+				this.gainThunderhead();
+			}
+			ui.gain(numStacksToGain);
+
+			if (Traits.hasUnlocked(TraitName.AspectMasteryV, this.config.level)) {
+				if (af.available(3)) {
+					paradox.gain(1);
+				}
+			}
+
+			af.consume(af.availableAmount());
+			as.consume(as.availableAmount());
+		}
+	}
+
+	gainUmbralMana(effectApplicationDelay: number = 0) {
+		let mpToGain = 0;
+		switch(this.resources.get(ResourceType.UmbralIce).availableAmount()) {
+			case 1: mpToGain = 2500;  break;
+			case 2: mpToGain = 5000;  break;
+			case 3: mpToGain = 10000; break;
+			default: mpToGain = 0; break;
+		}
+		this.addEvent(new Event(
+			"gain umbral mana",
+				effectApplicationDelay,
+			() => {
+				this.resources.get(ResourceType.Mana).gain(mpToGain);
+			}));
+	}
+
+	captureManaCostAndUHConsumption(aspect: Aspect, baseManaCost: number) {
+		let mod = StatsModifier.fromResourceState(this.resources);
+
+		let manaCost;
+		let uhConsumption = 0;
+
+		if (aspect === Aspect.Fire) {
+			manaCost = baseManaCost * mod.manaCostFire;
+			uhConsumption = mod.uhConsumption;
+		}
+		else if (aspect === Aspect.Ice) {
+			manaCost = baseManaCost * mod.manaCostIce;
+		}
+		else {
+			manaCost = baseManaCost;
+		}
+		return [manaCost, uhConsumption];
+	}
+
+	captureSpellCastTimeAFUI(aspect: Aspect, llAdjustedCastTime: number) {
+		let mod = StatsModifier.fromResourceState(this.resources);
+
+		let castTime = llAdjustedCastTime;
+		if (aspect === Aspect.Fire) castTime *= mod.castTimeFire;
+		else if (aspect === Aspect.Ice) castTime *= mod.castTimeIce;
+
+		return castTime;
+	}
+
+	hasEnochian() {
+		// lasts a teeny bit longer to allow simultaneous events catch its effect
+		let enochian = this.resources.get(ResourceType.Enochian);
+		return enochian.available(1);
+	}
+
+	// falls off after 15s unless refreshed by AF / UI
+	startOrRefreshEnochian() {
+		let enochian = this.resources.get(ResourceType.Enochian);
+
+		if (enochian.available(1) && enochian.pendingChange) {
+			// refresh timer (if there's already a timer)
+			enochian.overrideTimer(this, 15);
+
+		} else {
+			// reset polyglot countdown to 30s if enochian wasn't actually active
+			if (!enochian.available(1)) {
+				this.resources.get(ResourceType.Polyglot).overrideTimer(this, 30);
+			}
+
+			// either fresh gain, or there's enochian but no timer
+			enochian.gain(1);
+
+			// add the event for losing it
+			this.resources.addResourceEvent({
+				rscType: ResourceType.Enochian,
+				name: "lose enochian, clear all AF, UI, UH, stop poly timer",
+				delay: 15,
+				fnOnRsc: rsc=>{
+					this.loseEnochian();
+				}
+			});
+		}
+	}
+
+	loseEnochian() {
+		this.resources.get(ResourceType.Enochian).consume(1);
+		let af = this.resources.get(ResourceType.AstralFire);
+		let ui = this.resources.get(ResourceType.UmbralIce);
+		let uh = this.resources.get(ResourceType.UmbralHeart);
+		let paradox = this.resources.get(ResourceType.Paradox);
+		let as = this.resources.get(ResourceType.AstralSoul);
+
+		af.consume(af.availableAmount());
+		ui.consume(ui.availableAmount());
+		uh.consume(uh.availableAmount());
+		paradox.consume(paradox.availableAmount());
+		as.consume(as.availableAmount());
+	}
 }
 
 
@@ -146,19 +308,53 @@ const makeGCD_BLM = (name: SkillName, unlockLevel: number, params: Partial<{
 	baseManaCost: number,
 	basePotency: number,
 	applicationDelay: number,
-	onCapture: any,  // TODO
-	onApplication: any,  // TODO
-}>): SkillInfo => makeGCD(ShellJob.BLM, name, unlockLevel, params);
+	validateAttempt: ValidateAttemptFn,
+	onConfirm: EffectFn,
+	onApplication: EffectFn,
+}>): Skill<BLMState> => makeSpell(ShellJob.BLM, name, unlockLevel, {
+	autoUpgrade: params.autoUpgrade,
+	autoDowngrade: params.autoDowngrade,
+	aspect: params.aspect,
+	castTime: (state) => state.captureSpellCastTimeAFUI(params.baseCastTime ?? 0),
+	// TODO split up UH consumption
+	manaCost: (state) => state.captureManaCostAndUHConsumption(params.aspect ?? Aspect.other, params.baseManaCost ?? 0)[0],
+	// TODO apply AFUI modifiers?
+	potency: (state) => basePotency,
+	applicationDelay: params.applicationDelay,
+	isInstantFn: (state) => (
+		// The expressions here are very sensitive to order, as the short-circuiting logic determines 
+		// which buffs to consume first.
+		// Priority of instant cast buff consumption:
+		// 0. Always instant: Scathe (lol), Umbral Soul
+		// 1. Instant with specific resources: Paradox, Xeno/Foul, F3P, T3P (rip).
+		//    Do not consume para marker/polyglot yet here, since at lvl 70 Foul still consumes poly despite not being instant.
+		// 2. Swift
+		// 3. Triple
+
+		// Paradox made instant via Dawntrail
+		(name === SkillName.UmbralSoul || name === SkillName.Paradox) ||
+		// Xenoglossy and Foul after lvl 80; consume polyglot if available
+		(
+			((name === SkillName.Foul && Traits.hasUnlocked(TraitName.EnhancedFoul, state.config.level)) ||
+				name === SkillName.Xenoglossy)
+		) ||
+		// F3P
+		(name === SkillName.Fire3 && state.tryConsumeResource(ResourceType.Firestarter)) ||
+		// Swift
+		state.tryConsumeResource(ResourceType.Swift) ||
+		// Triple
+		state.tryConsumeResource(ResourceType.Triple)
+	),
+	onConfirm: params.onConfirm,
+	onApplication: params.onApplication,
+});
 
 
 const makeAbility_BLM =(name: SkillName, unlockLevel: number, cdName: ResourceType, params: Partial<{
-	autoUpgrade: SkillAutoReplace,
-	autoDowngrade: SkillAutoReplace,
-	basePotency: number,
 	applicationDelay: number,
-	onCapture: any,  // TODO
-	onApplication: any,  // TODO
-}>): SkillInfo => makeAbility(ShellJob.BLM, name, unlockLevel, cdName, params);
+	onConfirm: EffectFn,
+	onApplication: EffectFn,
+}>): Skill<BLMState> => makeAbility(ShellJob.BLM, name, unlockLevel, cdName, params);
 
 
 // ref logs
@@ -172,7 +368,39 @@ makeGCD_BLM(SkillName.Blizzard, 1, {
 	baseManaCost: 400,
 	basePotency: 180,
 	applicationDelay: 0.846,
+	onConfirm: (state) => {
+		// Refresh Enochian and gain a UI stack at the cast confirm window, not the damage application.
+		// MP is regained on damage application (TODO)
+		if (state.getFireStacks() === 0) { // no AF
+			state.switchToAForUI(ResourceType.UmbralIce, 1);
+			state.startOrRefreshEnochian();
+		} else { // in AF
+			state.resources.get(ResourceType.Enochian).removeTimer();
+			state.loseEnochian()
+		}
+	},
 });
+
+const gainFirestarterProc = (game: PlayerState): Event<BLMState>[] => {
+	// re-measured in DT, screen recording at: https://drive.google.com/file/d/1MEFnd-m59qx1yIaZeehSsAxjhLMsWBuw/view?usp=drive_link
+	let duration = 30.5;
+	if (game.resources.get(ResourceType.Firestarter).available(1)) {
+		state.resources.get(ResourceType.Firestarter).overrideTimer(state, duration);
+		return [];
+	} else {
+		state.resources.get(ResourceType.Firestarter).gain(1);
+		return [new Event("drop firestarter proc", duration, (state) => state.resources.get(ResourceType.Firestarter).consume(1))];
+	}
+};
+
+const potentiallyGainFirestarter = (game: PlayerState): Event<BLMState>[] => {
+	let rand = game.rng();
+	if (game.config.procMode===ProcMode.Always || (game.config.procMode===ProcMode.RNG && rand < 0.4)) {
+		return gainFirestarterProc(game);
+	} else {
+		return [];
+	}
+};
 
 makeGCD_BLM(SkillName.Fire, 2, {
 	aspect: Aspect.Fire,
@@ -180,11 +408,115 @@ makeGCD_BLM(SkillName.Fire, 2, {
 	baseManaCost: 800,
 	basePotency: 180,
 	applicationDelay: 1.871,
+	// TODO make sure MP cost is figured out
+	onConfirm: (state) => {
+		// Refresh Enochian and gain a UI stack at the cast confirm window, not the damage application.
+		const f3p = potentiallyGainFirestarter(state);
+		if (state.getIceStacks() === 0) { // in fire or no enochian
+			state.switchToAForUI(ResourceType.AstralFire, 1);
+			state.startOrRefreshEnochian();
+		} else { // in UI
+			state.resources.get(ResourceType.Enochian).removeTimer();
+			state.loseEnochian()
+		}
+		return f3p;
+	},
 });
 
 makeAbility_BLM(SkillName.Transpose, 4, ResourceType.cd_Transpose, {
 	applicationDelay: 0, // instant
+	validateAttempt: validateOrSkillError(
+		(state) => state.getFireStacks() > 0 || state.getIceStacks() > 0,
+		"must be in AF or UI to cast Transpose"
+	),
+	onApplication: (state) => {
+		if (state.getFireStacks() === 0 && state.getIceStacks() === 0) {
+			return [];
+		}
+		state.switchToAForUI(state.getFireStacks() > 0 ? Resource.UmbralIce : Resource.AstralFire, 1);
+		state.startOrRefreshEnochian();
+		return [];
+	},
 });
+
+const applyThunderDoT = (game: PlayerState, node: ActionNode, skillName: SkillName) => {
+	let thunder = game.resources.get(ResourceType.ThunderDoT) as DoTBuff;
+	const thunderDuration = (skillName === SkillName.Thunder3 && 27) || 30;
+	if (thunder.available(1)) {
+		console.assert(thunder.node);
+		(thunder.node as ActionNode).removeUnresolvedPotencies();
+
+		thunder.overrideTimer(game, thunderDuration);
+	} else {
+		thunder.gain(1);
+		controller.reportDotStart(game.getDisplayTime());
+		// TODO return this instead of using a side effect
+		game.resources.addResourceEvent({
+			rscType: ResourceType.ThunderDoT,
+			name: "drop thunder DoT",
+			delay: thunderDuration,
+			fnOnRsc: rsc=>{
+				  rsc.consume(1);
+				  controller.reportDotDrop(game.getDisplayTime());
+			 }
+		});
+	}
+	thunder.node = node;
+	thunder.tickCount = 0;
+};
+
+const addThunderPotencies = (node: ActionNode, skillName: SkillName.Thunder3 | SkillName.HighThunder) => {
+	let mods = getPotencyModifiersFromResourceState(game.resources, Aspect.Lightning);
+	let thunder = skillsList.get(skillName);
+
+	// initial potency
+	let pInitial = new Potency({
+		config: controller.record.config ?? controller.gameConfig,
+		sourceTime: game.getDisplayTime(),
+		sourceSkill: skillName,
+		aspect: Aspect.Lightning,
+		basePotency: thunder ? thunder.info.basePotency : 150,
+		snapshotTime: undefined,
+		description: ""
+	});
+	pInitial.modifiers = mods;
+	node.addPotency(pInitial);
+
+	// dots
+	const thunderTicks = (skillName === SkillName.Thunder3 && 9) || 10;
+	const thunderTickPotency = (skillName === SkillName.Thunder3 && 50) || 60;
+	for (let i = 0; i < thunderTicks; i++) {
+		let pDot = new Potency({
+			config: controller.record.config ?? controller.gameConfig,
+			sourceTime: game.getDisplayTime(),
+			sourceSkill: skillName,
+			aspect: Aspect.Lightning,
+			basePotency: game.config.adjustedDoTPotency(thunderTickPotency),
+			snapshotTime: undefined,
+			description: "DoT " + (i+1) + `/${thunderTicks}`
+		});
+		pDot.modifiers = mods;
+		node.addPotency(pDot);
+	}
+};
+
+const thunderConfirm = (skillName: SkillName.Thunder3 | SkillName.HighThunder) => (
+	(game: PlayerState, node: ActionNode) => {
+		// potency
+		addThunderPotencies(node, skillName); // should call on capture
+		let onHitPotency = node.getPotencies()[0];
+		node.getPotencies().forEach(p=>{ p.snapshotTime = game.getDisplayTime(); });
+
+		// tincture
+		if (game.resources.get(ResourceType.Tincture).available(1)) {
+			node.addBuff(BuffType.Tincture);
+		}
+
+		let thunderhead = game.resources.get(ResourceType.Thunderhead);
+		thunderhead.consume(1);
+		thunderhead.removeTimer();
+	}
+);
 
 makeGCD_BLM(SkillName.Thunder3, 45, {
 	aspect: Aspect.Lightning,
@@ -192,18 +524,42 @@ makeGCD_BLM(SkillName.Thunder3, 45, {
 	baseManaCost: 0,
 	basePotency: 120,
 	applicationDelay: 0.757, // Unknown damage application, copied from HT
+	onConfirm: thunderConfirm(Skill.Thunder3),
+	onApplication: (state, node) => {
+		controller.resolvePotency(onHitPotency);
+		applyThunderDoT(game, node, skillName);
+	},
 	autoUpgrade: { trait: TraitName.ThunderMasteryIII, otherSkill: SkillName.HighThunder },
 });
 
-makeAbility_BLM(SkillName.Manaward, 30, ResourceType.cd_Manaward, {
+makeResourceAbility(ShellJob.BLM, SkillName.Manaward, 30, ResourceType.cd_Manaward, {
+	rscType: ResourceType.Manaward,
 	applicationDelay: 1.114, // delayed
+	duration: 20,
 });
 
 // Manafont: application delay 0.88s -> 0.2s since Dawntrail
 // infact most effects seem instant but MP gain is delayed.
 // see screen recording: https://drive.google.com/file/d/1zGhU9egAKJ3PJiPVjuRBBMkKdxxHLS9b/view?usp=drive_link
-makeAbility_BLM(SkillName.Manafont, 30, ResourceType.cd_Manafont, {
+makeResourceAbility(SkillName.Manafont, 30, ResourceType.cd_Manafont, {
 	applicationDelay: 0.2, // delayed
+	validateAttempt: validateOrSkillError(
+		(state) => state.resources.get(ResourceType.AstralFire).availableAmount() > 0,
+		"must be in AF to cast Manafont",
+	),
+	onConfirm: (state) => {
+		state.resources.get(ResourceType.AstralFire).gain(3);
+		state.resources.get(ResourceType.UmbralHeart).gain(3);
+
+		if (Traits.hasUnlocked(TraitName.AspectMasteryV, state.config.level))
+			state.resources.get(ResourceType.Paradox).gain(1);
+
+		state.gainThunderhead();
+		state.startOrRefreshEnochian();
+	},
+	onApplication: (state) => {
+		state.resources.get(ResourceType.Mana).gain(10000)
+	},
 });
 
 makeGCD_BLM(SkillName.Fire3, 35, {
@@ -212,6 +568,11 @@ makeGCD_BLM(SkillName.Fire3, 35, {
 	baseManaCost: 2000,
 	basePotency: 280,
 	applicationDelay: 1.292,
+	onConfirm: (state) => {
+		// Firestarter consumption is handled in makeGCD_BLM
+		state.switchToAForUI(ResourceType.AstralFire, 3);
+		state.startOrRefreshEnochian();
+	},
 });
 
 makeGCD_BLM(SkillName.Blizzard3, 35, {
@@ -220,6 +581,10 @@ makeGCD_BLM(SkillName.Blizzard3, 35, {
 	baseManaCost: 800,
 	basePotency: 280,
 	applicationDelay: 0.89,
+	onConfirm: (state) => {
+		state.switchToAForUI(ResourceType.UmbralIce, 3);
+		state.startOrRefreshEnochian();
+	},
 });
 
 makeGCD_BLM(SkillName.Freeze, 40, {
@@ -228,6 +593,8 @@ makeGCD_BLM(SkillName.Freeze, 40, {
 	baseManaCost: 1000,
 	basePotency: 120,
 	applicationDelay: 0.664,
+	validateAttempt: validateOrSkillError((state) => state.getIceStacks() > 0, "must be in UI to cast Freeze"),
+	onConfirm: (state) => state.resources.get(ResourceType.UmbralHeart).gain(3),
 });
 
 makeGCD_BLM(SkillName.Flare, 50, {
@@ -236,11 +603,38 @@ makeGCD_BLM(SkillName.Flare, 50, {
 	baseManaCost: 0,  // mana is handled separately
 	basePotency: 240,
 	applicationDelay: 1.157,
+	validateAttempt: (state) => {
+		if (state.getFireStacks() === 0) {
+			return { message: "must be in AF to cast Flare" };
+		} else if (state.getMP() < 800) {
+			return { message: "must have at least 800 MP to cast Flare" };
+		}
+		return undefined; // no errors
+	},
+	onConfirm: (state) => {
+		let uh = state.resources.get(ResourceType.UmbralHeart);
+		let mana = state.resources.get(ResourceType.Mana);
+		let manaCost = uh.available(1) ? mana.availableAmount() * 0.66 : mana.availableAmount();
+		// mana
+		state.resources.get(ResourceType.Mana).consume(manaCost);
+		uh.consume(uh.availableAmount());
+		// +3 AF; refresh enochian
+		state.resources.get(ResourceType.AstralFire).gain(3);
+
+		if (Traits.hasUnlocked(TraitName.EnhancedAstralFire, game.config.level))
+			state.resources.get(ResourceType.AstralSoul).gain(3);
+
+		state.startOrRefreshEnochian();
+	},
 });
 
-
-makeAbility_BLM(SkillName.LeyLines, 52, ResourceType.cd_LeyLines, {
+makeResourceAbility(ShellJob.BLM, SkillName.LeyLines, 52, ResourceType.cd_LeyLines, {
+	rscType: ResourceType.LeyLines,
 	applicationDelay: 0.49, // delayed
+	duration: 30,
+	onApplication: (state) => {
+		state.resources.get(ResourceType.LeyLines).enabled = true
+	},
 });
 
 makeGCD_BLM(SkillName.Blizzard4, 58, {
@@ -249,6 +643,8 @@ makeGCD_BLM(SkillName.Blizzard4, 58, {
 	baseManaCost: 800,
 	basePotency: 320,
 	applicationDelay: 1.156,
+	validateAttempt: validateOrSkillError((state) => state.getIceStacks() > 0, "must be in UI to cast Blizzard 4"),
+	onConfirm: (state) => state.resources.get(ResourceType.UmbralHeart).gain(3),
 });
 
 makeGCD_BLM(SkillName.Fire4, 60, {
@@ -257,10 +653,19 @@ makeGCD_BLM(SkillName.Fire4, 60, {
 	baseManaCost: 800,
 	basePotency: 320,
 	applicationDelay: 1.159,
+	validateAttempt: validateOrSkillError((state) => state.getFireStacks() > 0, "must be in AF to cast Fire 4"),
+	onConfirm: (state) => {
+		if (Traits.hasUnlocked(TraitName.EnhancedAstralFire, state.config.level))
+			state.resources.get(ResourceType.AstralSoul).gain(1);
+	},
 });
 
 makeAbility_BLM(SkillName.BetweenTheLines, 62, ResourceType.cd_BetweenTheLines, {
 	applicationDelay: 0, // ?
+	validateAttempt: validateOrSkillError(
+		(state) => state.resources.get(ResourceType.LeyLines).availableAmountIncludingDisabled() > 0,
+		"must have active Ley Lines to cast Between the Lines",
+	),
 });
 
 makeAbility_BLM(SkillName.AetherialManipulation, 50, ResourceType.cd_AetherialManipulation, {
@@ -269,14 +674,31 @@ makeAbility_BLM(SkillName.AetherialManipulation, 50, ResourceType.cd_AetherialMa
 
 makeAbility_BLM(SkillName.Triplecast, 66, ResourceType.cd_Triplecast, {
 	applicationDelay: 0, // instant
+	onApplication: (state) => {
+		const triple = state.resources.get(ResourceType.Triplecast)
+		if (triple.pendingChaing) triple.removeTimer();
+		triple.gain(3);
+		return [new Event(
+			"drop remaining triplecast charges",
+			15.7, // 15.7s: see screen recording: https://drive.google.com/file/d/1qoIpAMK2KAKETgID6a3p5dqkeWRcNDdB/view?usp=drive_link
+			(state) => {
+				const rsc = state.resources.get(ResourceType.Triplecast);
+				rsc.consume(rsc.availableAmount());
+			},
+		)];
+	},
 });
-
 
 makeGCD_BLM(SkillName.Foul, 70, {
 	baseCastTime: 2.5,
 	baseManaCost: 0,
 	basePotency: 600,
 	applicationDelay: 1.158,
+	validateAttempt: validateOrSkillError(
+		(state) => state.resources.get(ResourceType.Polyglot).available(1),
+		"must have Polyglot stacks to cast Foul",
+	),
+	onConfirm: (state) => state.resources.get(ResourceType.Polyglot).consume(1),
 });
 
 makeGCD_BLM(SkillName.Despair, 72, {
@@ -285,6 +707,14 @@ makeGCD_BLM(SkillName.Despair, 72, {
 	baseManaCost: 0, // mana handled separately, like flare
 	basePotency: 350,
 	applicationDelay: 0.556,
+	validateAttempt: (state) => {
+		if (state.getFireStacks() === 0) {
+			return { message: "must be in AF to cast Despair" };
+		} else if (state.getMP() < 800) {
+			return { message: "must have at least 800 MP to cast Despair" };
+		}
+		return undefined; // no error
+	},
 });
 
 // Umbral Soul: immediate snapshot & UH gain; delayed MP gain
@@ -295,6 +725,15 @@ makeGCD_BLM(SkillName.UmbralSoul, 35, {
 	baseManaCost: 0,
 	basePotency: 0,
 	applicationDelay: 0.633,
+	validateAttempt: validateOrSkillError((state) => state.getIceStacks() > 0, "must be in UI to cast Umbral Soul"),
+	onConfirm: (state) => {
+		state.resources.get(ResourceType.UmralIce).gain(1);
+		state.resources.get(ResourceType.UmbralHeart).gain(1);
+		game.startOrRefreshEnochian();
+		// halt
+		let enochian = game.resources.get(ResourceType.Enochian);
+		enochian.removeTimer();
+	},
 });
 
 makeGCD_BLM(SkillName.Xenoglossy, 80, {
@@ -302,6 +741,11 @@ makeGCD_BLM(SkillName.Xenoglossy, 80, {
 	baseManaCost: 0,
 	basePotency: 880,
 	applicationDelay: 0.63,
+	validateAttempt: validateOrSkillError(
+		(state) => state.resources.get(ResourceType.Polyglot).available(1),
+		"must have Polyglot stacks to cast Xenoglossy",
+	),
+	onConfirm: (state) => state.resources.get(ResourceType.Polyglot).consume(1),
 });
 
 makeGCD_BLM(SkillName.Fire2, 18, {
@@ -311,6 +755,10 @@ makeGCD_BLM(SkillName.Fire2, 18, {
 	basePotency: 80,
 	applicationDelay: 1.154, // Unknown damage application, copied from HF2
 	autoUpgrade: { trait: TraitName.AspectMasteryIV, otherSkill: SkillName.HighFire2 },
+	onConfirm: (state) => {
+		state.switchToAForUI(ResourceType.AstralFire, 3);
+		state.startOrRefreshEnochian();
+	},
 });
 
 makeGCD_BLM(SkillName.Blizzard2, 12, {
@@ -320,6 +768,10 @@ makeGCD_BLM(SkillName.Blizzard2, 12, {
 	basePotency: 80,
 	applicationDelay: 1.158, // Unknown damage application, copied from HB2
 	autoUpgrade: { trait: TraitName.AspectMasteryIV, otherSkill: SkillName.HighBlizzard2 },
+	onConfirm: (state) => {
+		state.switchToAForUI(ResourceType.UmbralIce, 3);
+		state.startOrRefreshEnochian();
+	},
 });
 
 makeGCD_BLM(SkillName.HighFire2, 82, {
@@ -329,6 +781,10 @@ makeGCD_BLM(SkillName.HighFire2, 82, {
 	basePotency: 100,
 	applicationDelay: 1.154,
 	autoDowngrade: { trait: TraitName.AspectMasteryIV, otherSkill: SkillName.Fire2 },
+	onConfirm: (state) => {
+		state.switchToAForUI(ResourceType.AstralFire, 3);
+		state.startOrRefreshEnochian();
+	},
 });
 
 makeGCD_BLM(SkillName.HighBlizzard2, 82, {
@@ -338,10 +794,25 @@ makeGCD_BLM(SkillName.HighBlizzard2, 82, {
 	basePotency: 100,
 	applicationDelay: 1.158,
 	autoDowngrade: { trait: TraitName.AspectMasteryIV, otherSkill: SkillName.Blizzard2 },
+	onConfirm: (state) => {
+		state.switchToAForUI(ResourceType.UmbralIce, 3);
+		state.startOrRefreshEnochian();
+	},
 });
 
 makeAbility_BLM(SkillName.Amplifier, 86, ResourceType.cd_Amplifier, {
 	applicationDelay: 0, // ? (assumed to be instant)
+	validateAttempt: validateOrSkillError(
+		(state) => state.getFireStacks() > 0 || state.getIceStacks() > 0,
+		"must be in AF or UI to cast Amplifier"
+	),
+	onApplication: (state) => {
+		let polyglot = state.resources.get(ResourceType.Polyglot);
+		if (polyglot.available(polyglot.maxValue)) {
+			controller.reportWarning(WarningType.PolyglotOvercap)
+		}
+		polyglot.gain(1);
+	},
 });
 
 makeGCD_BLM(SkillName.Paradox, 90, {
@@ -349,6 +820,25 @@ makeGCD_BLM(SkillName.Paradox, 90, {
 	baseManaCost: 1600,
 	basePotency: 520,
 	applicationDelay: 0.624,
+	validateAttempt: validateOrSkillError(
+		(state) => state.resources.get(ResourceType.Paradox).available(1),
+		"must have Paradox marker to cast Paradox"
+	),
+	onConfirm: (state) => {
+		state.resources.get(ResourceType.Paradox).consume(1);
+		if (state.hasEnochian()) {
+			state.startOrRefreshEnochian();
+		}
+		if (game.getIceStacks() > 0) {
+			game.resources.get(ResourceType.UmbralIce).gain(1);
+		} else if (game.getFireStacks() > 0) {
+			game.resources.get(ResourceType.AstralFire).gain(1);
+			return gainFirestarterProc(game);
+		} else {
+			console.error("cannot cast Paradox outside of AF/UI");
+		}
+		return [];
+	},
 });
 
 makeGCD_BLM(SkillName.HighThunder, 92, {
@@ -357,6 +847,11 @@ makeGCD_BLM(SkillName.HighThunder, 92, {
 	baseManaCost: 0,
 	basePotency: 150,
 	applicationDelay: 0.757,
+	onConfirm: thunderConfirm,
+	onApplication: (state, node) => {
+		controller.resolvePotency(onHitPotency);
+		applyThunderDoT(game, node, skillName);
+	},
 	autoDowngrade: { trait: TraitName.ThunderMasteryIII, otherSkill: SkillName.HighThunder },
 });
 
@@ -366,9 +861,21 @@ makeGCD_BLM(SkillName.FlareStar, 100, {
 	baseManaCost: 0,
 	basePotency: 400,
 	applicationDelay: 0.622,
+	validateAttempt: validateOrSkillError(
+		(state) => state.resources.get(ResourceType.AstralSoul).available(6),
+		"must have 6 Astral Souls to cast Paradox"
+	),
+	onConfirm: (state) => state.resources.get(ResourceType.AstralSoul).consume(6),
 });
 
 makeAbility_BLM(SkillName.Retrace, 96, ResourceType.cd_Retrace, {
 	applicationDelay: 0, // ? (assumed to be instant)
+	validateAttempt: validateOrSkillError(
+		(state) => (Traits.hasUnlocked(TraitName.EnhancedLeyLines, state.config.level) &&
+			state.resources.get(ResourceType.LeyLines).availableAmountIncludingDisabled() > 0),
+		"must have active Ley Lines in order to cast Retrace",
+	),
+	onConfirm: (state) => {
+		state.resources.get(ResourceType.LeyLines).enabled = true;
+	},
 });
-

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -325,8 +325,11 @@ const makeGCD_BLM = (name: SkillName, unlockLevel: number, params: {
 		(state, node) => {
 			// put this before the spell's onConfirm to ensure F3P and other buffs aren't prematurely consumed
 			// fire spells: attempt to consume umbral hearts
-			if (aspect === Aspect.Fire && name !== SkillName.Despair && name !== SkillName.FlareStar &&
-				!(name === SkillName.Fire3 && state.hasResourceAvailable(ResourceType.Firestarter))) {
+			if (
+				state.getFireStacks() > 0 &&
+				aspect === Aspect.Fire && name !== SkillName.Despair && name !== SkillName.FlareStar &&
+				!(name === SkillName.Fire3 && state.hasResourceAvailable(ResourceType.Firestarter))
+			) {
 				state.tryConsumeResource(ResourceType.UmbralHeart)
 			}
 			// ice spells: gain mana on spell application if in UI

--- a/src/Game/Jobs/RoleActions.ts
+++ b/src/Game/Jobs/RoleActions.ts
@@ -1,6 +1,6 @@
 import {ShellJob} from "../../Controller/Common";
 import {SkillName, ResourceType} from "../Common";
-import {makeAbility, makeResourceAbility} from "../Skills";
+import {makeResourceAbility} from "../Skills";
 import {DoTBuff, EventTag} from "../Resources"
 import {Traits, TraitName} from "../Traits";
 

--- a/src/Game/Jobs/RoleActions.ts
+++ b/src/Game/Jobs/RoleActions.ts
@@ -2,6 +2,7 @@ import {ShellJob} from "../../Controller/Common";
 import {SkillName, ResourceType} from "../Common";
 import {makeAbility, makeResourceAbility} from "../Skills";
 import {DoTBuff, EventTag} from "../Resources"
+import {Traits, TraitName} from "../Traits";
 
 const CASTER_JOBS = [ShellJob.BLM, ShellJob.PCT];
 
@@ -28,7 +29,7 @@ makeResourceAbility(CASTER_JOBS, SkillName.LucidDreaming, 14, ResourceType.cd_Lu
 		let lucid = state.resources.get(ResourceType.LucidDreaming) as DoTBuff;
 		lucid.node = node;
 		lucid.tickCount = 0;
-		let nextLucidTickEvt = game.findNextQueuedEventByTag(EventTag.LucidTick);
+		let nextLucidTickEvt = state.findNextQueuedEventByTag(EventTag.LucidTick);
 		if (nextLucidTickEvt) {
 			nextLucidTickEvt.addTag(EventTag.ManaGain);
 		}

--- a/src/Game/Jobs/RoleActions.ts
+++ b/src/Game/Jobs/RoleActions.ts
@@ -1,6 +1,7 @@
 import {ShellJob} from "../../Controller/Common";
-import {SkillName, ResourceType} from "../../Game/Common";
+import {SkillName, ResourceType} from "../Common";
 import {makeAbility, makeResourceAbility} from "../Skills";
+import {DoTBuff, EventTag} from "../Resources"
 
 const CASTER_JOBS = [ShellJob.BLM, ShellJob.PCT];
 

--- a/src/Game/Jobs/RoleActions.ts
+++ b/src/Game/Jobs/RoleActions.ts
@@ -1,35 +1,56 @@
 import {ShellJob} from "../../Controller/Common";
 import {SkillName, ResourceType} from "../../Game/Common";
-import {makeAbility} from "../Skills";
+import {makeAbility, makeResourceAbility} from "../Skills";
 
 const CASTER_JOBS = [ShellJob.BLM, ShellJob.PCT];
 
-makeAbility(CASTER_JOBS, SkillName.Addle, 8, ResourceType.cd_Addle, {
+makeResourceAbility(CASTER_JOBS, SkillName.Addle, 8, ResourceType.cd_Addle, {
+	rscType: ResourceType.Addle,
 	applicationDelay: 0.621, // delayed
+	duration: (state) => (Traits.hasUnlocked(TraitName.EnhancedAddle, state.config.level) && 15) || 10,
 	assetPath: "CasterRole/Addle.png",
 });
 
-makeAbility(CASTER_JOBS, SkillName.Swiftcast, 18, ResourceType.cd_Swiftcast, {
+makeResourceAbility(CASTER_JOBS, SkillName.Swiftcast, 18, ResourceType.cd_Swiftcast, {
+	rscType: ResourceType.Swiftcast,
 	applicationDelay: 0, // instant
+	duration: 10,
 	assetPath: "CasterRole/Swiftcast.png",
 });
 
-makeAbility(CASTER_JOBS, SkillName.LucidDreaming, 14, ResourceType.cd_LucidDreaming, {
+makeResourceAbility(CASTER_JOBS, SkillName.LucidDreaming, 14, ResourceType.cd_LucidDreaming, {
+	rscType: ResourceType.LucidDreaming,
 	applicationDelay: 0.623, // delayed
 	assetPath: "CasterRole/Lucid Dreaming.png",
+	duration: 21,
+	onApplication: (state, node) => {
+		let lucid = state.resources.get(ResourceType.LucidDreaming) as DoTBuff;
+		lucid.node = node;
+		lucid.tickCount = 0;
+		let nextLucidTickEvt = game.findNextQueuedEventByTag(EventTag.LucidTick);
+		if (nextLucidTickEvt) {
+			nextLucidTickEvt.addTag(EventTag.ManaGain);
+		}
+	},
 });
 
-makeAbility(CASTER_JOBS, SkillName.Surecast, 44, ResourceType.cd_Surecast, {
+makeResourceAbility(CASTER_JOBS, SkillName.Surecast, 44, ResourceType.cd_Surecast, {
+	rscType: ResourceType.Surecast,
 	applicationDelay: 0, // surprisingly instant because arms length is not
+	duration: 6,
 	assetPath: "CasterRole/Surecast.png",
 });
 
-makeAbility(CASTER_JOBS, SkillName.Tincture, 1, ResourceType.cd_Tincture, {
+makeResourceAbility(CASTER_JOBS, SkillName.Tincture, 1, ResourceType.cd_Tincture, {
+	rscType: ResourceType.Tincture,
 	applicationDelay: 0.64, // delayed // somewhere in the midrange of what's seen in logs
+	duration: 30,
 	assetPath: "CasterRole/Tincture.png",
 });
 
-makeAbility(CASTER_JOBS, SkillName.Sprint, 1, ResourceType.cd_Sprint, {
+makeResourceAbility(CASTER_JOBS, SkillName.Sprint, 1, ResourceType.cd_Sprint, {
+	rscType: ResourceType.Sprint,
 	applicationDelay: 0.133, // delayed
+	duration: 10,
 	assetPath: "General/Sprint.png",
 });

--- a/src/Game/Potency.ts
+++ b/src/Game/Potency.ts
@@ -144,8 +144,11 @@ export class Potency {
 		if (this.base < 1) {
 			console.warn(this);
 		}
-		console.assert(this.snapshotTime !== undefined);
-		console.assert(this.applicationTime === undefined, this.sourceSkill);
+		console.assert(this.snapshotTime !== undefined, `${this.sourceSkill} displayed at ${displayTime} did not have snapshotTime`);
+		console.assert(
+			this.applicationTime === undefined,
+			`${this.sourceSkill} displayed at ${displayTime} was already resolved at ${this.applicationTime}`
+		);
 		this.applicationTime = displayTime;
 	}
 

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -1,4 +1,5 @@
 import {Debug, ResourceType} from "./Common"
+import {EffectFn} from "./Skills";
 import {PlayerState, GameState} from "./GameState";
 import {ActionNode} from "../Controller/Record";
 
@@ -8,16 +9,16 @@ export enum EventTag {
 	LucidTick
 }
 
-export class Event<T extends PlayerState> {
+export class Event {
 	name: string;
 	#tags: EventTag[];
 	timeTillEvent: number;
 	delay: number;
-	effectFn: (state: T, node?: ActionNode) => void;
+	effectFn: EffectFn<PlayerState>;
 	canceled: boolean;
 
 	// effectFn : () -> ()
-	constructor(name: string, delay: number, effectFn: ()=>void) {
+	constructor(name: string, delay: number, effectFn: EffectFn<PlayerState>) {
 		this.name = name;
 		this.#tags = [];
 		this.timeTillEvent = delay;

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -198,7 +198,7 @@ export class ResourceState {
 		let rsc = this.#map.get(rscType);
 		if (rsc) return rsc;
 		else {
-			console.assert(false);
+			console.assert(`could not find resource ${rscType}`);
 			return new Resource(ResourceType.Never, 0, 0);
 		}
 	}

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -1,5 +1,5 @@
 import {Debug, ResourceType} from "./Common"
-import {PlayerState, GameState} from "./GameState";
+import {GameState} from "./GameState";
 import {ActionNode} from "../Controller/Record";
 import {BLMState} from "./Jobs/BLM";
 

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -1,5 +1,4 @@
 import {Debug, ResourceType} from "./Common"
-import {EffectFn} from "./Skills";
 import {PlayerState, GameState} from "./GameState";
 import {ActionNode} from "../Controller/Record";
 import {BLMState} from "./Jobs/BLM";
@@ -15,11 +14,11 @@ export class Event {
 	#tags: EventTag[];
 	timeTillEvent: number;
 	delay: number;
-	effectFn: EffectFn<PlayerState>;
+	effectFn: () => void;
 	canceled: boolean;
 
 	// effectFn : () -> ()
-	constructor(name: string, delay: number, effectFn: EffectFn<PlayerState>) {
+	constructor(name: string, delay: number, effectFn: () => void) {
 		this.name = name;
 		this.#tags = [];
 		this.timeTillEvent = delay;

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -2,6 +2,7 @@ import {Debug, ResourceType} from "./Common"
 import {EffectFn} from "./Skills";
 import {PlayerState, GameState} from "./GameState";
 import {ActionNode} from "../Controller/Record";
+import {BLMState} from "./Jobs/BLM";
 
 export enum EventTag {
 	ManaGain,
@@ -384,13 +385,13 @@ export class ResourceOverride {
 					name: "drop " + rsc.type,
 					delay: newTimer,
 					fnOnRsc: (r: Resource) => {
-						  if (rsc.type === ResourceType.Enochian) { // since enochian should also take away AF/UI/UH stacks
-						  		// TODO move to job-specific code
-								game.loseEnochian();
-						  } else {
-							  r.consume(r.availableAmount());
-						  }
-					 }
+						if (rsc.type === ResourceType.Enochian) { // since enochian should also take away AF/UI/UH stacks
+							// TODO move to job-specific code
+							(game as BLMState).loseEnochian();
+						} else {
+							r.consume(r.availableAmount());
+						}
+					}
 				});
 			};
 

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -156,7 +156,7 @@ export class CoolDownState {
 		let rsc = this.#map.get(rscType);
 		if (rsc) return rsc;
 		else {
-			console.assert(false);
+			console.assert(false, `no cooldown for resource ${rscType}`);
 			return new CoolDown(ResourceType.Never, 0, 0, 0);
 		}
 	}

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -1,5 +1,5 @@
 import {Debug, ResourceType} from "./Common"
-import {GameState} from "./GameState";
+import {PlayerState, GameState} from "./GameState";
 import {ActionNode} from "../Controller/Record";
 
 export enum EventTag {
@@ -8,12 +8,12 @@ export enum EventTag {
 	LucidTick
 }
 
-export class Event {
+export class Event<T extends PlayerState> {
 	name: string;
 	#tags: EventTag[];
 	timeTillEvent: number;
 	delay: number;
-	effectFn: () => void;
+	effectFn: (state: T, node?: ActionNode) => void;
 	canceled: boolean;
 
 	// effectFn : () -> ()

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -198,7 +198,7 @@ export class ResourceState {
 		let rsc = this.#map.get(rscType);
 		if (rsc) return rsc;
 		else {
-			console.assert(`could not find resource ${rscType}`);
+			console.error(`could not find resource ${rscType}`);
 			return new Resource(ResourceType.Never, 0, 0);
 		}
 	}

--- a/src/Game/Skills.ts
+++ b/src/Game/Skills.ts
@@ -1,21 +1,8 @@
-import {Aspect, BuffType, LevelSync, ProcMode, ResourceType, SkillName, WarningType} from './Common'
-// @ts-ignore
-import {controller} from "../Controller/Controller";
+import {Aspect, LevelSync, ResourceType, SkillName} from './Common'
 import {ShellJob, ShellInfo} from "../Controller/Common";
-import {Event, DoTBuff, EventTag, Resource} from "./Resources";
 import {ActionNode} from "../Controller/Record";
 import {PlayerState, GameState} from "./GameState";
-import {getPotencyModifiersFromResourceState, Potency} from "./Potency";
 import {TraitName, Traits} from './Traits';
-
-export interface SkillCaptureCallbackInfo {
-	capturedManaCost: number
-}
-
-export interface SkillApplicationCallbackInfo {
-
-}
-
 
 // if skill is lower than current level, auto upgrade until (no more upgrade options) or (more upgrades will exceed current level)
 // if skill is higher than current level, auto downgrade until skill is at or below current level. If run out of downgrades, throw error

--- a/src/Game/Skills.ts
+++ b/src/Game/Skills.ts
@@ -130,7 +130,19 @@ export type Skill<T extends PlayerState> = Spell<T> | Weaponskill<T> | Ability<T
 // This is automatically populated by the makeWeaponskill, makeSpell, and makeAbility helper functions.
 // Unfortunately, I [sz] don't really know of a good way to encode the relationship between
 // the ShellJob and Skill<T>, so we'll just have to live with performing casts at certain locations.
-export const skillMap: Map<ShellJob, Map<SkillName, Skill<PlayerState>>> = new Map();
+const skillMap: Map<ShellJob, Map<SkillName, Skill<PlayerState>>> = new Map();
+
+// Return a particular skill for a job.
+// Raises if the skill is not found.
+export function getSkill<T extends PlayerState>(job: ShellJob, skillName: SkillName): Skill<T> {
+	return skillMap.get(job)!.get(skillName)!;
+}
+
+// Return the map of all skills for a job.
+export function getAllSkills<T extends PlayerState>(job: ShellJob): Map<SkillName, Skill<T>> {
+	return skillMap.get(job)!;
+}
+
 
 ALL_JOBS.forEach((job) => skillMap.set(job, new Map()));
 
@@ -349,6 +361,7 @@ export class DisplayedSkills extends Array<SkillName> {
 		console.assert(skillMap.has(ShellInfo.job), `No skill map found for job: ${ShellInfo.job}`)
 		// TODO move contextual hotbar info (paradox, retrace) to here
 		const hotbarExcludeSkills = [
+			SkillName.Never, // never display Never
 			SkillName.Paradox,
 			SkillName.Retrace
 		];

--- a/src/Game/Skills.ts
+++ b/src/Game/Skills.ts
@@ -4,7 +4,7 @@ import {controller} from "../Controller/Controller";
 import {ShellJob, ShellInfo} from "../Controller/Common";
 import {Event, DoTBuff, EventTag, Resource} from "./Resources";
 import {ActionNode} from "../Controller/Record";
-import {GameState} from "./GameState";
+import {PlayerState, GameState} from "./GameState";
 import {getPotencyModifiersFromResourceState, Potency} from "./Potency";
 import {TraitName, Traits} from './Traits';
 
@@ -22,8 +22,8 @@ export interface SkillError {
 
 // Represent the result of attempting to perform a skill. If an error occurs (for example, enochian
 // dropped after the start of an F4 cast but before the cast confirm window), then return a
-// SkillError. If the skill succeeded, then return a list of events to be enqueued.
-export type SkillResult = Event[] | SkillError;
+// SkillError. If the skill succeeded, then return undefined or a list of events to be enqueued.
+export type SkillResult<T extends PlayerState> = Event<T>[] | undefined | SkillError;
 
 // if skill is lower than current level, auto upgrade until (no more upgrade options) or (more upgrades will exceed current level)
 // if skill is higher than current level, auto downgrade until skill is at or below current level. If run out of downgrades, throw error
@@ -32,15 +32,42 @@ export type SkillAutoReplace = {
 	otherSkill: SkillName,
 }
 
-export type ResourceCalculationFn<T> = (state: ReadOnly<T>) => number;
-export type ValidateAttemptFn<T> = (state: ReadOnly<T>) => SkillError?;
-export type IsInstantFn<T> = (state: T) => bool;
-export type EffectFn<T> = (state: ReadOnly<T>) => SkillResult;
+/*
+ * A ResourceCalculationFn is called when a skill usage is attempted, and determine properties
+ * like cast time, recast time, mana cost, and potency based on the current game state.
+ * They should not actually consume any resources, as those are only consumed when the skill
+ * usage is confirmed.
+ */
+export type ResourceCalculationFn<T> = (state: Readonly<T>) => number;
+export type ValidateAttemptFn<T> = (state: Readonly<T>) => SkillError | undefined;
+export type IsInstantFn<T> = (state: T) => boolean;
+export type EffectFn<T> = (state: T, node?: ActionNode) => SkillResult<T>;
 
 
-// TODO split this interface between GCDs + oGCD abilities, as some properties are only relevant
-// to one or the other
-export interface Skill<T extends GameState> {
+type CondType<T> = (state: Readonly<T>) => boolean;
+/**
+ * Helper function to create a ValidateAttemptFn that returns a SkillError containing 
+ * `emsg` when `cond` evaluates to false.
+ */
+export const validateOrSkillError = (cond: CondType, emsg: string) => (
+	(state) => cond(state) ? undefined : { message: emsg }
+);
+
+/**
+ * A Skill represents an action that a player can take.
+ * 
+ * Skills are distinguished by a "kind" field, which should be assigned by each sub-type's
+ * corresponding helper constructor function. Switching on this kind field lets us apply
+ * different behavior for GCDs and oGCDs with the type checker's blessing, for example:
+ * 
+ * if (skill.kind === "ability") {
+ *   // do something with oGCDs
+ * } else if (skill.kind === "weaponskill" || skill.kind === "spell") {
+ *   // do something with GCDs 
+ *   // castTimeFn, recastTimeFn, etc. are valid here
+ * }
+ */
+export interface Skill<T extends PlayerState> {
 	// === COSMETIC PROPERTIES ===
 	readonly name: SkillName;
 	readonly assetPath: string; // path relative to the Components/Asset/Skills folder 
@@ -49,25 +76,56 @@ export interface Skill<T extends GameState> {
 	readonly autoDowngrade?: SkillAutoReplace;
 	readonly cdName: ResourceType;
 	readonly aspect: Aspect;
-	readonly isSpell: boolean;
 
-	/* === RESOURCE VALIDATION ===
-	 * The following functions are all called when a skill usage is attempted, and determine properties
-	 * like cast time, recast time, mana cost, and potency based on the current game state.
-	 * They should not actually consume any resources, as those are only consumed when the skill
-	 * usage is confirmed.
-	 */
-	readonly castTimeFn: ResourceCalculationFn;
-	readonly recastTimeFn: ResourceCalculationFn;
-	// TODO can MP cost ever change between cast start + confirm, e.g. if you use an ether kit or
-	// lost font of magic and cast flare with hearts?
-	readonly manaCostFn: ResourceCalculationFn;
 	// Determine the potency of the ability before any party buffs or modifiers.
-	readonly potencyFn: ResourceCalculationFn;
+	readonly potencyFn: ResourceCalculationFn<T>;
 
 	// Determine whether the skill can be executed in the current state.
 	// Should be called when the button is pressed.
-	readonly validateAttempt: ValidateAttemptFn;
+	readonly validateAttempt: ValidateAttemptFn<T>;
+
+	/* === EFFECTS ===
+	 * The following functions determine the effects of using a skill.
+	 * On success, they will return a list of future events to be applied
+	 * (an undefined return is treated as the empty list).
+	 * On failure, they will return an error that should be propagated.
+	 *
+	 * Immediate effects should be expressed through the function's side effects, but future
+	 * queued events (such as timer drops) should be returned as event objects.
+	 * Because they are stateful, you can also directly enqueue a future event without returning,
+	 * an Event, but doing so makes control flow harder to follow.
+	 */
+
+	/* Return a list of future Event objects when the action is applied.
+	 * If the action became invalid between the start of the cast and the cast confirmation,
+	 * then return a SkillError instead.
+	 * This should be called at the function's cast confirm window.
+	 *
+	 * If this is a spell that is normally hardcast, but was somehow made instant,
+	 * then the game loop will call `onConfirm` immediately after validation.
+	 */
+	readonly onConfirm: EffectFn<T>;
+
+	/* Return a list of events to apply at the time of skill application. This includes
+	 * damage events and buffs/debuffs.
+	 * If `onConfirm` did not error, then the game loop MUST automatically enqueue this function,
+	 * rather than `onConfirm` itself enqueuing an `onApplication` event.
+	 */
+	readonly onApplication: EffectFn<T>;
+
+	// The simulation delay, in seconds, between which `onConfirm` and `onApplication` are called.
+	readonly applicationDelay: number;
+}
+
+
+export type GCD<T extends PlayerState> = Skill<T> & {
+	// GCDs have cast/recast + MP cost, but oGCDs do not.
+	// The only exception is BLU (as far as I [sz] know). Let us pray we never cross that particular bridge.
+	readonly castTimeFn: ResourceCalculationFn<T>;
+	readonly recastTimeFn: ResourceCalculationFn<T>;
+	// TODO can MP cost ever change between cast start + confirm, e.g. if you use an ether kit or
+	// lost font of magic and cast flare with hearts?
+	readonly manaCostFn: ResourceCalculationFn<T>;
 
 	/*
 	 * Consume any resource that would make this skill instant cast, and return
@@ -83,40 +141,30 @@ export interface Skill<T extends GameState> {
 	 *	
 	 * Because this may mutate the state, this function must be called only ONCE per skill usage.
 	 */
-	readonly isInstantFn: IsInstantFn;
+	// TODO probably need to change this, since tooltips need to compute if the spell is instant or not
+	readonly isInstantFn: IsInstantFn<T>;
+}
 
-	/* === EFFECTS ===
-	 * The following functions determine the effects of using a skill.
-	 * On success, they will return a list of events to be applied.
-	 * On failure, they will return an error that should be propagated.
-	 * 
-	 * Return a list of Event objects when the action is applied.
-	 * If the action became invalid between the start of the cast and the cast confirmation,
-	 * then return a SkillError instead.
-	 * This should be called at the function's cast confirm window.
-	 *
-	 * If this is a spell that is normally hardcast, but was somehow made instant,
-	 * then the game loop will call `onConfirm` immediately after validation.
-	 */
-	readonly onConfirm: EffectFn;
+export type Spell<T extends PlayerState> = GCD<T> & {
+	kind: "spell";
+}
 
-	/* Return a list of events to apply at the time of skill application. This includes
-	 * damage events and buffs/debuffs.
-	 * If `onConfirm` did not error, then the game loop MUST automatically enqueue this function,
-	 * rather than `onConfirm` itself enqueuing an `onApplication` event.
-	 */
-	readonly onApplication: EffectFn;
 
-	// The simulation delay, in seconds, between which `onConfirm` and `onApplication` are called.
-	readonly applicationDelay: number;
+export type Weaponskill<T extends PlayerState> = GCD<T> & {
+	kind: "weaponskill";
+}
+
+
+export type Ability<T extends PlayerState> = Skill<T> & {
+	kind: "ability";
 }
 
 
 // Map tracking skills for each job.
-// This is automatically populated by the makeGCD and makeAbility helper functions.
+// This is automatically populated by the makeWeaponskill, makeSpell, and makeAbility helper functions.
 // Unfortunately, I [sz] don't really know of a good way to encode the relationship between
 // the ShellJob and Skill<T>, so we'll just have to live with performing casts at certain locations.
-export const skillMap: Map<ShellJob, Map<SkillName, Skill<GenericState>>> = new Map();
+export const skillMap: Map<ShellJob, Map<SkillName, Skill<PlayerState>>> = new Map();
 
 // can't iterate over a const enum so just populate manually :/
 [
@@ -124,6 +172,17 @@ export const skillMap: Map<ShellJob, Map<SkillName, Skill<GenericState>>> = new 
 	ShellJob.PCT,
 ].forEach((job) => skillMap.set(job, new Map()));
 
+
+// Helper function to transform an optional<number | function> that has a default number value into a function.
+function fnify<T extends PlayerState>(arg?: number | ResourceCalculationFn<T>, defaultValue: number): ResourceCalculationFn<T> {
+	if (arg === undefined) {
+		return (state) => defaultValue;
+	} else if (typeof arg === "number") {
+		return (state) => arg;
+	} else {
+		return arg;
+	}
+};
 
 /**
  * Declare a GCD skill.
@@ -145,34 +204,26 @@ export const skillMap: Map<ShellJob, Map<SkillName, Skill<GenericState>>> = new 
  * TODO: If we ever branch out to non-BLM/PCT jobs, we should distinguish between
  * spells and weaponskills for sps/sks calculation purposes.
  */
-export const makeGCD<T> = (jobs: ShellJob | ShellJob[], name: SkillName, unlockLevel: number, params: Partial<{
+export function makeSpell<T extends PlayerState>(jobs: ShellJob | ShellJob[], name: SkillName, unlockLevel: number, params: Partial<{
 	assetPath: string,
 	autoUpgrade: SkillAutoReplace,
 	autoDowngrade: SkillAutoReplace,
 	aspect: Aspect,
-	castTime: number | ResourceCalculationFn,
-	recastTime: number | ResourceCalculationFn,
-	manaCost: number | ResourceCalculationFn,
-	potency: number | ResourceCalculationFn,
+	castTime: number | ResourceCalculationFn<T>,
+	recastTime: number | ResourceCalculationFn<T>,
+	manaCost: number | ResourceCalculationFn<T>,
+	potency: number | ResourceCalculationFn<T>,
 	applicationDelay: number,
-	validateAttempt: ValidateAttemptFn,
-	isInstantFn: IsInstantFn,
-	onConfirm: EffectFn,
-	onApplication: EffectFn,
-}>): Skill<T> => {
+	validateAttempt: ValidateAttemptFn<T>,
+	isInstantFn: IsInstantFn<T>,
+	onConfirm: EffectFn<T>,
+	onApplication: EffectFn<T>,
+}>): Spell<T> {
 	if (!Array.isArray(jobs)) {
 		jobs = [jobs];
 	}
-	const fnify = (arg?: number | ResourceCalculationFn, defaultValue: number): ResourceCalculationFn => {
-		if (arg === undefined) {
-			return (state) => defaultValue;
-		} else if (typeof arg === "number") {
-			return (state) => arg;
-		} else {
-			return arg;
-		}
-	};
 	const info = {
+		kind: "spell",
 		name: name,
 		assetPath: params.assetPath ?? (jobs.length === 1 ? `${jobs[0]}/${name}.png` : "General/Missing.png"),
 		unlockLevel: unlockLevel,
@@ -180,19 +231,18 @@ export const makeGCD<T> = (jobs: ShellJob | ShellJob[], name: SkillName, unlockL
 		autoDowngrade: params.autoDowngrade,
 		cdName: ResourceType.cd_GCD,
 		aspect: params.aspect ?? Aspect.Other,
-		isSpell: true,
 		castTimeFn: fnify(params.castTime, 0),
 		recastTimeFn: fnify(params.recastTime, 2.5),
 		manaCostFn: fnify(params.manaCost, 0),
 		potencyFn: fnify(params.potency, 0),
-		validateAttempt: params.validateAttempt ?? ((state) => undefined);
-		isInstantFn: params.isInstant ?? ((state) => true);
-		onConfirm: params.onConfirm ?? ((state) => []);
+		validateAttempt: params.validateAttempt ?? ((state) => undefined),
+		isInstantFn: params.isInstant ?? ((state) => true),
+		onConfirm: params.onConfirm ?? ((state, node) => []),
 		// TODO encode damage event
-		onApplication: params.onApplication ?? ((state) => []);
+		onApplication: params.onApplication ?? ((state, node) => []),
 		applicationDelay: params.applicationDelay ?? 0,
 	};
-	jobs.forEach((job) => skillInfosMap.get(job)!.set(info.name, info));
+	jobs.forEach((job) => skillMap.get(job)!.set(info.name, info));
 	return info;
 };
 
@@ -201,773 +251,124 @@ export const makeGCD<T> = (jobs: ShellJob | ShellJob[], name: SkillName, unlockL
  * Declare an oGCD ability.
  *
  * Only the ability's name, unlock level, and cooldown are mandatory. All optional params default as follows:
- * - autoUpgrade + autoDowngrade: remain undefined
- * - basePotency: 0
- * - applicationDelay: 0 if basePotency is defined, otherwise left undefined
- * - onCapture: empty function
- * - onApplication: empty function
  * - assetPath: if `jobs` is a single job, then "$JOB/$SKILLNAME.png"; otherwise "General/Missing.png"
- *
- * Cast time and mana cost are only relevant for BLU (as far as I [sz] know). Let us pray we never
- * cross that particular bridge.
+ * - autoUpgrade + autoDowngrade: remain undefined
+ * - potency: 0
+ * - applicationDelay: 0 if basePotency is defined, otherwise left undefined
+ * - validateAttempt: function always returning undefined (no error)
+ * - onConfirm: function always returning empty list (no events enqueued)
+ * - onApplication: function returning a damage event if `basePotency` is a non-zero scalar, else empty list
  */
-export const makeAbility = (jobs: ShellJob | ShellJob[], name: SkillName, unlockLevel: number, cdName: ResourceType, params: Partial<{
+export function makeAbility<T extends PlayerState>(jobs: ShellJob | ShellJob[], name: SkillName, unlockLevel: number, cdName: ResourceType, params: Partial<{
+	assetPath: string,
 	autoUpgrade: SkillAutoReplace,
 	autoDowngrade: SkillAutoReplace,
-	basePotency: number,
+	potency: number | ResourceCalculationFn<T>,
 	applicationDelay: number,
-	onCapture: any,  // TODO
-	onApplication: any,  // TODO
-	assetPath: string,
-}>): SkillInfo => {
+	validateAttempt: ValidateAttemptFn<T>,
+	onConfirm: EffectFn<T>,
+	onApplication: EffectFn<T>,
+}>): Ability<T> {
 	if (!Array.isArray(jobs)) {
 		jobs = [jobs];
 	}
-	const info = {
+	const info: Ability<T> = {
+		kind: "ability",
 		name: name,
+		assetPath: params.assetPath ?? (jobs.length === 1 ? `${jobs[0]}/${name}.png` : "General/Missing.png"),
 		unlockLevel: unlockLevel,
 		autoUpgrade: params.autoUpgrade,
 		autoDowngrade: params.autoDowngrade,
 		cdName: cdName,
 		aspect: Aspect.Other,
-		isSpell: false,
-		baseCastTime: 0,
-		baseManaCost: 0,
-		basePotency: params.basePotency ?? 0,
+		potencyFn: fnify(params.basePotency, 0),
 		applicationDelay: params.applicationDelay ?? 0,
-		onCapture: params.onCapture ?? (() => {}),
-		onApplication: params.onApplication ?? (() => {}),
-		assetPath: params.assetPath ?? (jobs.length === 1 ? `${jobs[0]}/${name}.png` : "General/Missing.png"),
+		validateAttempt: ValidateAttemptFn ?? ((state) => undefined),
+		onConfirm: params.onConfirm ?? ((state, node) => []),
+		onApplication: params.onApplication ?? ((state, node) => []),
 	};
-	jobs.forEach((job) => skillInfosMap.get(job)!.set(info.name, info));
+	jobs.forEach((job) => skillMap.get(job)!.set(info.name, info));
 	return info;
 }
 
 // Dummy skill to avoid a hard crash when a skill info isn't found
-const NEVER_SKILL = makeGCD([], SkillName.Never, 1, {});
+const NEVER_SKILL = makeSpell([], SkillName.Never, 1, {});
 
 
-export class Skill {
-	readonly name: SkillName;
-	readonly available: () => boolean;
-	readonly use: (game: GameState, node: ActionNode) => void;
-	info: SkillInfo;
-
-	constructor(name: SkillName, requirementFn: ()=>boolean, effectFn: (game: GameState, node: ActionNode)=>void) {
-		this.name = name;
-		this.available = requirementFn;
-		this.use = effectFn;
-		let info = skillInfosMap.get(ShellInfo.job)!.get(name);
-		if (!info) {
-			info = NEVER_SKILL;
-			console.error(`Skill info for ${name} not found!`);
-		}
-		this.info = info;
+/**
+ * Helper function to create an Ability that applies a buff or debuff (`rscType`) for a certain duration.
+ *
+ * Any additional effects should be encoded in `additionalEvents`, a list of Event objects with
+ * delay relative to the application of the ability.
+ */
+// TODO allow specifying cooldown + number of charges here
+export function makeResourceAbility<T extends PlayerState>(
+	jobs: ShellJob | ShellJob[],
+	name: SkillName,
+	unlockLevel: number,
+	cdName: ResourceType,
+	params: {
+		rscType: ResourceType,
+		applicationDelay: number,
+		duration: number | ResourceCalculationFn<T>,
+		potency?: number | ResourceCalculationFn<T>,
+		validateAttempt?: ValidateAttemptFn<T>,
+		onConfirm?: EffectFn<T>,
+		onApplication?: EffectFn<T>,
+		assetPath?: string,
 	}
-}
+): Ability<T> {
+	// When the ability is applied, enqueue two events:
+	// 1. An immediate resource gain event
+	// 2. A resource drop event after a duration, overriding an existing timer if it exists
+	const onApplication = (state: T, node?: ActionNode) => {
+		state.resources.get(params.rscType).gain(1);
+		// TODO tell scheduler to override existing drop event if necessary
+		const durationFn = (typeof params.duration === "number") ? ((state: T) => params.duration) : params.duration;
+		const otherApplication = (params?.onApplication === undefined) ? [] : (params.onApplication(state, node) ?? []);
+		return [new Event(
+			"drop " + params.rscType,
+			durationFn(state),
+			(state: T) => state.resources.get(params.rscType).consume(1),
+		)].concat(otherList);
+	};
+	return makeAbility(jobs, name, unlockLevel, cdName, {
+		potency: params.potency,
+		applicationDelay: params.applicationDelay,
+		// TODO (state) => state.resources.get(cdName).available(1),
+		validateAttempt: params.validateAttempt,
+		onConfirm: params.onConfirm,
+		onApplication: onApplication,
+		assetPath: params.assetPath,
+	});
+};
 
-export class SkillsList extends Map<SkillName, Skill> {
-	constructor(game: GameState) {
-		super();
 
-		let skillsList = this;
+export class SkillsList<T extends PlayerState> {
+	job: ShellJob;
 
-		let addResourceAbility = function(props: {
-			skillName: SkillName,
-			rscType: ResourceType,
-			instant: boolean,
-			duration: number,
-			additionalEffect?: () => void
-		}) {
-			let takeEffect = (node: ActionNode) => {
-				let resource = game.resources.get(props.rscType);
-				if (resource.available(1)) {
-					resource.overrideTimer(game, props.duration);
-				} else {
-					resource.gain(1);
-					game.resources.addResourceEvent({
-						rscType: props.rscType,
-						name: "drop " + props.rscType,
-						delay: props.duration,
-						fnOnRsc: (rsc: Resource) => {
-							rsc.consume(1);
-						}
-					});
-				}
-				node.resolveAll(game.getDisplayTime());
-				if (props.additionalEffect) {
-					props.additionalEffect();
-				}
-			};
-			skillsList.set(props.skillName, new Skill(props.skillName,
-				() => {
-					return true;
-				},
-				(game, node) => {
-					game.useInstantSkill({
-						skillName: props.skillName,
-						onCapture: props.instant ? ()=>takeEffect(node) : undefined,
-						onApplication: props.instant ? undefined : ()=>takeEffect(node),
-						dealDamage: false,
-						node: node
-					});
-				}
-			));
-		}
-
-		// Blizzard
-		skillsList.set(SkillName.Blizzard, new Skill(SkillName.Blizzard,
-			() => {
-				return true;
-			},
-			(game: GameState, node: ActionNode) => {
-				if (game.getFireStacks() === 0) // no AF
-				{
-					game.castSpell({skillName: SkillName.Blizzard, onCapture: (cap: SkillCaptureCallbackInfo) => {
-						game.switchToAForUI(ResourceType.UmbralIce, 1);
-						game.startOrRefreshEnochian();
-					}, onApplication: (app: SkillApplicationCallbackInfo) => {
-					}, node: node});
-				} else // in AF
-				{
-					game.castSpell({skillName: SkillName.Blizzard, onCapture: (cap: SkillCaptureCallbackInfo) => {
-						game.resources.get(ResourceType.Enochian).removeTimer();
-						game.loseEnochian();
-					}, onApplication: (app: SkillApplicationCallbackInfo) => {
-					}, node: node});
-				}
-			}
-		));
-
-		let gainFirestarterProc = function(game: GameState) {
-			let fs = game.resources.get(ResourceType.Firestarter);
-			// re-measured in DT, screen recording at: https://drive.google.com/file/d/1MEFnd-m59qx1yIaZeehSsAxjhLMsWBuw/view?usp=drive_link
-			let duration = 30.5;
-			if (fs.available(1)) {
-				fs.overrideTimer(game, duration);
-			} else {
-				fs.gain(1);
-				game.resources.addResourceEvent({
-					rscType: ResourceType.Firestarter,
-					name: "drop firestarter proc",
-					delay: duration,
-					fnOnRsc: (rsc: Resource)=>{
-						rsc.consume(1);
-					}
-				});
-			}
-		}
-
-		let potentiallyGainFirestarter = function(game: GameState) {
-			let rand = game.rng(); // firestarter proc
-			if (game.config.procMode===ProcMode.Always || (game.config.procMode===ProcMode.RNG && rand < 0.4)) gainFirestarterProc(game);
-		}
-
-		// Fire
-		skillsList.set(SkillName.Fire, new Skill(SkillName.Fire,
-			() => {
-				return true;
-			},
-			(game, node) => {
-				if (game.getIceStacks() === 0) { // in fire or no enochian
-					game.castSpell({skillName: SkillName.Fire, onCapture: (cap: SkillCaptureCallbackInfo) => {
-						game.switchToAForUI(ResourceType.AstralFire, 1);
-						game.startOrRefreshEnochian();
-						potentiallyGainFirestarter(game);
-					}, onApplication: (app: SkillApplicationCallbackInfo) => {
-					}, node: node});
-				} else {
-					game.castSpell({skillName: SkillName.Fire, onCapture: (cap: SkillCaptureCallbackInfo) => {
-						game.resources.get(ResourceType.Enochian).removeTimer();
-						game.loseEnochian();
-						potentiallyGainFirestarter(game);
-					}, onApplication: (app: SkillApplicationCallbackInfo) => {
-					}, node: node});
-				}
-			}
-		));
-
-		// Transpose
-		skillsList.set(SkillName.Transpose, new Skill(SkillName.Transpose,
-			() => {
-				return game.getFireStacks() > 0 || game.getIceStacks() > 0; // has UI or AF
-			},
-			(game, node) => {
-				game.useInstantSkill({
-					skillName: SkillName.Transpose,
-					onCapture: () => {
-						if (game.getFireStacks() === 0 && game.getIceStacks() === 0) {
-							return;
-						}
-						if (game.getFireStacks() > 0) {
-							game.switchToAForUI(ResourceType.UmbralIce, 1);
-						} else {
-							game.switchToAForUI(ResourceType.AstralFire, 1);
-						}
-						game.startOrRefreshEnochian();
-					},
-					dealDamage: false,
-					node: node
-				});
-				node.resolveAll(game.getDisplayTime());
-			}
-		));
-
-		// Ley Lines
-		addResourceAbility({
-			skillName: SkillName.LeyLines,
-			rscType: ResourceType.LeyLines,
-			instant: false,
-			duration: 30,
-			additionalEffect: () => {
-				game.resources.get(ResourceType.LeyLines).enabled = true;
-			}
-		});
-
-		let applyThunderDoT = function(game: GameState, node: ActionNode, skillName: SkillName) {
-			let thunder = game.resources.get(ResourceType.ThunderDoT) as DoTBuff;
-			const thunderDuration = (skillName === SkillName.Thunder3 && 27) || 30;
-			if (thunder.available(1)) {
-				console.assert(thunder.node);
-				(thunder.node as ActionNode).removeUnresolvedPotencies();
-
-				thunder.overrideTimer(game, thunderDuration);
-			} else {
-				thunder.gain(1);
-				controller.reportDotStart(game.getDisplayTime());
-				game.resources.addResourceEvent({
-					rscType: ResourceType.ThunderDoT,
-					name: "drop thunder DoT",
-					delay: thunderDuration,
-					fnOnRsc: rsc=>{
-						  rsc.consume(1);
-						  controller.reportDotDrop(game.getDisplayTime());
-					 }
-				});
-			}
-			thunder.node = node;
-			thunder.tickCount = 0;
-		}
-
-		let addThunderPotencies = function(node: ActionNode, skillName: SkillName.Thunder3 | SkillName.HighThunder) {
-			let mods = getPotencyModifiersFromResourceState(game.resources, Aspect.Lightning);
-			let thunder = skillsList.get(skillName);
-
-			// initial potency
-			let pInitial = new Potency({
-				config: controller.record.config ?? controller.gameConfig,
-				sourceTime: game.getDisplayTime(),
-				sourceSkill: skillName,
-				aspect: Aspect.Lightning,
-				basePotency: thunder ? thunder.info.basePotency : 150,
-				snapshotTime: undefined,
-				description: ""
-			});
-			pInitial.modifiers = mods;
-			node.addPotency(pInitial);
-
-			// dots
-			const thunderTicks = (skillName === SkillName.Thunder3 && 9) || 10;
-			const thunderTickPotency = (skillName === SkillName.Thunder3 && 50) || 60;
-			for (let i = 0; i < thunderTicks; i++) {
-				let pDot = new Potency({
-					config: controller.record.config ?? controller.gameConfig,
-					sourceTime: game.getDisplayTime(),
-					sourceSkill: skillName,
-					aspect: Aspect.Lightning,
-					basePotency: game.config.adjustedDoTPotency(thunderTickPotency),
-					snapshotTime: undefined,
-					description: "DoT " + (i+1) + `/${thunderTicks}`
-				});
-				pDot.modifiers = mods;
-				node.addPotency(pDot);
-			}
-		}
-
-		let addThunders = function(skillName: SkillName.Thunder3 | SkillName.HighThunder) {
-			skillsList.set(skillName, new Skill(skillName,
-				() => {
-					return game.resources.get(ResourceType.Thunderhead).available(1);
-				},
-				(game, node) => {
-					// potency
-					addThunderPotencies(node, skillName); // should call on capture
-					let onHitPotency = node.getPotencies()[0];
-					node.getPotencies().forEach(p=>{ p.snapshotTime = game.getDisplayTime(); });
-	
-					// tincture
-					if (game.resources.get(ResourceType.Tincture).available(1)) {
-						node.addBuff(BuffType.Tincture);
-					}
-	
-					game.useInstantSkill({
-						skillName: skillName,
-						onApplication: () => {
-							controller.resolvePotency(onHitPotency);
-							applyThunderDoT(game, node, skillName);
-						},
-						dealDamage: false,
-						node: node
-					});
-					let thunderhead = game.resources.get(ResourceType.Thunderhead);
-					thunderhead.consume(1);
-					thunderhead.removeTimer();
-				}
-			));
-		}
-		addThunders(SkillName.Thunder3);
-		addThunders(SkillName.HighThunder);
-
-		// Manaward
-		addResourceAbility({skillName: SkillName.Manaward, rscType: ResourceType.Manaward, instant: false, duration: 20});
-
-		// Manafont
-		skillsList.set(SkillName.Manafont, new Skill(SkillName.Manafont,
-			() => {
-				return game.resources.get(ResourceType.AstralFire).availableAmount() > 0;
-			},
-			(game, node) => {
-				let useSkillEvent = game.useInstantSkill({
-					skillName: SkillName.Manafont,
-					onCapture: () => {
-						game.resources.get(ResourceType.AstralFire).gain(3);
-						game.resources.get(ResourceType.UmbralHeart).gain(3);
-
-						if (Traits.hasUnlocked(TraitName.AspectMasteryV, game.config.level))
-							game.resources.get(ResourceType.Paradox).gain(1);
-
-						game.gainThunderhead();
-						game.startOrRefreshEnochian();
-						node.resolveAll(game.getDisplayTime());
-					},
-					onApplication: () => {
-						game.resources.get(ResourceType.Mana).gain(10000);
-					},
-					dealDamage: false,
-					node: node
-				});
-				useSkillEvent.addTag(EventTag.ManaGain);
-			}
-		));
-
-		// Fire 3
-		skillsList.set(SkillName.Fire3, new Skill(SkillName.Fire3,
-			() => {
-				return true;
-			},
-			(game, node) => {
-				if (game.resources.get(ResourceType.Firestarter).available(1)) {
-					game.useInstantSkill({
-						skillName: SkillName.Fire3,
-						dealDamage: true,
-						node: node
-					});
-					game.switchToAForUI(ResourceType.AstralFire, 3);
-					game.startOrRefreshEnochian();
-					game.resources.get(ResourceType.Firestarter).consume(1);
-					game.resources.get(ResourceType.Firestarter).removeTimer();
-				} else {
-					game.castSpell({skillName: SkillName.Fire3, onCapture: (cap: SkillCaptureCallbackInfo) => {
-						game.switchToAForUI(ResourceType.AstralFire, 3);
-						game.startOrRefreshEnochian();
-					}, onApplication: (app: SkillApplicationCallbackInfo) => {
-					}, node: node});
-				}
-			}
-		));
-
-		// Blizzard 3
-		skillsList.set(SkillName.Blizzard3, new Skill(SkillName.Blizzard3,
-			() => {
-				return true;
-			},
-			(game, node) => {
-				game.castSpell({skillName: SkillName.Blizzard3, onCapture: (cap: SkillCaptureCallbackInfo) => {
-					game.switchToAForUI(ResourceType.UmbralIce, 3);
-					game.startOrRefreshEnochian();
-				}, onApplication: (app: SkillApplicationCallbackInfo) => {
-				}, node: node});
-			}
-		));
-
-		// Freeze
-		skillsList.set(SkillName.Freeze, new Skill(SkillName.Freeze,
-			() => {
-				return game.getIceStacks() > 0; // in UI
-			},
-			(game, node) => {
-				game.castSpell({skillName: SkillName.Freeze, onCapture: (cap: SkillCaptureCallbackInfo) => {
-					game.resources.get(ResourceType.UmbralHeart).gain(3);
-				}, onApplication: (app: SkillApplicationCallbackInfo) => {
-				}, node: node});
-			}
-		));
-
-		// Flare
-		skillsList.set(SkillName.Flare, new Skill(SkillName.Flare,
-			() => {
-				return game.getFireStacks() > 0 && // in AF
-					game.getMP() >= 800;
-			},
-			(game, node) => {
-				game.castSpell({skillName: SkillName.Flare, onCapture: (cap: SkillCaptureCallbackInfo) => {
-					let uh = game.resources.get(ResourceType.UmbralHeart);
-					let mana = game.resources.get(ResourceType.Mana);
-					let manaCost = uh.available(1) ? mana.availableAmount() * 0.66 : mana.availableAmount();
-					// mana
-					game.resources.get(ResourceType.Mana).consume(manaCost);
-					uh.consume(uh.availableAmount());
-					// +3 AF; refresh enochian
-					game.resources.get(ResourceType.AstralFire).gain(3);
-
-					if (Traits.hasUnlocked(TraitName.EnhancedAstralFire, game.config.level))
-						game.resources.get(ResourceType.AstralSoul).gain(3);
-
-					game.startOrRefreshEnochian();
-				}, onApplication: (app: SkillApplicationCallbackInfo) => {
-				}, node: node});
-			}
-		));
-
-		// Blizzard 4
-		skillsList.set(SkillName.Blizzard4, new Skill(SkillName.Blizzard4,
-			() => {
-				return game.getIceStacks() > 0; // in UI
-			},
-			(game, node) => {
-				game.castSpell({skillName: SkillName.Blizzard4, onCapture: (cap: SkillCaptureCallbackInfo) => {
-					game.resources.get(ResourceType.UmbralHeart).gain(3);
-				}, onApplication: (app: SkillApplicationCallbackInfo) => {
-				}, node: node});
-			}
-		));
-
-		// Fire 4
-		skillsList.set(SkillName.Fire4, new Skill(SkillName.Fire4,
-			() => {
-				return game.getFireStacks() > 0; // in AF
-			},
-			(game, node) => {
-				game.castSpell({skillName: SkillName.Fire4, onCapture: (cap: SkillCaptureCallbackInfo) => {
-					if (Traits.hasUnlocked(TraitName.EnhancedAstralFire, game.config.level))
-						game.resources.get(ResourceType.AstralSoul).gain(1);
-				}, onApplication: (app: SkillApplicationCallbackInfo) => {
-				}, node: node});
-			}
-		));
-
-		// Between the Lines
-		skillsList.set(SkillName.BetweenTheLines, new Skill(SkillName.BetweenTheLines,
-			() => {
-				let ll = game.resources.get(ResourceType.LeyLines);
-				return ll.availableAmountIncludingDisabled() > 0;
-			},
-			(game, node) => {
-				game.useInstantSkill({
-					skillName: SkillName.BetweenTheLines,
-					dealDamage: false,
-					onCapture: ()=>{node.resolveAll(game.getDisplayTime())},
-					node: node
-				});
-			}
-		));
-
-		// Aetherial Manipulation
-		skillsList.set(SkillName.AetherialManipulation, new Skill(SkillName.AetherialManipulation,
-			() => {
-				return true;
-			},
-			(game, node) => {
-				game.useInstantSkill({
-					skillName: SkillName.AetherialManipulation,
-					dealDamage: false,
-					onCapture: ()=>{node.resolveAll(game.getDisplayTime())},
-					node: node
-				});
-			}
-		));
-
-		// Triplecast
-		skillsList.set(SkillName.Triplecast, new Skill(SkillName.Triplecast,
-			() => {
-				return true;
-			},
-			(game, node) => {
-				game.useInstantSkill({
-					skillName: SkillName.Triplecast,
-					onCapture: () => {
-						let triple = game.resources.get(ResourceType.Triplecast);
-						if (triple.pendingChange) triple.removeTimer(); // should never need this, but just in case
-						triple.gain(3);
-						// 15.7s: see screen recording: https://drive.google.com/file/d/1qoIpAMK2KAKETgID6a3p5dqkeWRcNDdB/view?usp=drive_link
-						game.resources.addResourceEvent({
-							rscType: ResourceType.Triplecast,
-							name: "drop remaining Triple charges", delay: 15.7, fnOnRsc:(rsc: Resource) => {
-								rsc.consume(rsc.availableAmount());
-							}
-						});
-						node.resolveAll(game.getDisplayTime());
-					},
-					dealDamage: false,
-					node: node
-				});
-			}
-		));
-
-		// Foul
-		skillsList.set(SkillName.Foul, new Skill(SkillName.Foul,
-			() => {
-				return game.resources.get(ResourceType.Polyglot).available(1);
-			},
-			(game, node) => {
-				if (Traits.hasUnlocked(TraitName.EnhancedFoul, game.config.level)) {
-					game.resources.get(ResourceType.Polyglot).consume(1);
-					game.useInstantSkill({
-						skillName: SkillName.Foul,
-						dealDamage: true,
-						node: node
-					});
-				}
-				else {
-					game.castSpell({skillName: SkillName.Foul, onCapture: (cap: SkillCaptureCallbackInfo) => {
-						game.resources.get(ResourceType.Polyglot).consume(1);
-					}, onApplication: (app: SkillApplicationCallbackInfo) => {
-					}, node: node});
-				}
-			}
-		));
-
-		// Despair
-		skillsList.set(SkillName.Despair, new Skill(SkillName.Despair,
-			() => {
-				return game.getFireStacks() > 0 && // in AF
-					game.getMP() >= 800;
-			},
-			(game, node) => {
-				game.castSpell({skillName: SkillName.Despair, onCapture: (cap: SkillCaptureCallbackInfo) => {
-					let mana = game.resources.get(ResourceType.Mana);
-					// mana
-					mana.consume(mana.availableAmount());
-					// +3 AF; refresh enochian
-					game.resources.get(ResourceType.AstralFire).gain(3);
-					game.startOrRefreshEnochian();
-				}, onApplication: (app: SkillApplicationCallbackInfo) => {
-				}, node: node});
-			}
-		));
-
-		// Umbral Soul
-		skillsList.set(SkillName.UmbralSoul, new Skill(SkillName.UmbralSoul,
-			() => {
-				return game.getIceStacks() > 0;
-			},
-			(game, node) => {
-				game.castSpell({
-					skillName: SkillName.UmbralSoul,
-					onCapture: () => {
-						game.resources.get(ResourceType.UmbralIce).gain(1);
-						game.resources.get(ResourceType.UmbralHeart).gain(1);
-						game.startOrRefreshEnochian();
-						// halt
-						let enochian = game.resources.get(ResourceType.Enochian);
-						enochian.removeTimer();
-					},
-					onApplication: (app: SkillApplicationCallbackInfo) => {},
-					node: node
-				});
-			}
-		));
-
-		// Xenoglossy
-		skillsList.set(SkillName.Xenoglossy, new Skill(SkillName.Xenoglossy,
-			() => {
-				return game.resources.get(ResourceType.Polyglot).available(1);
-			},
-			(game, node) => {
-				game.resources.get(ResourceType.Polyglot).consume(1);
-				game.useInstantSkill({
-					skillName: SkillName.Xenoglossy,
-					dealDamage: true,
-					node: node
-				});
-			}
-		));
-
-		let addFire2 = function(skillName: SkillName) {
-			skillsList.set(skillName, new Skill(skillName,
-				() => { return true; },
-				(game, node) => {
-					game.castSpell({skillName: skillName, onCapture: (cap: SkillCaptureCallbackInfo) => {
-						game.switchToAForUI(ResourceType.AstralFire, 3);
-						game.startOrRefreshEnochian();
-					}, onApplication: (app: SkillApplicationCallbackInfo) => {
-					}, node: node});
-				}
-			))};
-		[SkillName.Fire2, SkillName.HighFire2].forEach(addFire2);
-
-		let addBlizzard2 = function(skillName: SkillName) {
-			skillsList.set(skillName, new Skill(skillName,
-				() => { return true; },
-				(game, node) => {
-					game.castSpell({skillName: skillName, onCapture: (cap: SkillCaptureCallbackInfo) => {
-						game.switchToAForUI(ResourceType.UmbralIce, 3);
-						game.startOrRefreshEnochian();
-					}, onApplication: (app: SkillApplicationCallbackInfo) => {
-					}, node: node});
-				}
-			))};
-		[SkillName.Blizzard2, SkillName.HighBlizzard2].forEach(addBlizzard2);
-
-		// Amplifier
-		skillsList.set(SkillName.Amplifier, new Skill(SkillName.Amplifier,
-			() => {
-				return game.getIceStacks() > 0 || game.getFireStacks() > 0;
-			},
-			(game, node) => {
-				game.useInstantSkill({
-					skillName: SkillName.Amplifier,
-					onCapture: () => {
-						let polyglot = game.resources.get(ResourceType.Polyglot);
-						if (polyglot.available(polyglot.maxValue)) {
-							controller.reportWarning(WarningType.PolyglotOvercap)
-						}
-						polyglot.gain(1);
-					},
-					dealDamage: false,
-					node: node
-				});
-				node.resolveAll(game.getDisplayTime());
-			}
-		));
-
-		// Paradox
-		skillsList.set(SkillName.Paradox, new Skill(SkillName.Paradox,
-			() => {
-				return game.resources.get(ResourceType.Paradox).available(1);
-			},
-			(game, node) => {
-				game.castSpell({skillName: SkillName.Paradox, onCapture: (cap: SkillCaptureCallbackInfo) => {
-					game.resources.get(ResourceType.Paradox).consume(1);
-					// enochian (refresh only) (which also clears the halt status)
-					if (game.hasEnochian()) {
-						game.startOrRefreshEnochian();
-					}
-					if (game.getIceStacks() > 0) {
-						game.resources.get(ResourceType.UmbralIce).gain(1);
-					} else if (game.getFireStacks() > 0) {// firestarter proc
-						game.resources.get(ResourceType.AstralFire).gain(1);
-						gainFirestarterProc(game);
-					} else {
-						console.assert(false);
-					}
-				}, onApplication: (app: SkillApplicationCallbackInfo) => {
-				}, node: node});
-			}
-		));
-
-		// Flare Star
-		skillsList.set(SkillName.FlareStar, new Skill(SkillName.FlareStar,
-			() => {
-				return game.resources.get(ResourceType.AstralSoul).available(6);
-			},
-			(game, node) => {
-				game.castSpell({skillName: SkillName.FlareStar, onCapture: (cap: SkillCaptureCallbackInfo) => {
-					game.resources.get(ResourceType.AstralSoul).consume(6);
-				}, onApplication: (app: SkillApplicationCallbackInfo) => {
-				}, node: node});
-			}
-		));
-
-		// Retrace
-		skillsList.set(SkillName.Retrace, new Skill(SkillName.Retrace,
-			() => {
-				return Traits.hasUnlocked(TraitName.EnhancedLeyLines, game.config.level) &&
-					game.resources.get(ResourceType.LeyLines).availableAmountIncludingDisabled() > 0;
-			},
-			(game, node) => {
-				game.useInstantSkill({
-					skillName: SkillName.Retrace,
-					onCapture: () => {
-						game.resources.get(ResourceType.LeyLines).enabled = true;
-					},
-					dealDamage: false,
-					node: node
-				});
-				node.resolveAll(game.getDisplayTime());
-			}
-		));
-
-		// Addle
-		const addleDuration = (Traits.hasUnlocked(TraitName.EnhancedAddle, game.config.level) && 15) || 10;
-		addResourceAbility({skillName: SkillName.Addle, rscType: ResourceType.Addle, instant: false, duration: addleDuration});
-
-		// Swiftcast
-		addResourceAbility({skillName: SkillName.Swiftcast, rscType: ResourceType.Swiftcast, instant: true, duration: 10});
-
-		// Lucid Dreaming
-		skillsList.set(SkillName.LucidDreaming, new Skill(SkillName.LucidDreaming,
-			() => { return true; },
-			(game, node) => {
-				game.useInstantSkill({
-					skillName: SkillName.LucidDreaming,
-					onApplication: () => {
-						let lucid = game.resources.get(ResourceType.LucidDreaming) as DoTBuff;
-						if (lucid.available(1)) {
-							lucid.overrideTimer(game, 21);
-						} else {
-							lucid.gain(1);
-							game.resources.addResourceEvent({
-								rscType: ResourceType.LucidDreaming,
-								name: "drop lucid dreaming", delay: 21, fnOnRsc: (rsc: Resource) => {
-									rsc.consume(1);
-								}
-							});
-						}
-						lucid.node = node;
-						lucid.tickCount = 0;
-						let nextLucidTickEvt = game.findNextQueuedEventByTag(EventTag.LucidTick);
-						if (nextLucidTickEvt) {
-							nextLucidTickEvt.addTag(EventTag.ManaGain);
-						}
-					},
-					dealDamage: false,
-					node: node
-				});
-				node.resolveAll(game.getDisplayTime());
-			}))
-
-		// Surecast
-		addResourceAbility({skillName: SkillName.Surecast, rscType: ResourceType.Surecast, instant: true, duration: 6});
-
-		// Tincture
-		addResourceAbility({skillName: SkillName.Tincture, rscType: ResourceType.Tincture, instant: false, duration: 30});
-
-		// Sprint
-		addResourceAbility({skillName: SkillName.Sprint, rscType: ResourceType.Sprint, instant: false, duration: 10});
-
-		return skillsList;
+	constructor(_state: GameState /* TODO remove */) {
+		this.job = ShellInfo.job;
 	}
-	get(key: SkillName): Skill {
-		let skill = super.get(key);
+
+	get(key: SkillName): Skill<T> {
+		let skill = skillMap.get(this.job)!.get(key) as Skill<T>;
 		if (skill) return skill;
 		else {
-			console.assert(false);
-			return new Skill(
-				SkillName.Never,
-				()=>{return false},
-				(game: GameState, node: ActionNode)=>{});
+			console.error(`could not find skill with name: ${key}`);
+			return NEVER_SKILL;
 		}
 	}
-	getAutoReplaced(key: SkillName, level: number): Skill {
+
+	getAutoReplaced(key: SkillName, level: number): Skill<T> {
 		let skill = this.get(key);
 		// upgrade: if level >= upgrade options
-		while (skill.info.autoUpgrade && Traits.hasUnlocked(skill.info.autoUpgrade.trait, level)) {
-			skill = this.getAutoReplaced(skill.info.autoUpgrade.otherSkill, level);
+		while (skill.autoUpgrade && Traits.hasUnlocked(skill.autoUpgrade.trait, level)) {
+			skill = this.getAutoReplaced(skill.autoUpgrade.otherSkill, level);
 		}
 		// downgrade: if level < current skill required level
-		while (skill.info.autoDowngrade && level < skill.info.unlockLevel) {
-			skill = this.getAutoReplaced(skill.info.autoDowngrade.otherSkill, level);
+		while (skill.autoDowngrade && level < skill.unlockLevel) {
+			skill = this.getAutoReplaced(skill.autoDowngrade.otherSkill, level);
 		}
 		return skill;
 	}
@@ -976,13 +377,13 @@ export class SkillsList extends Map<SkillName, Skill> {
 export class DisplayedSkills extends Array<SkillName> {
 	constructor(level: LevelSync) {
 		super();
-		console.assert(skillInfosMap.has(ShellInfo.job), `No skill map found for job: ${ShellInfo.job}`)
+		console.assert(skillMap.has(ShellInfo.job), `No skill map found for job: ${ShellInfo.job}`)
 		// TODO move contextual hotbar info (paradox, retrace) to here
 		const hotbarExcludeSkills = [
 			SkillName.Paradox,
 			SkillName.Retrace
 		];
-		for (const skillInfo of skillInfosMap.get(ShellInfo.job)!.values()) {
+		for (const skillInfo of skillMap.get(ShellInfo.job)!.values()) {
 			// Leave off abilities that are above the current level sync.
 			// Also leave off any abilities that auto-downgrade, like HF2/HB2/HT,
 			// since their downgrade versions will already be on the hotbar.

--- a/src/Game/Skills.ts
+++ b/src/Game/Skills.ts
@@ -1,5 +1,5 @@
 import {Aspect, LevelSync, ResourceType, SkillName} from './Common'
-import {ShellJob, ShellInfo} from "../Controller/Common";
+import {ShellJob, ShellInfo, ALL_JOBS} from "../Controller/Common";
 import {ActionNode} from "../Controller/Record";
 import {PlayerState, GameState} from "./GameState";
 import {TraitName, Traits} from './Traits';
@@ -132,11 +132,7 @@ export type Skill<T extends PlayerState> = Spell<T> | Weaponskill<T> | Ability<T
 // the ShellJob and Skill<T>, so we'll just have to live with performing casts at certain locations.
 export const skillMap: Map<ShellJob, Map<SkillName, Skill<PlayerState>>> = new Map();
 
-// can't iterate over the onst enum ShellJob so just populate manually :/
-[
-	ShellJob.BLM,
-	ShellJob.PCT,
-].forEach((job) => skillMap.set(job, new Map()));
+ALL_JOBS.forEach((job) => skillMap.set(job, new Map()));
 
 
 // Helper function to transform an optional<number | function> that has a default number value into a function.
@@ -258,9 +254,6 @@ export function makeAbility<T extends PlayerState>(jobs: ShellJob | ShellJob[], 
 	return info;
 }
 
-// Dummy skill to avoid a hard crash when a skill info isn't found
-const NEVER_SKILL = makeSpell([], SkillName.Never, 1, {});
-
 /**
  * Helper function to create an Ability that applies a buff or debuff (`rscType`) for a certain duration.
  *
@@ -315,6 +308,10 @@ export function makeResourceAbility<T extends PlayerState>(
 	});
 };
 
+// Dummy skill to avoid a hard crash when a skill info isn't found
+const NEVER_SKILL = makeAbility(ALL_JOBS, SkillName.Never, 1, ResourceType.Never, {
+	validateAttempt: (state) => false,
+});
 
 export class SkillsList<T extends PlayerState> {
 	job: ShellJob;

--- a/src/Game/XIVMath.ts
+++ b/src/Game/XIVMath.ts
@@ -70,22 +70,32 @@ export class XIVMath {
 		return basePotency * dotStrength;
 	}
 
-	static preTaxGcd(level: LevelSync, spellSpeed: number, hasLL: boolean) {
-		const subStat = this.getSubstatBase(level);
-		const div = this.getStatDiv(level);
-
-		let baseGCD = 2.5;
-		let subtractLL = hasLL ? 15 : 0;
-
-		return Math.floor(Math.floor(Math.floor((100-subtractLL)*100/100)*Math.floor((2000-Math.floor(130*(spellSpeed-subStat)/div+1000))*(1000*baseGCD)/10000)/100)*100/100)/100;
+	// Return the speed modifier granted by a specific buff.
+	// For example, for the 15% reduction granted by Circle of Power (which we just call Ley Lines),
+	// return the integer 15.
+	static getSpeedModifier(buff: ResourceType) {
+		if (buff === ResourceType.LeyLines) {
+			return 15;
+		}
+		console.error("No speed modifier for buff: ", buff);
 	}
 
-	static preTaxCastTime(level: LevelSync, spellSpeed: number, baseCastTime: number, hasLL: boolean) {
+	static preTaxGcd(level: LevelSync, spellSpeed: number, baseGCD: number, speedBuff?: ResourceType) {
 		const subStat = this.getSubstatBase(level);
 		const div = this.getStatDiv(level);
 
-		let subtractLL = hasLL ? 15 : 0;
-		return Math.floor(Math.floor(Math.floor((100-subtractLL)*100/100)*Math.floor((2000-Math.floor(130*(spellSpeed-subStat)/div+1000))*(1000*baseCastTime)/1000)/100)*100/100)/1000;
+		// let us pray we never need to stack haste buffs
+		let subtractSpeed = speedBuff === undefined ? 0 : XIVMath.getSpeedModifier(speedBuff);
+
+		return Math.floor(Math.floor(Math.floor((100-subtractSpeed)*100/100)*Math.floor((2000-Math.floor(130*(spellSpeed-subStat)/div+1000))*(1000*baseGCD)/10000)/100)*100/100)/100;
+	}
+
+	static preTaxCastTime(level: LevelSync, spellSpeed: number, baseCastTime: number, speedBuff?: ResourceType) {
+		const subStat = this.getSubstatBase(level);
+		const div = this.getStatDiv(level);
+
+		let subtractSpeed = speedBuff === undefined ? 0 : XIVMath.getSpeedModifier(speedBuff);
+		return Math.floor(Math.floor(Math.floor((100-subtractSpeed)*100/100)*Math.floor((2000-Math.floor(130*(spellSpeed-subStat)/div+1000))*(1000*baseCastTime)/1000)/100)*100/100)/1000;
 	}
 
 	static afterFpsTax(fps: number, baseDuration: number) {

--- a/src/Game/XIVMath.ts
+++ b/src/Game/XIVMath.ts
@@ -1,4 +1,4 @@
-import { LevelSync } from "./Common";
+import { LevelSync, ResourceType } from "./Common";
 
 export class XIVMath {
 	static getMainstatBase(level: LevelSync) {
@@ -78,6 +78,7 @@ export class XIVMath {
 			return 15;
 		}
 		console.error("No speed modifier for buff: ", buff);
+		return 0;
 	}
 
 	static preTaxGcd(level: LevelSync, spellSpeed: number, baseGCD: number, speedBuff?: ResourceType) {


### PR DESCRIPTION
This PR creates `BLMState`, a child class of `GameState`. BLM-specific skills and state have been adjusted to match this new format.

All skills now have their effects on the game state encoded in the `onConfirm` and `onApplication` functions. These should be specified either at the skill's declaration site, or for logic shared across many spells, added to a common helper function (`makeGCD_BLM`). While a particular skill's side effects can still be expressed in two different places (the declaration site and the body of `makeGCD_BLM`), it should now be considerably easier to find the logic than before.

Many frontend elements and the controller still make calls to BLM-specific components, like `state.getIceStacks()`, in order to properly render job gauges. For the time being, I've left those in with explicit casts from `GameState` -> `BLMState`, which I hope to refactor out in the near future.

Remaining tasks before we're truly job agnostic:
- Consolidate resource/CD length declaration (PCT still has overrides disabled)
- Remove casts from controller/frontend references, and figure out how to split job-specific logic in the frontend
- Refactor `getSkillAvailabilityStatus` and state-dependent button replacements (paradox, retrace)