### PR TITLE
Add hotbar icon for multi-stack abilities

### DIFF
--- a/src/Components/Skills.tsx
+++ b/src/Components/Skills.tsx
@@ -152,13 +152,50 @@ class SkillButton extends React.Component {
 		} else if (this.props.cdProgress <= 1 - Debug.epsilon) {
 			readyOverlay = "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.25) 85%, rgba(0,0,0,0.6) 100%)"
 		}
+		// The numbers used to indicate remaining stacks are an in-game font, and not an icon
+		// available in xivapi. We instead just pick a large sans serif font, and render the number
+		// in white w/ red border if there's at least 1 stack, and red w/ black border at 0 stacks.
+		const info = controller.getSkillInfo({
+			game: controller.getDisplayedGame(),
+			skillName: this.props.skillName
+		});
+		const readyStacks = info.stacksAvailable;
+		const maxStacks = info.maxStacks;
+		let stacksOverlay;
+		const skillBoxPx = 48;
+		if (maxStacks > 1) {
+			console.log(this.props.skillName, readyStacks, maxStacks)
+			stacksOverlay =	<div tabIndex={-1} style={{
+				// for readability, deliberately make the 0-stack black border thinner
+				WebkitTextStroke: readyStacks === 0 ? "0.8px black" : "1.2px red",
+				fontFamily: "sans-serif",
+				fontWeight: "bolder",
+				color: readyStacks === 0 ? "red" : "white",
+				// should take up a little over 1/3 of the icon
+				fontSize: `${skillBoxPx/3 + 4}px`,
+				// stretch the font slightly to be closer to in-game
+				transform: "scale(1.5, 1)",
+				// make the shadow thicker when readyStacks == maxStacks, since it's harder
+				// to see the text when the icon is not grayed out
+				textShadow: readyStacks === maxStacks ? "0px 0px 4px black" : "0px 0px 2px black",
+				// offset to account for stretch transformation + font size
+				bottom: 3,
+				right: 6,
+				zIndex: 2,
+				position: "absolute",
+			}}>
+				{readyStacks}
+			</div>;
+		} else {
+			stacksOverlay = <></>;
+		}
 		let icon = <div onMouseEnter={this.handleMouseEnter}>
 			<div className={"skillIcon"} style={iconStyle}>
 				<img style={iconImgStyle} src={iconPath} alt={this.props.skillName}/>
 				<div style={{ // skill icon border
 					position: "absolute",
-					width: 48,
-					height: 48,
+					width: skillBoxPx,
+					height: skillBoxPx,
 					background: "url('https://miyehn.me/ffxiv-blm-rotation/misc/skillIcon_overlay.png') no-repeat"
 				}}></div>
 				<div style={{ // grey out
@@ -182,6 +219,7 @@ class SkillButton extends React.Component {
 				left: 2,
 				zIndex: 1
 			}}/>
+			{stacksOverlay}
 		</div>;
 		let progressCircle = <ProgressCircle
 			className="cdProgress"
@@ -214,6 +252,7 @@ export type SkillButtonViewInfo = {
 	skillName: SkillName,
 	status: SkillReadyStatus,
 	stacksAvailable: number,
+	maxStacks: number,
 	castTime: number,
 	instantCast: boolean,
 	cdRecastTime: number,

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -517,6 +517,7 @@ export abstract class GameState {
 			skillName: skill.name,
 			status: status,
 			stacksAvailable: cd.stacksAvailable(),
+			maxStacks: cd.maxStacks(),
 			castTime: capturedCastTime,
 			instantCast: instantCastAvailable,
 			cdRecastTime: cdRecastTime,

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -111,6 +111,7 @@ export class CoolDown extends Resource {
 	}
 	currentStackCd() { return this.#cdPerStack * this.#recastTimeScale; }
 	stacksAvailable() { return Math.floor((this.availableAmount() + Debug.epsilon) / this.#cdPerStack); }
+	maxStacks() { return this.maxValue / this.#cdPerStack; }
 	useStack(game: GameState) {
 		this.consume(this.#cdPerStack);
 		this.#reCaptureRecastTimeScale(game);


### PR DESCRIPTION
Apparently, the number of stacks is rendered in-game as a font, and there's no sprite (I found a few similar-looking numbers in xivapi but there was no icon for 0). Instead, I picked the browser-default sans serif font and changed the colors accordingly:
- When the number of stacks is not zero, the number is displayed in white text w/ red border.
- When the number of stacks is zero, the number is displayed in red text w/ black border.

I made the drop shadow more intense if the ability is at maximum stacks to contrast better with the non-grayed out ability.

Here's what it looks like for picto (already deployed, unfortunately Pom Muse just has bad contrast with the skininess of the Windows default font)
![image](https://github.com/user-attachments/assets/4452e0e4-6318-4b74-bd21-423226da3bb1)
