### PR TITLE
(1/?) Reorganize page layout

### DIFF
--- a/src/Components/Common.tsx
+++ b/src/Components/Common.tsx
@@ -38,7 +38,7 @@ export const TimelineDimensions = {
 	},
 
 	leftBufferWidth: 20, // leave this much space on the left before starting to draw timeline (for timeline selection bar)
-	addSlotButtonHeight: 20,
+	addSlotButtonHeight: 20
 
 }
 
@@ -373,6 +373,7 @@ type SliderProps = {
 	onChange?: (e: string) => void,
 	defaultValue?: string,
 	description?: ContentNode
+	style?: CSSProperties
 }
 type SliderState = {
 	value: string,
@@ -399,7 +400,7 @@ export class Slider extends React.Component {
 		if (typeof this.props.onChange !== "undefined") this.props.onChange(this.state.value);
 	}
 	render() {
-		return <div style={{display: "inline-block"}}>
+		return <div style={{...{display: "inline-block"}, ...this.props.style}}>
 			<span>{this.props.description ?? ""}</span>
 			<input
 				size={10} type="range"

--- a/src/Components/Common.tsx
+++ b/src/Components/Common.tsx
@@ -250,7 +250,7 @@ export function Tabs(props: {
 	style?: CSSProperties
 }) {
 
-	const titleHeight = TABS_TITLE_HEIGHT - 2;
+	const titleHeight = TABS_TITLE_HEIGHT - 2; // the top and bottom border each takes up 1px
 	const [selectedIndex, setSelectedIndex] = React.useState<number | undefined>(undefined);
 
 	// initialization

--- a/src/Components/Main.tsx
+++ b/src/Components/Main.tsx
@@ -5,8 +5,6 @@ import { Config, TimeControl } from "./PlaybackControl";
 import { StatusDisplay } from "./StatusDisplay";
 import {controller} from "../Controller/Controller";
 import 'react-tabs/style/react-tabs.css';
-import {LoadSave} from "./LoadSave";
-import {ImageExport} from "./ImageExport";
 import {SkillSequencePresets} from "./SkillSequencePresets";
 import {IntroSection} from "./IntroSection";
 import changelog from "../changelog.json"
@@ -303,8 +301,10 @@ export default class Main extends React.Component {
 							}}>
 								<Config/>
 								<TimeControl/>
-								<LoadSave/>
-								<ImageExport/>
+								<div>{localize({
+									en: "You can also import/export fights from/to local files at the bottom of the page.",
+									zh: "页面底部有导入和导出战斗文件相关选项。"
+								})}</div>
 							</div>
 						</div>
 						<SkillSequencePresets/>

--- a/src/Components/Timeline.tsx
+++ b/src/Components/Timeline.tsx
@@ -1,4 +1,6 @@
-import React from 'react'
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import React, {CSSProperties} from 'react'
 import {controller} from "../Controller/Controller";
 import {Help, Input, Slider} from "./Common";
 import {TimelineMarkerPresets} from "./TimelineMarkerPresets";
@@ -13,12 +15,18 @@ import {localize} from "./Localization";
 import {getCurrentThemeColors} from "./ColorTheme";
 import {getCachedValue, setCachedValue} from "../Controller/Common";
 
-export let updateTimelineView = () => {};
+import { LiaWindowMinimize } from "react-icons/lia";
+import { FaWindowMinimize } from "react-icons/fa6";
 
-export let scrollTimelineTo = (positionX: number)=>{}
+export let updateTimelineView = () => {
+};
+
+export let scrollTimelineTo = (positionX: number) => {
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-let getVisibleRangeX = () => {}
+let getVisibleRangeX = () => {
+}
 
 // the actual timeline canvas
 class TimelineMain extends React.Component {
@@ -31,6 +39,7 @@ class TimelineMain extends React.Component {
 		visibleWidth: number,
 		version: number
 	};
+
 	constructor(props: {}) {
 		super(props);
 		this.state = {
@@ -42,7 +51,7 @@ class TimelineMain extends React.Component {
 		}
 		this.myRef = React.createRef();
 
-		this.updateVisibleRange = (()=>{
+		this.updateVisibleRange = (() => {
 			if (this.myRef.current) {
 				this.setState({
 					visibleLeft: this.myRef.current.scrollLeft,
@@ -51,6 +60,7 @@ class TimelineMain extends React.Component {
 			}
 		});
 	}
+
 	componentDidMount() {
 		this.setState({
 			timelineWidth: controller.timeline.getCanvasWidth(),
@@ -64,7 +74,7 @@ class TimelineMain extends React.Component {
 			});
 		});
 
-		scrollTimelineTo = ((positionX: number)=>{
+		scrollTimelineTo = ((positionX: number) => {
 			if (this.myRef.current != null) {
 				let clientWidth = this.myRef.current.clientWidth;
 				this.myRef.current.scrollLeft = positionX - clientWidth * 0.6;
@@ -72,10 +82,12 @@ class TimelineMain extends React.Component {
 			this.updateVisibleRange();
 		});
 
-		getVisibleRangeX = (()=>{return {
-			left: this.state.visibleLeft,
-			width: this.state.visibleWidth
-		}});
+		getVisibleRangeX = (() => {
+			return {
+				left: this.state.visibleLeft,
+				width: this.state.visibleWidth
+			}
+		});
 
 		this.updateVisibleRange();
 	}
@@ -83,8 +95,10 @@ class TimelineMain extends React.Component {
 	componentWillUnmount() {
 		updateTimelineView = () => {
 		};
-		scrollTimelineTo = (positionX)=>{};
-		getVisibleRangeX = ()=>{};
+		scrollTimelineTo = (positionX) => {
+		};
+		getVisibleRangeX = () => {
+		};
 	}
 
 	render() {
@@ -103,7 +117,7 @@ class TimelineMain extends React.Component {
 				overflowX: "scroll",
 				overflowY: "clip",
 				outline: "1px solid " + getCurrentThemeColors().bgMediumContrast,
-				marginBottom: 10,
+				//marginBottom: 10,
 				cursor: timelineCanvasGetPointerMouse() ? "pointer" : "default",
 			}} ref={this.myRef} onScroll={e => {
 				if (this.myRef.current) {
@@ -113,20 +127,20 @@ class TimelineMain extends React.Component {
 						visibleWidth: this.myRef.current.clientWidth
 					});
 				}
-			}} onMouseMove={e=>{
+			}} onMouseMove={e => {
 				if (this.myRef.current) {
 					let rect = this.myRef.current.getBoundingClientRect();
 					let x = e.clientX - rect.left;
 					let y = e.clientY - rect.top;
 					timelineCanvasOnMouseMove(x, y);
 				}
-			}} onMouseEnter={e=>{
+			}} onMouseEnter={e => {
 				timelineCanvasOnMouseEnter();
-			}} onMouseLeave={e=>{
+			}} onMouseLeave={e => {
 				timelineCanvasOnMouseLeave();
-			}} onClick={e=>{
+			}} onClick={e => {
 				timelineCanvasOnClick(e);
-			}} onKeyDown={e=>{
+			}} onKeyDown={e => {
 				timelineCanvasOnKeyDown(e);
 			}}>
 				<div style={{
@@ -149,6 +163,7 @@ class TimelineDisplaySettings extends React.Component {
 	};
 	setTinctureBuffPercentageStr: (val: string) => void;
 	setUntargetableMask: (val: boolean) => void;
+
 	constructor(props: {}) {
 		super(props);
 		// display scale
@@ -177,7 +192,7 @@ class TimelineDisplaySettings extends React.Component {
 		}
 
 		// functions
-		this.setTinctureBuffPercentageStr = ((val: string)=>{
+		this.setTinctureBuffPercentageStr = ((val: string) => {
 			this.setState({tinctureBuffPercentageStr: val});
 
 			let percentage = parseFloat(val);
@@ -186,45 +201,116 @@ class TimelineDisplaySettings extends React.Component {
 				setCachedValue("tinctureBuffPercentage", val);
 			}
 		});
-		this.setUntargetableMask = ((val: boolean)=>{
+		this.setUntargetableMask = ((val: boolean) => {
 			this.setState({untargetableMask: val});
 
 			controller.setUntargetableMask(val);
 			setCachedValue("untargetableMask", val ? "1" : "0");
 		});
 	}
+
 	componentDidMount() {
 		this.setTinctureBuffPercentageStr(this.state.tinctureBuffPercentageStr);
 		this.setUntargetableMask(this.state.untargetableMask);
 	}
 
 	render() {
-		return <div>
+		const colors = getCurrentThemeColors();
+
+		const previewTabOpen = true;
+
+		const tabClosed: CSSProperties = {
+			margin: "0 0px",
+			padding: "2px 12px",
+			//textDecoration: "underline",
+			borderLeft: "1px solid " + colors.bgMediumContrast,
+			borderBottom: previewTabOpen ? "1px solid " + colors.bgMediumContrast : 0,
+			cursor: "pointer"
+		};
+		const tabOpenBorderColor = colors.bgHighContrast;
+		const tabOpen: CSSProperties = {
+			margin: "0 0px",
+			padding: "2px 12px",
+			borderTop: "1px solid " + tabOpenBorderColor,
+			borderLeft: "1px solid " + tabOpenBorderColor,
+			borderRight: "1px solid " + tabOpenBorderColor,
+		}
+		return <div style={{position: "relative", margin: 6}}>
+			{/*
 			<span>{localize({en: "Display settings: ", zh: "显示设置："})}</span>
+			*/}
 			<Slider description={localize({en: "horizontal scale ", zh: "水平缩放 "})}
 					defaultValue={this.initialDisplayScale.toString()}
-					onChange={(newVal)=>{
+					style={{
+						position: "absolute",
+						top: 0,
+						right: 0
+					}}
+					onChange={(newVal) => {
 						controller.timeline.setHorizontalScale(parseFloat(newVal));
 						controller.scrollToTime();
 						setCachedValue("timelineDisplayScale", newVal);
 					}}/>
+			<span
+				style={{...(previewTabOpen ? tabOpen : tabClosed), ...(previewTabOpen ? undefined : {borderLeft: 0})}}>Timeline Options</span>
+
+			<span style={tabClosed}>Timeline Markers</span>
+
+			<span style={tabClosed}>Timeline Editor</span>
+
+			<span style={tabClosed}>PNG Export</span>
+
+			<span><LiaWindowMinimize style={{
+				marginLeft: 10,
+				cursor: "pointer",
+				position: "relative",
+				top: 2,
+				display: previewTabOpen ? "inline" : "none"
+			}}/></span>
+
+			<div style={{
+				display: previewTabOpen ? "block" : "none",
+				padding: "10px 10px 0 10px",
+				//outline: "1px solid red",
+				height: 300
+			}}>
+				timeline display settings<br/>
+				timeline display settings<br/>
+				timeline display settings<br/>
+				timeline display settings<br/>
+				timeline display settings<br/>
+			</div>
+			{/*
 			<span> | </span>
-			<Input defaultValue={this.state.tinctureBuffPercentageStr} description={localize({en: " tincture potency buff ", zh: "爆发药威力加成 "})} onChange={this.setTinctureBuffPercentageStr} width={2} style={{display: "inline"}}/>
+			<Input defaultValue={this.state.tinctureBuffPercentageStr}
+				   description={localize({en: " tincture potency buff ", zh: "爆发药威力加成 "})}
+				   onChange={this.setTinctureBuffPercentageStr} width={2} style={{display: "inline"}}/>
 			<span>% | </span>
 			<span>
 				<input type="checkbox" style={{position: "relative", top: 3, marginRight: 5}}
-				       checked={this.state.untargetableMask}
-				       onChange={evt => {this.setUntargetableMask(evt.target.checked)}}/>
-				<span>{localize({en: "exclude damage when untargetable", zh: "Boss上天期间威力按0计算"})} <Help topic={"untargetableMask"} content={
+					   checked={this.state.untargetableMask}
+					   onChange={evt => {
+						   this.setUntargetableMask(evt.target.checked)
+					   }}/>
+				<span>{localize({en: "exclude damage when untargetable", zh: "Boss上天期间威力按0计算"})} <Help
+					topic={"untargetableMask"} content={
 					<div>
-						<div className={"paragraph"}>{localize({en: "Having this checked will exclude damages from untargetable phases.", zh: "勾选时，统计将不包括Boss上天期间造成的伤害。"})}</div>
-						<div className={"paragraph"}>{localize({en: "You can mark up such phases using timeline markers of type \"Untargetable\".", zh: "可在下方用 “不可选中” 类型的时间轴标记来指定时间区间。"})}</div>
+						<div className={"paragraph"}>{localize({
+							en: "Having this checked will exclude damages from untargetable phases.",
+							zh: "勾选时，统计将不包括Boss上天期间造成的伤害。"
+						})}</div>
+						<div className={"paragraph"}>{localize({
+							en: "You can mark up such phases using timeline markers of type \"Untargetable\".",
+							zh: "可在下方用 “不可选中” 类型的时间轴标记来指定时间区间。"
+						})}</div>
 						<div className={"paragraph"}>{localize({
 							en: "This is just a statistics helper though. For example it doesn't prevent you from using skills when the boss is untargetable.",
-							zh: "此功能只是一个统计用的工具，在标注了 “不可选中” 的时间里其实也能正常使用技能。"})}</div>
+							zh: "此功能只是一个统计用的工具，在标注了 “不可选中” 的时间里其实也能正常使用技能。"
+						})}</div>
 					</div>
 				}/></span>
 			</span>
+			*/}
 		</div>
 	}
 }
@@ -235,15 +321,17 @@ export class Timeline extends React.Component {
 			bottom: 0,
 			left: 0,
 			right: 0,
-			paddingLeft: 6,
-			paddingRight: 6,
+			paddingLeft: 0, // forgot why I added the left and right paddings...
+			paddingRight: 0,
 			borderTop: "2px solid " + getCurrentThemeColors().bgHighContrast,
 			flex: 0
 		}}>
 			<TimelineMain/>
 			<TimelineDisplaySettings/>
+			{/*
 			<TimelineMarkerPresets/>
 			<TimelineEditor/>
+			*/}
 		</div>
 	}
 }

--- a/src/Components/Timeline.tsx
+++ b/src/Components/Timeline.tsx
@@ -1,8 +1,6 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
-import React, {CSSProperties} from 'react'
+import React from 'react'
 import {controller} from "../Controller/Controller";
-import {Help, Input, Slider} from "./Common";
+import {Help, Input, Slider, Tabs, TABS_TITLE_HEIGHT} from "./Common";
 import {TimelineMarkerPresets} from "./TimelineMarkerPresets";
 import {TimelineEditor} from "./TimelineEditor";
 import {
@@ -15,8 +13,8 @@ import {localize} from "./Localization";
 import {getCurrentThemeColors} from "./ColorTheme";
 import {getCachedValue, setCachedValue} from "../Controller/Common";
 
-import { LiaWindowMinimize } from "react-icons/lia";
-import { FaWindowMinimize } from "react-icons/fa6";
+import {ImageExport} from "./ImageExport";
+import {LoadSave} from "./LoadSave";
 
 export let updateTimelineView = () => {
 };
@@ -155,7 +153,8 @@ class TimelineMain extends React.Component {
 	}
 }
 
-class TimelineDisplaySettings extends React.Component {
+export const TIMELINE_SETTINGS_HEIGHT = 320;
+class TimelineSettings extends React.Component {
 	initialDisplayScale: number;
 	state: {
 		tinctureBuffPercentageStr: string,
@@ -215,102 +214,84 @@ class TimelineDisplaySettings extends React.Component {
 	}
 
 	render() {
-		const colors = getCurrentThemeColors();
-
-		const previewTabOpen = true;
-
-		const tabClosed: CSSProperties = {
-			margin: "0 0px",
-			padding: "2px 12px",
-			//textDecoration: "underline",
-			borderLeft: "1px solid " + colors.bgMediumContrast,
-			borderBottom: previewTabOpen ? "1px solid " + colors.bgMediumContrast : 0,
-			cursor: "pointer"
-		};
-		const tabOpenBorderColor = colors.bgHighContrast;
-		const tabOpen: CSSProperties = {
-			margin: "0 0px",
-			padding: "2px 12px",
-			borderTop: "1px solid " + tabOpenBorderColor,
-			borderLeft: "1px solid " + tabOpenBorderColor,
-			borderRight: "1px solid " + tabOpenBorderColor,
-		}
-		return <div style={{position: "relative", margin: 6}}>
-			{/*
-			<span>{localize({en: "Display settings: ", zh: "显示设置："})}</span>
-			*/}
-			<Slider description={localize({en: "horizontal scale ", zh: "水平缩放 "})}
-					defaultValue={this.initialDisplayScale.toString()}
-					style={{
-						position: "absolute",
-						top: 0,
-						right: 0
-					}}
-					onChange={(newVal) => {
-						controller.timeline.setHorizontalScale(parseFloat(newVal));
-						controller.scrollToTime();
-						setCachedValue("timelineDisplayScale", newVal);
-					}}/>
-			<span
-				style={{...(previewTabOpen ? tabOpen : tabClosed), ...(previewTabOpen ? undefined : {borderLeft: 0})}}>Timeline Options</span>
-
-			<span style={tabClosed}>Timeline Markers</span>
-
-			<span style={tabClosed}>Timeline Editor</span>
-
-			<span style={tabClosed}>PNG Export</span>
-
-			<span><LiaWindowMinimize style={{
-				marginLeft: 10,
-				cursor: "pointer",
-				position: "relative",
-				top: 2,
-				display: previewTabOpen ? "inline" : "none"
-			}}/></span>
-
-			<div style={{
-				display: previewTabOpen ? "block" : "none",
-				padding: "10px 10px 0 10px",
-				//outline: "1px solid red",
-				height: 300
-			}}>
-				timeline display settings<br/>
-				timeline display settings<br/>
-				timeline display settings<br/>
-				timeline display settings<br/>
-				timeline display settings<br/>
-			</div>
-			{/*
-			<span> | </span>
-			<Input defaultValue={this.state.tinctureBuffPercentageStr}
-				   description={localize({en: " tincture potency buff ", zh: "爆发药威力加成 "})}
-				   onChange={this.setTinctureBuffPercentageStr} width={2} style={{display: "inline"}}/>
-			<span>% | </span>
-			<span>
-				<input type="checkbox" style={{position: "relative", top: 3, marginRight: 5}}
-					   checked={this.state.untargetableMask}
-					   onChange={evt => {
-						   this.setUntargetableMask(evt.target.checked)
-					   }}/>
-				<span>{localize({en: "exclude damage when untargetable", zh: "Boss上天期间威力按0计算"})} <Help
-					topic={"untargetableMask"} content={
-					<div>
-						<div className={"paragraph"}>{localize({
-							en: "Having this checked will exclude damages from untargetable phases.",
-							zh: "勾选时，统计将不包括Boss上天期间造成的伤害。"
-						})}</div>
-						<div className={"paragraph"}>{localize({
-							en: "You can mark up such phases using timeline markers of type \"Untargetable\".",
-							zh: "可在下方用 “不可选中” 类型的时间轴标记来指定时间区间。"
-						})}</div>
-						<div className={"paragraph"}>{localize({
-							en: "This is just a statistics helper though. For example it doesn't prevent you from using skills when the boss is untargetable.",
-							zh: "此功能只是一个统计用的工具，在标注了 “不可选中” 的时间里其实也能正常使用技能。"
-						})}</div>
+		return <div style={{
+			position: "relative",
+			margin: 6
+		}}>
+			<Tabs uniqueName={"timeline"} content={[
+				{
+					titleNode: localize({en: "Display settings", zh: "显示设置"}),
+					contentNode: <div>
+						<Input defaultValue={this.state.tinctureBuffPercentageStr}
+						       description={localize({en: " tincture potency buff ", zh: "爆发药威力加成 "})}
+						       onChange={this.setTinctureBuffPercentageStr} width={2} style={{display: "inline"}}/>
+						<span>%</span>
+						<div>
+							<input type="checkbox" style={{position: "relative", top: 3, marginRight: 5}}
+							       checked={this.state.untargetableMask}
+							       onChange={evt => {
+								       this.setUntargetableMask(evt.target.checked)
+							       }}/>
+							<span>{localize({en: "exclude damage when untargetable", zh: "Boss上天期间威力按0计算"})} <Help
+								topic={"untargetableMask"} content={
+								<div>
+									<div className={"paragraph"}>{localize({
+										en: "Having this checked will exclude damages from untargetable phases.",
+										zh: "若勾选，统计将不包括Boss上天期间造成的伤害。"
+									})}</div>
+									<div className={"paragraph"}>{localize({
+										en: "You can mark up such phases using timeline markers of type \"Untargetable\".",
+										zh: "可在下方用 “不可选中” 类型的时间轴标记来指定时间区间。"
+									})}</div>
+									<div className={"paragraph"}>{localize({
+										en: "This is just a statistics helper though. For example it doesn't prevent you from using skills when the boss is untargetable.",
+										zh: "此功能只是一个统计用的工具，在标注了 “不可选中” 的时间里其实也能正常使用技能。"
+									})}</div>
+								</div>
+							}/></span>
+						</div>
 					</div>
-				}/></span>
-			</span>
-			*/}
+				},
+				{
+					titleNode: localize({en: "Timeline markers", zh: "时间轴标记"}),
+					contentNode: <TimelineMarkerPresets/>
+				},
+				{
+					titleNode: <div style={{
+						position: "relative"
+					}}>
+						{localize({en: "Timeline editor ", zh: "时间轴编辑器 "})}
+						<Help topic={"timeline editor"} content={<div>
+							<div className={"paragraph"} style={{color: "orangered"}}><b>Has the bare minimum features but might still be buggy (let me know). Would recommend going over Instructions/Troubleshoot first, plus saving data to drive in case bugs mess up the entire tool</b></div>
+							<div className={"paragraph"}>I hope it's otherwise self-explanatory. Note that edits made here are not saved until they're applied to the actual timeline.</div>
+						</div>}/>
+					</div>,
+					contentNode: <TimelineEditor/>
+				},
+				{
+					titleNode: localize({en: "Import/Export", zh: "导入/导出"}),
+					contentNode: <div>
+						<LoadSave/>
+						<ImageExport/>
+					</div>
+				}
+			]} collapsible={true} height={TIMELINE_SETTINGS_HEIGHT} defaultSelectedIndex={undefined}/>
+			<Slider
+				description={localize({en: "horizontal scale ", zh: "水平缩放 "})}
+				defaultValue={this.initialDisplayScale.toString()}
+				style={{
+					position: "absolute",
+					top: 0,
+					right: 6,
+					height: TABS_TITLE_HEIGHT,
+					lineHeight: `${TABS_TITLE_HEIGHT}px`,
+					verticalAlign: "middle",
+				}}
+				onChange={(newVal) => {
+					controller.timeline.setHorizontalScale(parseFloat(newVal));
+					controller.scrollToTime();
+					setCachedValue("timelineDisplayScale", newVal);
+				}}/>
 		</div>
 	}
 }
@@ -327,11 +308,7 @@ export class Timeline extends React.Component {
 			flex: 0
 		}}>
 			<TimelineMain/>
-			<TimelineDisplaySettings/>
-			{/*
-			<TimelineMarkerPresets/>
-			<TimelineEditor/>
-			*/}
+			<TimelineSettings/>
 		</div>
 	}
 }

--- a/src/Components/Timeline.tsx
+++ b/src/Components/Timeline.tsx
@@ -115,7 +115,6 @@ class TimelineMain extends React.Component {
 				overflowX: "scroll",
 				overflowY: "clip",
 				outline: "1px solid " + getCurrentThemeColors().bgMediumContrast,
-				//marginBottom: 10,
 				cursor: timelineCanvasGetPointerMouse() ? "pointer" : "default",
 			}} ref={this.myRef} onScroll={e => {
 				if (this.myRef.current) {
@@ -214,44 +213,42 @@ class TimelineSettings extends React.Component {
 	}
 
 	render() {
+		let displaySettings = <div>
+			<Input defaultValue={this.state.tinctureBuffPercentageStr}
+			       description={localize({en: " tincture potency buff ", zh: "爆发药威力加成 "})}
+			       onChange={this.setTinctureBuffPercentageStr} width={2} style={{display: "inline"}}/>
+			<span>%</span>
+			<div>
+				<input type="checkbox" style={{position: "relative", top: 3, marginRight: 5}}
+				       checked={this.state.untargetableMask}
+				       onChange={evt => {
+					       this.setUntargetableMask(evt.target.checked)
+				       }}/>
+				<span>{localize({en: "exclude damage when untargetable", zh: "Boss上天期间威力按0计算"})} <Help
+					topic={"untargetableMask"} content={
+					<div>
+						<div className={"paragraph"}>{localize({
+							en: "Having this checked will exclude damages from untargetable phases.",
+							zh: "若勾选，统计将不包括Boss上天期间造成的伤害。"
+						})}</div>
+						<div className={"paragraph"}>{localize({
+							en: "You can mark up such phases using timeline markers of type \"Untargetable\".",
+							zh: "可在下方用 “不可选中” 类型的时间轴标记来指定时间区间。"
+						})}</div>
+						<div className={"paragraph"}>{localize({
+							en: "This is just a statistics helper though. For example it doesn't prevent you from using skills when the boss is untargetable.",
+							zh: "此功能只是一个统计用的工具，在标注了 “不可选中” 的时间里其实也能正常使用技能。"
+						})}</div>
+					</div>
+				}/></span>
+			</div>
+		</div>;
+
 		return <div style={{
 			position: "relative",
 			margin: 6
 		}}>
 			<Tabs uniqueName={"timeline"} content={[
-				{
-					titleNode: localize({en: "Display settings", zh: "显示设置"}),
-					contentNode: <div>
-						<Input defaultValue={this.state.tinctureBuffPercentageStr}
-						       description={localize({en: " tincture potency buff ", zh: "爆发药威力加成 "})}
-						       onChange={this.setTinctureBuffPercentageStr} width={2} style={{display: "inline"}}/>
-						<span>%</span>
-						<div>
-							<input type="checkbox" style={{position: "relative", top: 3, marginRight: 5}}
-							       checked={this.state.untargetableMask}
-							       onChange={evt => {
-								       this.setUntargetableMask(evt.target.checked)
-							       }}/>
-							<span>{localize({en: "exclude damage when untargetable", zh: "Boss上天期间威力按0计算"})} <Help
-								topic={"untargetableMask"} content={
-								<div>
-									<div className={"paragraph"}>{localize({
-										en: "Having this checked will exclude damages from untargetable phases.",
-										zh: "若勾选，统计将不包括Boss上天期间造成的伤害。"
-									})}</div>
-									<div className={"paragraph"}>{localize({
-										en: "You can mark up such phases using timeline markers of type \"Untargetable\".",
-										zh: "可在下方用 “不可选中” 类型的时间轴标记来指定时间区间。"
-									})}</div>
-									<div className={"paragraph"}>{localize({
-										en: "This is just a statistics helper though. For example it doesn't prevent you from using skills when the boss is untargetable.",
-										zh: "此功能只是一个统计用的工具，在标注了 “不可选中” 的时间里其实也能正常使用技能。"
-									})}</div>
-								</div>
-							}/></span>
-						</div>
-					</div>
-				},
 				{
 					titleNode: localize({en: "Timeline markers", zh: "时间轴标记"}),
 					contentNode: <TimelineMarkerPresets/>
@@ -274,7 +271,11 @@ class TimelineSettings extends React.Component {
 						<LoadSave/>
 						<ImageExport/>
 					</div>
-				}
+				},
+				{
+					titleNode: localize({en: "Display settings", zh: "显示设置"}),
+					contentNode: displaySettings
+				},
 			]} collapsible={true} height={TIMELINE_SETTINGS_HEIGHT} defaultSelectedIndex={undefined}/>
 			<Slider
 				description={localize({en: "horizontal scale ", zh: "水平缩放 "})}

--- a/src/Components/TimelineCanvas.tsx
+++ b/src/Components/TimelineCanvas.tsx
@@ -834,6 +834,7 @@ export function drawTimelines(originX: number, originY: number, imageExportSetti
 	let timelineSectionHeight = TimelineDimensions.slotHeight() * g_renderingProps.slotElements.length;
 
 	// add button
+	/*
 	if (g_renderingProps.slotElements.length < MAX_TIMELINE_SLOTS) {
 		let currentY = originY + g_renderingProps.slotElements.length * TimelineDimensions.slotHeight();
 		let handle : Rect = {
@@ -859,6 +860,7 @@ export function drawTimelines(originX: number, originY: number, imageExportSetti
 
 		timelineSectionHeight += TimelineDimensions.addSlotButtonHeight;
 	}
+	 */
 
 	return timelineSectionHeight;
 }

--- a/src/Components/TimelineCanvas.tsx
+++ b/src/Components/TimelineCanvas.tsx
@@ -834,7 +834,6 @@ export function drawTimelines(originX: number, originY: number, imageExportSetti
 	let timelineSectionHeight = TimelineDimensions.slotHeight() * g_renderingProps.slotElements.length;
 
 	// add button
-	/*
 	if (g_renderingProps.slotElements.length < MAX_TIMELINE_SLOTS) {
 		let currentY = originY + g_renderingProps.slotElements.length * TimelineDimensions.slotHeight();
 		let handle : Rect = {
@@ -860,7 +859,6 @@ export function drawTimelines(originX: number, originY: number, imageExportSetti
 
 		timelineSectionHeight += TimelineDimensions.addSlotButtonHeight;
 	}
-	 */
 
 	return timelineSectionHeight;
 }

--- a/src/Components/TimelineEditor.tsx
+++ b/src/Components/TimelineEditor.tsx
@@ -1,9 +1,9 @@
-import {Expandable, Help} from "./Common";
 import React, {CSSProperties} from "react";
 import {controller} from "../Controller/Controller";
 import {ActionNode, ActionType, Record, RecordValidStatus} from "../Controller/Record";
 import {localize, localizeSkillName} from "./Localization";
 import {getCurrentThemeColors} from "./ColorTheme";
+import {TIMELINE_SETTINGS_HEIGHT} from "./Timeline";
 
 export let refreshTimelineEditor = ()=>{};
 
@@ -193,7 +193,15 @@ export class TimelineEditor extends React.Component {
 			marginBottom: 10,
 			padding: 3
 		}
-		let toolbar = <div style={{display: "flex", flexDirection: "column", flex: 2, height: 200, marginRight: 10, position: "relative", verticalAlign: "top", overflowY: "hidden"}}>
+		let toolbar = <div style={{
+			display: "flex",
+			flexDirection: "column",
+			flex: 2,
+			marginRight: 10,
+			position: "relative",
+			verticalAlign: "top",
+			overflowY: "hidden"
+		}}>
 
 			<div style={{marginBottom: 6, flex: 1}}>
 				<button style={buttonStyle} onClick={e=>{
@@ -287,7 +295,7 @@ export class TimelineEditor extends React.Component {
 			itr = itr.next;
 		}
 		let colors = getCurrentThemeColors();
-		let content = <div style={{display: "flex", flexDirection: "row", position: "relative"}} onClick={
+		return <div style={{display: "flex", flexDirection: "row", position: "relative", height: TIMELINE_SETTINGS_HEIGHT - 50}} onClick={
 			(evt)=>{
 				if (!evt.shiftKey && !bHandledSkillSelectionThisFrame) {
 					if (!this.isDirty()) {
@@ -302,20 +310,20 @@ export class TimelineEditor extends React.Component {
 			}
 		}>
 			{toolbar}
-			<div className={"staticScrollbar"} style={{border: "1px solid " + colors.bgMediumContrast, flex: 6, height: 200, marginRight: 10, position: "relative", verticalAlign: "top", overflowY: "scroll"}}>
+			<div className={"staticScrollbar"} style={{
+				border: "1px solid " + colors.bgMediumContrast,
+				flex: 6,
+				marginRight: 10,
+				position: "relative",
+				verticalAlign: "top",
+				overflowY: "scroll"
+			}}>
 				{actionsList}
 			</div>
-			<div style={{border: "1px solid " + colors.bgMediumContrast, flex: 6, height: 200, position: "relative", verticalAlign: "top", overflowY: "hidden"}}>
+			<div style={{
+				border: "1px solid " + colors.bgMediumContrast, flex: 6, position: "relative", verticalAlign: "top", overflowY: "hidden"}}>
 				{applySection()}
 			</div>
-		</div>;
-		return <Expandable
-			title="Timeline editor"
-			titleNode={<span>{localize({en: "Timeline editor ", zh: "时间轴编辑器 "})}<Help topic={"timeline editor"} content={<div>
-				<div className={"paragraph"} style={{color: "orangered"}}><b>Has the bare minimum features but might still be buggy (let me know). Would recommend going over Instructions/Troubleshoot first, plus saving data to drive in case bugs mess up the entire tool</b></div>
-				<div className={"paragraph"}>I hope it's otherwise self-explanatory. Note that edits made here are not saved until they're applied to the actual timeline.</div>
-			</div>}/></span>}
-			content={content}
-			defaultShow={false}/>
+		</div>
 	}
 }

--- a/src/Components/TimelineMarkerPresets.tsx
+++ b/src/Components/TimelineMarkerPresets.tsx
@@ -282,7 +282,7 @@ export class TimelineMarkerPresets extends React.Component {
 			</div>
 		</div>
 
-		let content = <div>
+		return <div>
 			<button style={btnStyle} onClick={()=>{
 				controller.timeline.deleteAllMarkers();
 				controller.updateStats();
@@ -422,11 +422,6 @@ export class TimelineMarkerPresets extends React.Component {
 				<span>{localize({en: "Save marker tracks to file: ", zh: "保存标记到文件："})}</span>
 				{saveTrackLinks}
 			</div>
-		</div>;
-		return <Expandable
-			title="Timeline markers"
-			titleNode={<span>{localize({en: "Timeline markers", zh: "时间轴标记"})}</span>}
-			content={content}
-			defaultShow={false}/>
+		</div>
 	}
 }


### PR DESCRIPTION
I'm using this PR as a space to dump thoughts, notes, screenshots etc. Comments and suggestions welcome.

Tabs might be useful. Currently bootstrapping some ideas:
![image](https://github.com/user-attachments/assets/a4e3b834-78d9-4ac5-87d2-eb825d48f048)
![image](https://github.com/user-attachments/assets/0c5c04a8-9f5b-4e16-b69d-f85a85a1b9a1)

TODO:
- [x] how to use tabs for the config section
- [x] figure out the new content hierarchy when/if using tabs
- [ ] the bottom of the page is so wide. Should probably use multiple columns to use screen space efficiently. Check: https://react-resizable-panels.vercel.app/ or https://ui.shadcn.com/