### PR TITLE
Add ability to resize ability selections

### DIFF
--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,11 @@
 [
 	{
+		"date": "10/10/24",
+		"changes": [
+			"Added ability to modify action selections made with shift-click"
+		]
+	},
+	{
 		"date": "10/9/24",
 		"changes": [
 			"Page layout updates",


### PR DESCRIPTION
shift-clicking an ability timeline now lets you resize the selection around the first chosen selection

<details><summary>demo</summary>
<img src=https://github.com/user-attachments/assets/01ed8e4c-7200-47a8-b1f0-2edd3d24336e />
</details>

<details><summary>analogous behavior from google sheets</summary>
<img src=https://github.com/user-attachments/assets/96238277-aa08-4681-bea7-c71c48689eda />
</details>

the orange timeline cursor shifting around to always match the start of the selection is a little weird (note that google sheets keeps a selection box on the initially-selected square), but I think it's reasonable to keep this behavior and it would be a bit more effort to change