### PR TITLE
PCT merge cleanup - remove Hammer aspect and getPotencyModifiersFromResourceState (2/2)

### DIFF
--- a/src/Components/DamageStatistics.tsx
+++ b/src/Components/DamageStatistics.tsx
@@ -121,7 +121,7 @@ function buffName(buff: PotencyModifierType) {
 		text = localize({en: "pot", zh: "爆发药"}) as string;
 	} else if (buff === PotencyModifierType.PARTY) {
 		text = localize({en: "party", zh: "团辅"}) as string;
-	} else if (buff === PotencyModifierType.HAMMER) {
+	} else if (buff === PotencyModifierType.AUTO_CDH) {
 		text = localize({en: "auto crit/direct hit", zh: "必直暴"}) as string;
 	} else if (buff === PotencyModifierType.STARRY) {
 		text = localize({en: "starry muse", zh: "星空构想"}) as string;
@@ -154,7 +154,7 @@ function BuffTag(props: {buff?: PotencyModifierType, tc?: boolean}) {
 	} else if (props.buff === PotencyModifierType.ENO) {
 		text = localize({en: "ENO", zh: "天语"});
 		color = colors.blm.enochian;
-	} else if (props.buff === PotencyModifierType.HAMMER) {
+	} else if (props.buff === PotencyModifierType.AUTO_CDH) {
 		text = localize({en: "CDH", zh: "必直暴"});
 		color = colors.resources.cdhTag;
 	} else if (props.buff === PotencyModifierType.STARRY) {

--- a/src/Game/Common.ts
+++ b/src/Game/Common.ts
@@ -19,7 +19,6 @@ export const enum Aspect {
 	Fire = "Fire",
 	Ice = "Ice",
 	Lightning = "Lightning",
-	Hammer = "Hammer",
 	Other = "Other"
 }
 

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -22,7 +22,7 @@ import {
 import {controller} from "../Controller/Controller";
 import {ActionNode} from "../Controller/Record";
 import {ShellInfo, ShellJob} from "../Controller/Common";
-import {getPotencyModifiersFromResourceState, Potency, PotencyModifier, PotencyModifierType} from "./Potency";
+import {Potency, PotencyModifier, PotencyModifierType} from "./Potency";
 import {Buff} from "./Buffs";
 
 import type {BLMState} from "./Jobs/BLM";
@@ -368,7 +368,12 @@ export abstract class GameState {
 			// potency
 			if (potency) {
 				potency.snapshotTime = this.getDisplayTime();
-				potency.modifiers = getPotencyModifiersFromResourceState(this.resources, skill.aspect);
+				const mods = [];
+				if (this.hasResourceAvailable(ResourceType.Tincture)) {
+					mods.push({source: PotencyModifierType.POT, damageFactor: 1, critFactor: 0, dhFactor: 0});
+				}
+				mods.push(...skill.jobPotencyModifiers(this));
+				potency.modifiers = mods;
 			}
 
 			// tincture
@@ -456,7 +461,12 @@ export abstract class GameState {
 				snapshotTime: this.getDisplayTime(),
 				description: "",
 			});
-			potency.modifiers = getPotencyModifiersFromResourceState(this.resources, skill.aspect);
+			const mods = [];
+			if (this.hasResourceAvailable(ResourceType.Tincture)) {
+				mods.push({source: PotencyModifierType.POT, damageFactor: 1, critFactor: 0, dhFactor: 0});
+			}
+			mods.push(...skill.jobPotencyModifiers(this));
+			potency.modifiers = mods;
 			node.addPotency(potency);
 		}
 

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -317,9 +317,9 @@ const retraceCondition = (state: Readonly<BLMState>) => (
 const paraCondition = (state: Readonly<BLMState>) => state.hasResourceAvailable(ResourceType.Paradox);
 
 const getEnochianModifier = (state: Readonly<BLMState>) => (
-	(Traits.hasUnlocked(TraitName.EnhancedEnochianIV, controller.game.config.level) && 1.33) ||
-	(Traits.hasUnlocked(TraitName.EnhancedEnochianIII, controller.game.config.level) && 1.25) ||
-	(Traits.hasUnlocked(TraitName.EnhancedEnochianII, controller.game.config.level) && 1.15) ||
+	(Traits.hasUnlocked(TraitName.EnhancedEnochianIV, state.config.level) && 1.33) ||
+	(Traits.hasUnlocked(TraitName.EnhancedEnochianIII, state.config.level) && 1.25) ||
+	(Traits.hasUnlocked(TraitName.EnhancedEnochianII, state.config.level) && 1.15) ||
 	1.10
 );
 

--- a/src/Game/Jobs/PCT.ts
+++ b/src/Game/Jobs/PCT.ts
@@ -227,7 +227,6 @@ const makeGCD_PCT = (name: SkillName, unlockLevel: number, params: {
 			if (params.jobPotencyModifiers) {
 				mods.push(...params.jobPotencyModifiers(state));
 			}
-			console.log(name, mods);
 			return mods;
 		},
 		validateAttempt: params.validateAttempt,

--- a/src/Game/Jobs/PCT.ts
+++ b/src/Game/Jobs/PCT.ts
@@ -2,7 +2,8 @@
 
 import {controller} from "../../Controller/Controller";
 import {ShellJob} from "../../Controller/Common";
-import {Aspect, ResourceType, SkillName, WarningType} from "../Common";
+import {ResourceType, SkillName, WarningType} from "../Common";
+import {PotencyModifierType} from "../Potency";
 import {
 	Ability,
 	combineEffects,
@@ -12,6 +13,7 @@ import {
 	makeResourceAbility,
 	makeSpell,
 	NO_EFFECT,
+	PotencyModifierFn,
 	Spell,
 	StatePredicate,
 } from "../Skills";
@@ -175,21 +177,22 @@ export class PCTState extends GameState {
 // If an ability appears on the hotbar only when replacing another ability, it should have
 // `startOnHotbar` set to false, and `replaceIf` set appropriately on the abilities to replace.
 
+const starryMod = {source: PotencyModifierType.STARRY, damageFactor: 1.05, critFactor: 0, dhFactor: 0};
+
 const makeGCD_PCT = (name: SkillName, unlockLevel: number, params: {
 	replaceIf?: ConditionalSkillReplace<PCTState>[],
 	startOnHotbar?: boolean,
 	highlightIf?: StatePredicate<PCTState>,
-	aspect?: Aspect,
 	baseCastTime: number,
 	baseRecastTime?: number,
 	baseManaCost?: number,
 	basePotency?: number | Array<[TraitName, number]>,
+	jobPotencyModifiers?: PotencyModifierFn<PCTState>,
 	applicationDelay: number,
 	validateAttempt?: StatePredicate<PCTState>,
 	onConfirm?: EffectFn<PCTState>,
 	onApplication?: EffectFn<PCTState>,
 }): Spell<PCTState> => {
-	const aspect = params.aspect ?? Aspect.Other;
 	const baseRecastTime = params.baseRecastTime ?? 2.5;
 	let onConfirm: EffectFn<PCTState> = combineEffects(
 		(state, node) => {
@@ -200,7 +203,9 @@ const makeGCD_PCT = (name: SkillName, unlockLevel: number, params: {
 			(name === SkillName.StarPrism) ||
 			(name === SkillName.HolyInWhite) ||
 			(name === SkillName.CometInBlack) ||
-			(aspect === Aspect.Hammer) ||
+			(name === SkillName.HammerStamp) ||
+			(name === SkillName.HammerBrush) ||
+			(name === SkillName.PolishingHammer) ||
 			state.tryConsumeResource(ResourceType.Swiftcast)
 		},
 		params.onConfirm ?? NO_EFFECT,
@@ -210,11 +215,21 @@ const makeGCD_PCT = (name: SkillName, unlockLevel: number, params: {
 		replaceIf: params.replaceIf,
 		startOnHotbar: params.startOnHotbar,
 		highlightIf: params.highlightIf,
-		aspect: aspect,
 		castTime: (state) => state.captureSpellCastTime(name, params.baseCastTime),
 		recastTime: (state) => state.captureSpellRecastTime(name, baseRecastTime),
 		manaCost: params.baseManaCost ?? 0,
 		potency: params.basePotency,
+		jobPotencyModifiers: (state) => {
+			const mods = [];
+			if (state.hasResourceAvailable(ResourceType.StarryMuse)) {
+				mods.push(starryMod);
+			}
+			if (params.jobPotencyModifiers) {
+				mods.push(...params.jobPotencyModifiers(state));
+			}
+			console.log(name, mods);
+			return mods;
+		},
 		validateAttempt: params.validateAttempt,
 		applicationDelay: params.applicationDelay,
 		isInstantFn: (state) => (
@@ -222,7 +237,9 @@ const makeGCD_PCT = (name: SkillName, unlockLevel: number, params: {
 			(name === SkillName.StarPrism) ||
 			(name === SkillName.HolyInWhite) ||
 			(name === SkillName.CometInBlack) ||
-			(aspect === Aspect.Hammer) ||
+			(name === SkillName.HammerStamp) ||
+			(name === SkillName.HammerBrush) ||
+			(name === SkillName.PolishingHammer) ||
 			state.hasResourceAvailable(ResourceType.Swiftcast)
 		),
 		onConfirm: onConfirm,
@@ -241,7 +258,12 @@ const makeAbility_PCT = (name: SkillName, unlockLevel: number, cdName: ResourceT
 	validateAttempt?: StatePredicate<PCTState>,
 	onConfirm?: EffectFn<PCTState>,
 	onApplication?: EffectFn<PCTState>,
-}): Ability<PCTState> => makeAbility(ShellJob.PCT, name, unlockLevel, cdName, params);
+}): Ability<PCTState> => makeAbility(ShellJob.PCT, name, unlockLevel, cdName, {
+	jobPotencyModifiers: (state) => (
+		state.hasResourceAvailable(ResourceType.StarryMuse) ? [starryMod] : []
+	),
+	...params,
+});
 
 // Conditions for replacing RGB/CMY on hotbar
 const redCondition: ConditionalSkillReplace<PCTState> = {
@@ -919,7 +941,6 @@ const hammerInfos: Array<[SkillName, number, number | Array<[TraitName, number]>
 ];
 hammerInfos.forEach(([name, level, potencies, applicationDelay], i) => makeGCD_PCT(name, level, {
 	replaceIf: hammerConditions.slice(0, i).concat(hammerConditions.slice(i + 1)),
-	aspect: Aspect.Hammer,
 	baseCastTime: 0,
 	startOnHotbar: i === 0,
 	basePotency: potencies,
@@ -927,6 +948,9 @@ hammerInfos.forEach(([name, level, potencies, applicationDelay], i) => makeGCD_P
 	validateAttempt: hammerConditions[i].condition,
 	onConfirm: (state) => state.tryConsumeResource(ResourceType.HammerTime),
 	highlightIf: (state) => state.hasResourceAvailable(ResourceType.HammerTime),
+	jobPotencyModifiers: (state) => [
+		{source: PotencyModifierType.AUTO_CDH, damageFactor: 1, critFactor: 1.0, dhFactor: 1.0}
+	],
 }));
 
 makeGCD_PCT(SkillName.LandscapeMotif, 70, {


### PR DESCRIPTION
Non-pot potency modifiers are now declared along with skill declarations for all skills, with the exception of T3/high thunder dot nodes. DoTs are rare enough that I think it's fine to force people to explicitly declare all modifiers for those, and would give a relatively small surface to refactor.

Tested visible potency values for some timelines of both PCT and BLM; these changes are purely cosmetic either way.