### PR TITLE
Simplify resource declarations

### DIFF
--- a/src/BlmRotations.test.ts
+++ b/src/BlmRotations.test.ts
@@ -319,7 +319,6 @@ it("accepts the standard aoe rotation", testWithConfig({}, () => {
 		// hard clip triplecast
 		SkillName.Triplecast,
 		SkillName.Flare, // AF3
-
 	].forEach(applySkill);
 	// wait for cast time + damage application
 	controller.step(4);

--- a/src/Components/PlaybackControl.tsx
+++ b/src/Components/PlaybackControl.tsx
@@ -3,7 +3,7 @@ import {controller} from '../Controller/Controller'
 import {ButtonIndicator, Clickable, Expandable, Help, Input, ValueChangeEvent} from "./Common";
 import {getCachedValue, setCachedValue, ShellInfo, ShellVersion, TickMode} from "../Controller/Common";
 import {FIXED_BASE_CASTER_TAX, LevelSync, ProcMode, ResourceType} from "../Game/Common";
-import {resourceInfos, ResourceOrCoolDownInfo, ResourceOverrideData} from "../Game/Resources";
+import {getAllResources, ResourceOrCoolDownInfo, ResourceOverrideData} from "../Game/Resources";
 import {localize} from "./Localization";
 import {getCurrentThemeColors} from "./ColorTheme";
 import {SerializedConfig} from "../Game/GameConfig";
@@ -498,7 +498,7 @@ export class Config extends React.Component {
 		overridesList.forEach(ov=>{
 			S.add(ov.type);
 		});
-		for (let k of resourceInfos.keys()) {
+		for (let k of getAllResources(ShellInfo.job).keys()) {
 			if (!S.has(k)) {
 				firstAddableRsc = k;
 				break;
@@ -593,7 +593,7 @@ export class Config extends React.Component {
 
 	#addResourceOverride() {
 		let rscType = this.state.selectedOverrideResource;
-		let info = resourceInfos.get(rscType)!;
+		let info = getAllResources(ShellInfo.job).get(rscType)!;
 
 		let inputOverrideTimer = parseFloat(this.state.overrideTimer);
 		let inputOverrideStacks = parseInt(this.state.overrideStacks);
@@ -657,6 +657,7 @@ export class Config extends React.Component {
 	}
 
 	#addResourceOverrideNode() {
+		const resourceInfos = getAllResources(ShellInfo.job);
 		let resourceOptions = [];
 		let S = new Set();
 		this.state.initialResourceOverrides.forEach(override=>{
@@ -774,7 +775,7 @@ export class Config extends React.Component {
 		let resourceOverridesDisplayNodes = [];
 		for (let i = 0; i < this.state.initialResourceOverrides.length; i++) {
 			let override = this.state.initialResourceOverrides[i];
-			let info = resourceInfos.get(override.type)!;
+			let info = getAllResources(ShellInfo.job).get(override.type)!;
 			resourceOverridesDisplayNodes.push(<ResourceOverrideDisplay
 				key={i}
 				override={override}

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -7,11 +7,11 @@ import {
 	Spell,
 	Ability,
 } from "./Skills"
-import {makeResource, getAllResources, CoolDown, CoolDownState, DoTBuff, Event, EventTag, Resource, ResourceState} from "./Resources"
+import {getAllResources, CoolDown, CoolDownState, DoTBuff, Event, EventTag, Resource, ResourceState} from "./Resources"
 
 import {controller} from "../Controller/Controller";
 import {ActionNode} from "../Controller/Record";
-import {ShellInfo, ShellJob, ALL_JOBS} from "../Controller/Common";
+import {ShellInfo, ShellJob} from "../Controller/Common";
 import {getPotencyModifiersFromResourceState, Potency, PotencyModifier, PotencyModifierType} from "./Potency";
 import {Buff} from "./Buffs";
 
@@ -22,12 +22,6 @@ import {SkillButtonViewInfo} from "../Components/Skills";
 let SeedRandom = require('seedrandom');
 
 type RNG = any;
-
-ALL_JOBS.forEach((job) => {
-	makeResource(job, ResourceType.Mana, 10000, {default: 10000});
-	makeResource(job, ResourceType.Tincture, 1, {timeout: 30});
-	makeResource(job, ResourceType.Sprint, 1, {timeout: 10});
-});
 
 // GameState := resources + events queue
 export abstract class GameState {

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -21,8 +21,39 @@ import {
 } from "../Skills";
 import {TraitName, Traits} from "../Traits";
 import {GameState, PlayerState} from "../GameState";
-import {CoolDown, DoTBuff, Event, Resource} from "../Resources"
+import {getResourceInfo, makeResource, CoolDown, DoTBuff, Event, Resource, ResourceInfo} from "../Resources"
 import {GameConfig} from "../GameConfig";
+
+// === JOB GAUGE ELEMENTS AND STATUS EFFECTS ===
+// TODO values changed by traits are handled in the class constructor, should be moved here
+const makeBLMResource = (rsc: ResourceType, maxValue: number, params?: {timeout: number}) => {
+	makeResource(ShellJob.BLM, rsc, maxValue, params ?? {});
+};
+
+makeBLMResource(ResourceType.Polyglot, 3, {timeout: 30});
+makeBLMResource(ResourceType.AstralFire, 3);
+makeBLMResource(ResourceType.UmbralIce, 3);
+makeBLMResource(ResourceType.UmbralHeart, 3);
+makeBLMResource(ResourceType.AstralSoul, 6);
+makeBLMResource(ResourceType.LeyLines, 1, {timeout: 30});
+makeBLMResource(ResourceType.Enochian, 1, {timeout: 15});
+makeBLMResource(ResourceType.Paradox, 1);
+
+// re-measured in DT, screen recording at: https://drive.google.com/file/d/1MEFnd-m59qx1yIaZeehSsAxjhLMsWBuw/view?usp=drive_link
+makeBLMResource(ResourceType.Firestarter, 1, {timeout: 30.5});
+
+// [6/29/24] note: from screen recording it looks more like: button press (0.1s) gain buff (30.0s) lose buff
+// see: https://drive.google.com/file/d/11KEAEjgezCKxhvUsaLTjugKAH_D1glmy/view?usp=sharing
+makeBLMResource(ResourceType.Thunderhead, 1, {timeout: 30});
+makeBLMResource(ResourceType.ThunderDoT, 1, {timeout: 30}); // TODO
+makeBLMResource(ResourceType.Manaward, 1, {timeout: 20});
+
+// 15.7s: see screen recording: https://drive.google.com/file/d/1qoIpAMK2KAKETgID6a3p5dqkeWRcNDdB/view?usp=drive_link
+makeBLMResource(ResourceType.Triplecast, 1, {timeout: 15.7});
+makeBLMResource(ResourceType.Addle, 1, {timeout: 15});
+makeBLMResource(ResourceType.Swiftcast, 1, {timeout: 10});
+makeBLMResource(ResourceType.LucidDreaming, 1, {timeout: 21});
+makeBLMResource(ResourceType.Surecast, 1, {timeout: 10});
 
 // === JOB GAUGE AND STATE ===
 export class BLMState extends GameState {
@@ -33,52 +64,18 @@ export class BLMState extends GameState {
 
 		this.thunderTickOffset = this.nonProcRng() * 3.0;
 
-		// RESOURCES (checked when using skills)
 		const polyglotStacks = 
 			(Traits.hasUnlocked(TraitName.EnhancedPolyglotII, this.config.level) && 3) ||
 			(Traits.hasUnlocked(TraitName.EnhancedPolyglot, this.config.level) && 2) ||
 			1;
-		[
-			new Resource(ResourceType.Polyglot, polyglotStacks, 0),
-			new Resource(ResourceType.AstralFire, 3, 0),
-			new Resource(ResourceType.UmbralIce, 3, 0),
-			new Resource(ResourceType.UmbralHeart, 3, 0),
-			new Resource(ResourceType.AstralSoul, 6, 0),
-			new Resource(ResourceType.LeyLines, 1, 0), // capture
-			new Resource(ResourceType.Enochian, 1, 0),
-			new Resource(ResourceType.Paradox, 1, 0),
-			new Resource(ResourceType.Firestarter, 1, 0),
-			new Resource(ResourceType.Thunderhead, 1, 0),
-			new DoTBuff(ResourceType.ThunderDoT, 1, 0),
-			new Resource(ResourceType.Manaward, 1, 0),
-			new Resource(ResourceType.Triplecast, 3, 0),
-			new Resource(ResourceType.Addle, 1, 0),
-			new Resource(ResourceType.Swiftcast, 1, 0),
-			new DoTBuff(ResourceType.LucidDreaming, 1, 0),
-			new Resource(ResourceType.Surecast, 1, 0),
-			new Resource(ResourceType.Tincture, 1, 0), // capture
-		].forEach((resource) => this.resources.set(resource));
+		this.resources.set(new Resource(ResourceType.Polyglot, polyglotStacks, 0));
 
 		// skill CDs (also a form of resource)
 		const manafontCooldown = (Traits.hasUnlocked(TraitName.EnhancedManafont, this.config.level) && 100) || 180;
 		const swiftcastCooldown = (Traits.hasUnlocked(TraitName.EnhancedSwiftcast, this.config.level) && 40) || 60;
 		[
-			new CoolDown(ResourceType.cd_LeyLines, 120, 1, 1),
-			new CoolDown(ResourceType.cd_Transpose, 5, 1, 1),
-			new CoolDown(ResourceType.cd_Manaward, 120, 1, 1),
-			new CoolDown(ResourceType.cd_BetweenTheLines, 3, 1, 1),
-			new CoolDown(ResourceType.cd_AetherialManipulation, 10, 1, 1),
-			new CoolDown(ResourceType.cd_Triplecast, 60, 2, 2),
-
 			new CoolDown(ResourceType.cd_Manafont, manafontCooldown, 1, 1),
-			new CoolDown(ResourceType.cd_Amplifier, 120, 1, 1),
-			new CoolDown(ResourceType.cd_Retrace, 40, 1, 1),
-			new CoolDown(ResourceType.cd_Addle, 90, 1, 1),
-
 			new CoolDown(ResourceType.cd_Swiftcast, swiftcastCooldown, 1, 1),
-			new CoolDown(ResourceType.cd_LucidDreaming, 60, 1, 1),
-			new CoolDown(ResourceType.cd_Surecast, 120, 1, 1),
-			new CoolDown(ResourceType.cd_Tincture, 270, 1, 1),
 		].forEach((cd) => this.cooldowns.set(cd));
 
 		this.registerRecurringEvents();
@@ -135,9 +132,7 @@ export class BLMState extends GameState {
 
 	gainThunderhead() {
 		let thunderhead = this.resources.get(ResourceType.Thunderhead);
-		// [6/29/24] note: from screen recording it looks more like: button press (0.1s) gain buff (30.0s) lose buff
-		// see: https://drive.google.com/file/d/11KEAEjgezCKxhvUsaLTjugKAH_D1glmy/view?usp=sharing
-		let duration = 30;
+		let duration = (getResourceInfo(ShellJob.BLM, ResourceType.Thunderhead) as ResourceInfo).maxTimeout;
 		if (thunderhead.available(1)) { // already has a proc; reset its timer
 			thunderhead.overrideTimer(this, duration);
 		} else { // there's currently no proc. gain one.
@@ -373,12 +368,13 @@ const makeGCD_BLM = (name: SkillName, unlockLevel: number, params: {
 };
 
 
-const makeAbility_BLM =(name: SkillName, unlockLevel: number, cdName: ResourceType, params: Partial<{
-	applicationDelay: number,
-	validateAttempt: ValidateAttemptFn<BLMState>,
-	onConfirm: EffectFn<BLMState>,
-	onApplication: EffectFn<BLMState>,
-}>): Ability<BLMState> => makeAbility(ShellJob.BLM, name, unlockLevel, cdName, params);
+const makeAbility_BLM =(name: SkillName, unlockLevel: number, cdName: ResourceType, params: {
+	applicationDelay?: number,
+	cooldown: number,
+	validateAttempt?: ValidateAttemptFn<BLMState>,
+	onConfirm?: EffectFn<BLMState>,
+	onApplication?: EffectFn<BLMState>,
+}): Ability<BLMState> => makeAbility(ShellJob.BLM, name, unlockLevel, cdName, params);
 
 
 // ref logs
@@ -406,8 +402,7 @@ makeGCD_BLM(SkillName.Blizzard, 1, {
 });
 
 const gainFirestarterProc = (state: PlayerState) => {
-	// re-measured in DT, screen recording at: https://drive.google.com/file/d/1MEFnd-m59qx1yIaZeehSsAxjhLMsWBuw/view?usp=drive_link
-	let duration = 30.5;
+	let duration = (getResourceInfo(ShellJob.BLM, ResourceType.Firestarter) as ResourceInfo).maxTimeout;
 	if (state.resources.get(ResourceType.Firestarter).available(1)) {
 		state.resources.get(ResourceType.Firestarter).overrideTimer(state, duration);
 	} else {
@@ -444,6 +439,7 @@ makeGCD_BLM(SkillName.Fire, 2, {
 
 makeAbility_BLM(SkillName.Transpose, 4, ResourceType.cd_Transpose, {
 	applicationDelay: 0, // instant
+	cooldown: 5,
 	validateAttempt: (state) => state.getFireStacks() > 0 || state.getIceStacks() > 0,
 	onApplication: (state, node) => {
 		if (state.getFireStacks() !== 0 || state.getIceStacks() !== 0) {
@@ -549,7 +545,7 @@ makeGCD_BLM(SkillName.Thunder3, 45, {
 makeResourceAbility(ShellJob.BLM, SkillName.Manaward, 30, ResourceType.cd_Manaward, {
 	rscType: ResourceType.Manaward,
 	applicationDelay: 1.114, // delayed
-	duration: 20,
+	cooldown: 120,
 });
 
 // Manafont: application delay 0.88s -> 0.2s since Dawntrail
@@ -557,6 +553,7 @@ makeResourceAbility(ShellJob.BLM, SkillName.Manaward, 30, ResourceType.cd_Manawa
 // see screen recording: https://drive.google.com/file/d/1zGhU9egAKJ3PJiPVjuRBBMkKdxxHLS9b/view?usp=drive_link
 makeAbility_BLM(SkillName.Manafont, 30, ResourceType.cd_Manafont, {
 	applicationDelay: 0.2, // delayed
+	cooldown: 100, // set by trait in the constructor
 	validateAttempt: (state) => state.getFireStacks() > 0,
 	onConfirm: (state, node) => {
 		state = state as BLMState;
@@ -636,7 +633,7 @@ makeGCD_BLM(SkillName.Flare, 50, {
 makeResourceAbility(ShellJob.BLM, SkillName.LeyLines, 52, ResourceType.cd_LeyLines, {
 	rscType: ResourceType.LeyLines,
 	applicationDelay: 0.49, // delayed
-	duration: 30,
+	cooldown: 120,
 	onApplication: (state, node) => {
 		state.resources.get(ResourceType.LeyLines).enabled = true
 	},
@@ -667,21 +664,26 @@ makeGCD_BLM(SkillName.Fire4, 60, {
 
 makeAbility_BLM(SkillName.BetweenTheLines, 62, ResourceType.cd_BetweenTheLines, {
 	applicationDelay: 0, // ?
+	cooldown: 3,
 	validateAttempt: (state) => state.resources.get(ResourceType.LeyLines).availableAmountIncludingDisabled() > 0,
 });
 
 makeAbility_BLM(SkillName.AetherialManipulation, 50, ResourceType.cd_AetherialManipulation, {
 	applicationDelay: 0, // ?
+	cooldown: 10,
 });
 
 makeAbility_BLM(SkillName.Triplecast, 66, ResourceType.cd_Triplecast, {
 	applicationDelay: 0, // instant
+	cooldown: 60,
 	onApplication: (state, node) => {
 		const triple = state.resources.get(ResourceType.Triplecast)
 		if (triple.pendingChange) triple.removeTimer();
 		triple.gain(3);
-		// 15.7s: see screen recording: https://drive.google.com/file/d/1qoIpAMK2KAKETgID6a3p5dqkeWRcNDdB/view?usp=drive_link
-		state.enqueueResourceDrop(ResourceType.Triplecast, 15.7);
+		state.enqueueResourceDrop(
+			ResourceType.Triplecast,
+			(getResourceInfo(ShellJob.BLM, ResourceType.Triplecast) as ResourceInfo).maxTimeout,
+		);
 	},
 });
 
@@ -794,6 +796,7 @@ makeGCD_BLM(SkillName.HighBlizzard2, 82, {
 
 makeAbility_BLM(SkillName.Amplifier, 86, ResourceType.cd_Amplifier, {
 	applicationDelay: 0, // ? (assumed to be instant)
+	cooldown: 120,
 	validateAttempt: (state) => state.getFireStacks() > 0 || state.getIceStacks() > 0,
 	onApplication: (state, node) => {
 		let polyglot = state.resources.get(ResourceType.Polyglot);
@@ -855,6 +858,7 @@ makeGCD_BLM(SkillName.FlareStar, 100, {
 
 makeAbility_BLM(SkillName.Retrace, 96, ResourceType.cd_Retrace, {
 	applicationDelay: 0, // ? (assumed to be instant)
+	cooldown: 40,
 	validateAttempt: (state) => (
 		Traits.hasUnlocked(TraitName.EnhancedLeyLines, state.config.level) &&
 		state.resources.get(ResourceType.LeyLines).availableAmountIncludingDisabled() > 0

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -49,7 +49,7 @@ makeBLMResource(ResourceType.ThunderDoT, 1, {timeout: 30}); // TODO
 makeBLMResource(ResourceType.Manaward, 1, {timeout: 20});
 
 // 15.7s: see screen recording: https://drive.google.com/file/d/1qoIpAMK2KAKETgID6a3p5dqkeWRcNDdB/view?usp=drive_link
-makeBLMResource(ResourceType.Triplecast, 1, {timeout: 15.7});
+makeBLMResource(ResourceType.Triplecast, 3, {timeout: 15.7});
 makeBLMResource(ResourceType.Addle, 1, {timeout: 15});
 makeBLMResource(ResourceType.Swiftcast, 1, {timeout: 10});
 makeBLMResource(ResourceType.LucidDreaming, 1, {timeout: 21});
@@ -371,6 +371,7 @@ const makeGCD_BLM = (name: SkillName, unlockLevel: number, params: {
 const makeAbility_BLM =(name: SkillName, unlockLevel: number, cdName: ResourceType, params: {
 	applicationDelay?: number,
 	cooldown: number,
+	maxCharges?: number,
 	validateAttempt?: ValidateAttemptFn<BLMState>,
 	onConfirm?: EffectFn<BLMState>,
 	onApplication?: EffectFn<BLMState>,
@@ -676,6 +677,7 @@ makeAbility_BLM(SkillName.AetherialManipulation, 50, ResourceType.cd_AetherialMa
 makeAbility_BLM(SkillName.Triplecast, 66, ResourceType.cd_Triplecast, {
 	applicationDelay: 0, // instant
 	cooldown: 60,
+	maxCharges: 2,
 	onApplication: (state, node) => {
 		const triple = state.resources.get(ResourceType.Triplecast)
 		if (triple.pendingChange) triple.removeTimer();

--- a/src/Game/Jobs/RoleActions.ts
+++ b/src/Game/Jobs/RoleActions.ts
@@ -9,6 +9,7 @@ const CASTER_JOBS = [ShellJob.BLM, ShellJob.PCT];
 makeResourceAbility(CASTER_JOBS, SkillName.Addle, 8, ResourceType.cd_Addle, {
 	rscType: ResourceType.Addle,
 	applicationDelay: 0.621, // delayed
+	cooldown: 90,
 	duration: (state) => (Traits.hasUnlocked(TraitName.EnhancedAddle, state.config.level) && 15) || 10,
 	assetPath: "CasterRole/Addle.png",
 });
@@ -16,15 +17,15 @@ makeResourceAbility(CASTER_JOBS, SkillName.Addle, 8, ResourceType.cd_Addle, {
 makeResourceAbility(CASTER_JOBS, SkillName.Swiftcast, 18, ResourceType.cd_Swiftcast, {
 	rscType: ResourceType.Swiftcast,
 	applicationDelay: 0, // instant
-	duration: 10,
+	cooldown: 40, // set by trait in constructor
 	assetPath: "CasterRole/Swiftcast.png",
 });
 
 makeResourceAbility(CASTER_JOBS, SkillName.LucidDreaming, 14, ResourceType.cd_LucidDreaming, {
 	rscType: ResourceType.LucidDreaming,
 	applicationDelay: 0.623, // delayed
+	cooldown: 60,
 	assetPath: "CasterRole/Lucid Dreaming.png",
-	duration: 21,
 	onApplication: (state, node) => {
 		let lucid = state.resources.get(ResourceType.LucidDreaming) as DoTBuff;
 		lucid.node = node;
@@ -39,20 +40,20 @@ makeResourceAbility(CASTER_JOBS, SkillName.LucidDreaming, 14, ResourceType.cd_Lu
 makeResourceAbility(CASTER_JOBS, SkillName.Surecast, 44, ResourceType.cd_Surecast, {
 	rscType: ResourceType.Surecast,
 	applicationDelay: 0, // surprisingly instant because arms length is not
-	duration: 6,
+	cooldown: 120,
 	assetPath: "CasterRole/Surecast.png",
 });
 
 makeResourceAbility(CASTER_JOBS, SkillName.Tincture, 1, ResourceType.cd_Tincture, {
 	rscType: ResourceType.Tincture,
 	applicationDelay: 0.64, // delayed // somewhere in the midrange of what's seen in logs
-	duration: 30,
+	cooldown: 270,
 	assetPath: "CasterRole/Tincture.png",
 });
 
 makeResourceAbility(CASTER_JOBS, SkillName.Sprint, 1, ResourceType.cd_Sprint, {
 	rscType: ResourceType.Sprint,
 	applicationDelay: 0.133, // delayed
-	duration: 10,
+	cooldown: 60,
 	assetPath: "General/Sprint.png",
 });

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -1,4 +1,5 @@
 import {Debug, ResourceType} from "./Common"
+import {ShellInfo, ShellJob, ALL_JOBS} from "../Controller/Common";
 import {GameState} from "./GameState";
 import {ActionNode} from "../Controller/Record";
 import {BLMState} from "./Jobs/BLM";
@@ -264,48 +265,49 @@ export type CoolDownInfo = {
 }
 export type ResourceOrCoolDownInfo = ResourceInfo | CoolDownInfo;
 
-export const resourceInfos = new Map<ResourceType, ResourceOrCoolDownInfo>();
+const resourceInfos = new Map<ShellJob, Map<ResourceType, ResourceOrCoolDownInfo>>();
 
-// resources
-resourceInfos.set(ResourceType.Mana, { isCoolDown: false, defaultValue: 10000, maxValue: 10000, maxTimeout: -1 });
-resourceInfos.set(ResourceType.Polyglot, { isCoolDown: false, defaultValue: 0, maxValue: 3, maxTimeout: 30 });
-resourceInfos.set(ResourceType.AstralFire, { isCoolDown: false, defaultValue: 0, maxValue: 3, maxTimeout: -1 });
-resourceInfos.set(ResourceType.UmbralIce, { isCoolDown: false, defaultValue: 0, maxValue: 3, maxTimeout: -1 });
-resourceInfos.set(ResourceType.UmbralHeart, { isCoolDown: false, defaultValue: 0, maxValue: 3, maxTimeout: -1 });
-resourceInfos.set(ResourceType.AstralSoul, { isCoolDown: false, defaultValue: 0, maxValue: 6, maxTimeout: -1 });
+ALL_JOBS.forEach((job) => resourceInfos.set(job, new Map([[ResourceType.cd_GCD, {
+	// special declaration for GCD override default
+	isCoolDown: true,
+	maxStacks: 1,
+	cdPerStack: 2.5
+}]])));
 
-resourceInfos.set(ResourceType.LeyLines, { isCoolDown: false, defaultValue: 0, maxValue: 1, maxTimeout: 30 });
-resourceInfos.set(ResourceType.Enochian, { isCoolDown: false, defaultValue: 0, maxValue: 1, maxTimeout: 15 }); // controls AF, UI, UH
-resourceInfos.set(ResourceType.Paradox, { isCoolDown: false, defaultValue: 0, maxValue: 1, maxTimeout: -1 });
-resourceInfos.set(ResourceType.Firestarter, { isCoolDown: false, defaultValue: 0, maxValue: 1, maxTimeout: 30 });
-resourceInfos.set(ResourceType.Thunderhead, { isCoolDown: false, defaultValue: 0, maxValue: 1, maxTimeout: 30 });
-resourceInfos.set(ResourceType.ThunderDoT, { isCoolDown: false, defaultValue: 0, maxValue: 1, maxTimeout: 30 }); // buff display only
-resourceInfos.set(ResourceType.Manaward, { isCoolDown: false, defaultValue: 0, maxValue: 1, maxTimeout: 20 });
-resourceInfos.set(ResourceType.Triplecast, { isCoolDown: false, defaultValue: 0, maxValue: 3, maxTimeout: 15 });
-resourceInfos.set(ResourceType.Addle, { isCoolDown: false, defaultValue: 0, maxValue: 1, maxTimeout: 15 });
-resourceInfos.set(ResourceType.Swiftcast, { isCoolDown: false, defaultValue: 0, maxValue: 1, maxTimeout: 10 });
-resourceInfos.set(ResourceType.LucidDreaming, { isCoolDown: false, defaultValue: 0, maxValue: 1, maxTimeout: 21 }); // buff display only
-resourceInfos.set(ResourceType.Surecast, { isCoolDown: false, defaultValue: 0, maxValue: 1, maxTimeout: 10 });
-resourceInfos.set(ResourceType.Tincture, { isCoolDown: false, defaultValue: 0, maxValue: 1, maxTimeout: 30 });
-resourceInfos.set(ResourceType.Sprint, { isCoolDown: false, defaultValue: 0, maxValue: 1, maxTimeout: 10 });
+export function getResourceInfo(job: ShellJob, rsc: ResourceType): ResourceOrCoolDownInfo {
+	const map = resourceInfos.get(job)!;
+	if (!map.has(rsc)) {
+		console.error(`no resource info found for ${rsc}`);
+	}
+	return map.get(rsc)!;
+}
 
-// CDs
-resourceInfos.set(ResourceType.cd_GCD, { isCoolDown: true, maxStacks: 1, cdPerStack: 2.5 });
-resourceInfos.set(ResourceType.cd_LeyLines, { isCoolDown: true, maxStacks: 1, cdPerStack: 120 });
-resourceInfos.set(ResourceType.cd_Transpose, { isCoolDown: true, maxStacks: 1, cdPerStack: 5 });
-resourceInfos.set(ResourceType.cd_Manaward, { isCoolDown: true, maxStacks: 1, cdPerStack: 120 });
-resourceInfos.set(ResourceType.cd_BetweenTheLines, { isCoolDown: true, maxStacks: 1, cdPerStack: 3 });
-resourceInfos.set(ResourceType.cd_AetherialManipulation, { isCoolDown: true, maxStacks: 1, cdPerStack: 10 });
-resourceInfos.set(ResourceType.cd_Triplecast, { isCoolDown: true, maxStacks: 2, cdPerStack: 60 });
-resourceInfos.set(ResourceType.cd_Manafont, { isCoolDown: true, maxStacks: 1, cdPerStack: 100 });
-resourceInfos.set(ResourceType.cd_Amplifier, { isCoolDown: true, maxStacks: 1, cdPerStack: 120 });
-resourceInfos.set(ResourceType.cd_Retrace, { isCoolDown: true, maxStacks: 1, cdPerStack: 40 });
-resourceInfos.set(ResourceType.cd_Addle, { isCoolDown: true, maxStacks: 1, cdPerStack: 90 });
-resourceInfos.set(ResourceType.cd_Swiftcast, { isCoolDown: true, maxStacks: 1, cdPerStack: 40 });
-resourceInfos.set(ResourceType.cd_LucidDreaming, { isCoolDown: true, maxStacks: 1, cdPerStack: 60 });
-resourceInfos.set(ResourceType.cd_Surecast, { isCoolDown: true, maxStacks: 1, cdPerStack: 120 });
-resourceInfos.set(ResourceType.cd_Tincture, { isCoolDown: true, maxStacks: 1, cdPerStack: 270 });
-resourceInfos.set(ResourceType.cd_Sprint, { isCoolDown: true, maxStacks: 1, cdPerStack: 60 });
+export function getAllResources(job: ShellJob): Map<ResourceType, ResourceOrCoolDownInfo> {
+	return resourceInfos.get(job)!;
+}
+
+// Add a status effect or job gauge element to the resource map of the specified job.
+export function makeResource(job: ShellJob, rsc: ResourceType, maxValue: number, params: Partial<{
+	default: number,
+	timeout: number,
+}>) {
+	getAllResources(job).set(rsc, {
+		isCoolDown: false,
+		defaultValue: params.default ?? 0,
+		maxValue: maxValue,
+		maxTimeout: params.timeout ?? -1,
+	});
+}
+
+// Add an ability to the resource map of the specified job.
+// Should only be called within the makeAbility constructor, except for the default GCD cooldown.
+export function makeCooldown(job: ShellJob, rsc: ResourceType, cdPerStack: number, maxStacks: number = 1) {
+	getAllResources(job).set(rsc, {
+		isCoolDown: true,
+		cdPerStack: cdPerStack,
+		maxStacks: maxStacks,
+	});
+}
 
 export type ResourceOverrideData = {
 	type: ResourceType,
@@ -362,7 +364,7 @@ export class ResourceOverride {
 	// MP, AF, UI, UH, Paradox, Polyglot: amount (stacks)
 	applyTo(game: GameState) {
 
-		let info = resourceInfos.get(this.type);
+		let info = getAllResources(ShellInfo.job).get(this.type);
 		if (!info) {
 			console.assert(false);
 			return;

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -267,13 +267,6 @@ export type ResourceOrCoolDownInfo = ResourceInfo | CoolDownInfo;
 
 const resourceInfos = new Map<ShellJob, Map<ResourceType, ResourceOrCoolDownInfo>>();
 
-ALL_JOBS.forEach((job) => resourceInfos.set(job, new Map([[ResourceType.cd_GCD, {
-	// special declaration for GCD override default
-	isCoolDown: true,
-	maxStacks: 1,
-	cdPerStack: 2.5
-}]])));
-
 export function getResourceInfo(job: ShellJob, rsc: ResourceType): ResourceOrCoolDownInfo {
 	const map = resourceInfos.get(job)!;
 	if (!map.has(rsc)) {
@@ -298,6 +291,19 @@ export function makeResource(job: ShellJob, rsc: ResourceType, maxValue: number,
 		maxTimeout: params.timeout ?? -1,
 	});
 }
+
+ALL_JOBS.forEach((job) => {
+	resourceInfos.set(job, new Map([[ResourceType.cd_GCD, {
+		// special declaration for GCD override default
+		isCoolDown: true,
+		maxStacks: 1,
+		cdPerStack: 2.5
+	}]]));
+	// MP, tincture buff, and sprint are common to all jobs
+	makeResource(job, ResourceType.Mana, 10000, {default: 10000});
+	makeResource(job, ResourceType.Tincture, 1, {timeout: 30});
+	makeResource(job, ResourceType.Sprint, 1, {timeout: 10});
+});
 
 // Add an ability to the resource map of the specified job.
 // Should only be called within the makeAbility constructor, except for the default GCD cooldown.


### PR DESCRIPTION
Simplified resource declarations, similar to the refactor done for skills. Resources should be declared within a job's state declaration file, cooldown durations + stacks are declared with their corresponding skill, and `ResourceState`, `CoolDownState`, and overrides are automatically populated in `GameState`'s constructor.

After this PR, buff durations are retrieved with the `makeResourceAbility` constructor to avoid duplication between overrides and resource declaration. Resources with varying buff duration based on trait level (just Addle) are kind of weird, and currently still follow the old declaration format--we'd have to modify `ResourceInfo` to store a buff's duration as `(Level) => number` instead of `number`. Cooldown lengths that are modified by traits (Manafont, Swiftcast) are currently set in the class state constructor, and can similarly be turned into a function if we want to keep that declaration separate.