### PR TITLE
Check MP cost at cast confirm window

### DIFF
--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,11 @@
 [
 	{
+		"date": "11/2/24",
+		"changes": [
+			"Fixed a bug where MP costs were not re-checked at the end of a cast bar if the MP cost changed mid-cast"
+		]
+	},
+	{
 		"date": "10/15/24",
 		"changes": [
 			"Party buff related fixes to make sure buffs are compatible with Amarantine's combat sim"


### PR DESCRIPTION
If Enochian drops midway through a cast, the MP cost of a spell should be checked again at the cast confirm window, and the spell canceled if the MP cost is no longer met.

Two manual test timelines:
- [bad_b3_eno_drop.txt](https://github.com/user-attachments/files/17609177/bad_b3_eno_drop.txt)
(works on main, fails after this PR): this is also added as an automated test; after reaching 0 MP in a fire phase, the B3 cast was free under AF3 but costs 800 MP instead when eno drops, making the cast fail
- [b3_should_be_800_mp.txt](https://github.com/user-attachments/files/17609180/b3_should_be_800_mp.txt) B3 succeeds but consumes 800 MP after the eno drop happens
