### PR TITLE
Avoid rendering during timeline replay

### DIFF
--- a/src/Components/LoadSave.tsx
+++ b/src/Components/LoadSave.tsx
@@ -19,8 +19,9 @@ export class LoadSave extends React.Component {
 				let fileToLoad = cur.files[0];
 				loadFromFile(fileToLoad, (content: Fixme)=>{
 					if (content.fileType === FileType.Record) {
+						// loadBattleRecordFromFile calls render methods, so no need to explicily
+						// invoke updateAllDisplay here
 						controller.loadBattleRecordFromFile(content);
-						controller.updateAllDisplay();
 						controller.autoSave();
 					} else {
 						window.alert("wrong file type '" + content.fileType + "'.");

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,11 @@
 [
 	{
+		"date": "9/21/24",
+		"changes": [
+			"Greatly reduced time needed to load a line"
+		]
+	},
+	{
 		"date": "9/10/24",
 		"changes": [
 			"Lines preset: when using a line created at a different level, adapt to current level by auto-converting equivalent skills if possible; throw an error otherwise"


### PR DESCRIPTION
This PR stops display rendering logic from running during `loadBattleRecordFromFile`, significantly improving page load + timeline import time. `loadSlot` is still unnecessarily called twice in `tryAutoLoad`, but the added latency is no longer super meaningful.

Before/after (n=1, not scientific)
- Page load (with Akairyu's [7.0 TOP timeline](https://discord.com/channels/277897135515762698/1255782490862387360/1284925798364745771) as the active slot): 2150 ms -> 873 ms
- Import timeline from file (again using Akairyu's TOP timeline): 2478 ms -> 108 ms