### PR TITLE
Show error timestamp in timeline editor

### DIFF
--- a/src/Components/TimelineEditor.tsx
+++ b/src/Components/TimelineEditor.tsx
@@ -176,8 +176,15 @@ export class TimelineEditor extends React.Component {
 							nodeName = node.skillName ?? "(unknown skill)";
 						}
 					}
+					let errorMessage = "This sequence contains invalid actions! Check: " + nodeName;
+					if (this.state.recordValidStatus?.invalidTime) {
+						const minutes = Math.floor(this.state.recordValidStatus.invalidTime / 60);
+						const seconds = (this.state.recordValidStatus.invalidTime - (minutes * 60));
+						errorMessage += ` @ ${minutes.toFixed(0)}:${seconds.toFixed(3)}`;
+					}
+					errorMessage += ` (${this.state.recordValidStatus?.invalidReason ?? "(unknown)"})`;
 					return <div>
-						<div style={{backgroundColor: "rgba(255, 0, 0, 0.25)"}}>This sequence contains invalid actions! Check: {nodeName + " (" + (this.state.recordValidStatus?.invalidReason ?? "(unknown)") + ")"}</div>
+						<div style={{backgroundColor: "rgba(255, 0, 0, 0.25)"}}>{errorMessage}</div>
 						{this.discardEditsBtn()}
 					</div>
 				}

--- a/src/Components/TimelineEditor.tsx
+++ b/src/Components/TimelineEditor.tsx
@@ -1,6 +1,7 @@
 import React, {CSSProperties} from "react";
 import {controller} from "../Controller/Controller";
 import {ActionNode, ActionType, Record, RecordValidStatus} from "../Controller/Record";
+import {StaticFn} from "./Common";
 import {localize, localizeSkillName} from "./Localization";
 import {getCurrentThemeColors} from "./ColorTheme";
 import {TIMELINE_SETTINGS_HEIGHT} from "./Timeline";
@@ -178,9 +179,8 @@ export class TimelineEditor extends React.Component {
 					}
 					let errorMessage = "This sequence contains invalid actions! Check: " + nodeName;
 					if (this.state.recordValidStatus?.invalidTime) {
-						const minutes = Math.floor(this.state.recordValidStatus.invalidTime / 60);
-						const seconds = (this.state.recordValidStatus.invalidTime - (minutes * 60));
-						errorMessage += ` @ ${minutes.toFixed(0)}:${seconds.toFixed(3)}`;
+						const timeStr = StaticFn.displayTime(this.state.recordValidStatus.invalidTime, 3);
+						errorMessage += ` @ ${timeStr}`;
 					}
 					errorMessage += ` (${this.state.recordValidStatus?.invalidReason ?? "(unknown)"})`;
 					return <div>

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -157,10 +157,17 @@ class Controller {
 
 		console.assert(inRecord.config !== undefined);
 
-		let result: {isValid: boolean, firstInvalidAction: ActionNode | undefined, invalidReason: string | undefined, straightenedIfValid: Record | undefined} = {
+		let result: {
+			isValid: boolean,
+			firstInvalidAction: ActionNode | undefined,
+			invalidReason: string | undefined,
+			invalidTime: number | undefined,
+			straightenedIfValid: Record | undefined,
+		} = {
 			isValid: true,
 			firstInvalidAction: undefined,
 			invalidReason: undefined,
+			invalidTime: undefined,
 			straightenedIfValid: undefined
 		};
 
@@ -196,6 +203,7 @@ class Controller {
 			result.isValid = status.success;
 			result.firstInvalidAction = status.firstInvalidNode;
 			result.invalidReason = status.invalidReason;
+			result.invalidTime = status.invalidTime;
 			if (status.success) {
 				result.straightenedIfValid = this.record;
 			}
@@ -859,7 +867,8 @@ class Controller {
 		success: boolean,
 		firstAddedNode: ActionNode | undefined,
 		firstInvalidNode: ActionNode | undefined,
-		invalidReason: SkillReadyStatus | undefined
+		invalidReason: SkillReadyStatus | undefined,
+		invalidTime: number | undefined,
 	} {
 		// Prevent UI updates from occuring until the final action
 		this.#skipViewUpdates = true;
@@ -883,7 +892,8 @@ class Controller {
 				success: true,
 				firstAddedNode: undefined,
 				firstInvalidNode: undefined,
-				invalidReason: undefined
+				invalidReason: undefined,
+				invalidTime: undefined,
 			};
 		}
 
@@ -900,8 +910,9 @@ class Controller {
 			}
 
 			let lastIter = false;
-			let firstInvalidNode : ActionNode | undefined = undefined;
-			let invalidReason : SkillReadyStatus | undefined = undefined;
+			let firstInvalidNode: ActionNode | undefined = undefined;
+			let invalidReason: SkillReadyStatus | undefined = undefined;
+			let invalidTime: number | undefined = undefined;
 
 			// maxReplayTime is used for replay for displaying historical game states (only replay some given duration)
 			let waitDuration = itr.waitDuration;
@@ -972,6 +983,7 @@ class Controller {
 					lastIter = true;
 					firstInvalidNode = itr;
 					invalidReason = status.status;
+					invalidTime = this.game.getDisplayTime();
 				}
 
 				if (this.#bInterrupted) {// likely because enochian dropped before a cast snapshots
@@ -979,6 +991,7 @@ class Controller {
 					lastIter = true;
 					firstInvalidNode = itr;
 					invalidReason = status.status;
+					invalidTime = this.game.getDisplayTime();
 				}
 			}
 			// buff enable/disable also only supported by exact / edited replay
@@ -996,6 +1009,7 @@ class Controller {
 					lastIter = true;
 					firstInvalidNode = itr;
 					invalidReason = SkillReadyStatus.BuffNoLongerAvailable;
+					invalidTime = this.game.getDisplayTime();
 				}
 			}
 			else {
@@ -1027,7 +1041,8 @@ class Controller {
 					success: false,
 					firstAddedNode: firstAddedNode,
 					firstInvalidNode: firstInvalidNode,
-					invalidReason: invalidReason
+					invalidReason: invalidReason,
+					invalidTime: invalidTime,
 				};
 			} else {
 				itr = itr.next;
@@ -1041,7 +1056,8 @@ class Controller {
 			success: true,
 			firstAddedNode: firstAddedNode,
 			firstInvalidNode: undefined,
-			invalidReason: undefined
+			invalidReason: undefined,
+			invalidTime: undefined,
 		};
 	}
 

--- a/src/Controller/Record.ts
+++ b/src/Controller/Record.ts
@@ -235,7 +235,8 @@ export class Line {
 export type RecordValidStatus = {
 	isValid: boolean,
 	firstInvalidAction: ActionNode | undefined,
-	invalidReason: SkillReadyStatus | undefined
+	invalidReason: SkillReadyStatus | undefined,
+	invalidTime: number | undefined,
 };
 
 // information abt a timeline


### PR DESCRIPTION
If moving/deleting a skill in the timeline editor invalidates some later action, the timeline editor will report the name of the offending skill in text, and display a little red arrow next to it in the timeline box. In situations where a change to an early portion of the timeline affects a skill usage far later (possibly multiple minutes away), it can be difficult to identify the issue. Adding an explicit timestamp to the error message helps alleviate this.

![image](https://github.com/user-attachments/assets/c76073d0-ffb9-4937-8353-c240e96a6a54)
