### PR TITLE
Dynamic job swapping

### DIFF
--- a/src/BlmRotations.test.ts
+++ b/src/BlmRotations.test.ts
@@ -16,8 +16,8 @@
 
 import fs from "node:fs";
 import {controller} from "./Controller/Controller";
-import {TickMode, ShellJob, ShellInfo} from "./Controller/Common";
-import {DEFAULT_CONFIG, GameConfig} from "./Game/GameConfig";
+import {TickMode, ShellJob} from "./Controller/Common";
+import {DEFAULT_BLM_CONFIG, GameConfig} from "./Game/GameConfig";
 import {PotencyModifierType} from "./Game/Potency";
 import {ResourceType, SkillName} from "./Game/Common";
 import {BLMState} from "./Game/Jobs/BLM";
@@ -93,14 +93,8 @@ afterEach(() => {
 // Run a test with the provided partial GameConfig and test function
 // Leave `params`` as an empty object to use the default config
 const testWithConfig = (params: Partial<GameConfig>, testFn: () => void) => {
-	// jest doesn't have great built-in skipping capabilities, so just don't run the test
-	// if the current job isn't BLM
-	// TODO: revisit when we can set the job dynamically
-	if (ShellInfo.job !== ShellJob.BLM) {
-		return () => console.log("skipped");
-	}
 	return () => {
-		const newConfig = {...DEFAULT_CONFIG};
+		const newConfig = {...DEFAULT_BLM_CONFIG};
 		Object.assign(newConfig, params);
 		controller.setConfigAndRestart(newConfig);
 		testFn();

--- a/src/Components/DamageStatistics.tsx
+++ b/src/Components/DamageStatistics.tsx
@@ -5,7 +5,7 @@ import {PotencyModifier, PotencyModifierType} from "../Game/Potency";
 import {getCurrentThemeColors} from "./ColorTheme";
 import {localize, localizeSkillName} from "./Localization";
 import {controller} from "../Controller/Controller";
-import {ShellJob, ShellInfo} from "../Controller/Common";
+import {ShellJob} from "../Controller/Common";
 import {
 	allSkillsAreIncluded,
 	getSkillOrDotInclude,
@@ -393,7 +393,7 @@ export class DamageStatistics extends React.Component {
 						</div>
 					}/>{colon}{ppsAvailable ? (this.data.totalPotency.applied / targetableDurationTilLastDisplay).toFixed(2) : "N/A"}</div>
 					<div>{gcdStr}</div>
-					{ShellInfo.job === ShellJob.BLM && <div>{dotStr}</div>}
+					{controller.getActiveJob() === ShellJob.BLM && <div>{dotStr}</div>}
 				</div>
 				<div style={{marginTop: 10}}>
 					<DamageStatsSettings/>
@@ -733,7 +733,7 @@ export class DamageStatistics extends React.Component {
 			{summary}
 			<div>
 				{mainTable}
-				{ShellInfo.job === ShellJob.BLM && thunderTable}
+				{controller.getActiveJob() === ShellJob.BLM && thunderTable}
 			</div>
 		</div>
 	}

--- a/src/Components/IntroSection.tsx
+++ b/src/Components/IntroSection.tsx
@@ -1,27 +1,33 @@
 import React, {CSSProperties} from 'react';
-import {ShellInfo, ShellJob} from "../Controller/Common";
+import {ShellJob} from "../Controller/Common";
 import {Expandable, Help, ButtonIndicator} from "./Common";
 import {localize} from "./Localization";
 import {DebugOptions} from "./DebugOptions";
 import changelog from "../changelog.json"
 import {getCurrentThemeColors} from "./ColorTheme";
 
-const THIS_DOMAIN = {
-	[ShellJob.BLM]: "https://miyehn.me/ffxiv-blm-rotation",
-	[ShellJob.PCT]: "https://picto.zqsz.me",
-}[ShellInfo.job];
+const THIS_DOMAIN = "https://xivintheshell.com"; // TODO
+// {
+// 	[ShellJob.BLM]: "https://miyehn.me/ffxiv-blm-rotation",
+// 	[ShellJob.PCT]: "https://picto.zqsz.me",
+// }[ShellInfo.job];
 
 const GITHUB_URL = "https://github.com/xivintheshell/xivintheshell";
 
-const HELP_CHANNEL_URL = {
-	[ShellJob.BLM]: "https://discordapp.com/channels/277897135515762698/1255782490862387360",
-	[ShellJob.PCT]: "https://discordapp.com/channels/277897135515762698/1274591512902238270",
-}[ShellInfo.job];
+const getHelpChannelUrl = (job: ShellJob) => {
+	switch (job) {
+		case ShellJob.BLM: return "https://discordapp.com/channels/277897135515762698/1255782490862387360";
+		case ShellJob.PCT: return "https://discordapp.com/channels/277897135515762698/1274591512902238270";
+		default: return "";
+	}
+}
 
-const RESOURCE_CHANNEL_URL = {
-	[ShellJob.BLM]: "https://discordapp.com/channels/277897135515762698/1255595442926915584",
-	[ShellJob.PCT]: "https://discordapp.com/channels/277897135515762698/1246222197488615524",
-}[ShellInfo.job];
+const getResourceChannel = (job: ShellJob) => {
+	switch (job) {
+		case ShellJob.BLM: return "https://discordapp.com/channels/277897135515762698/1255595442926915584";
+		case ShellJob.PCT: return "https://discordapp.com/channels/277897135515762698/1246222197488615524";
+	}
+}
 
 function Changelog() {
 	return <div className={"paragraph"}><Expandable title={"Changelog"} titleNode={localize({en: "Changelog", zh: "更新日志", ja: "更新履歴"})} defaultShow={false} content={
@@ -43,7 +49,7 @@ function Changelog() {
 }
 
 // needs to be a function to evaluate localization
-const getAcknowledgements = () => {
+const getAcknowledgements = (job: ShellJob) => {
 	return {
 		[ShellJob.BLM]: (
 			<>
@@ -74,7 +80,7 @@ const getAcknowledgements = () => {
 
 			{localize({
 				en: <div className={"paragraph"}>
-					If you have questions or would like to provide feedback, you can message in <a target={"_blank"} href={HELP_CHANNEL_URL} rel="noreferrer">this thread in The Balance</a>.
+					If you have questions or would like to provide feedback, you can message in <a target={"_blank"} href={getHelpChannelUrl(job)} rel="noreferrer">this thread in The Balance</a>.
 					You can also find me directly on discord (miyehn), or via email (ellyn.waterford@gmail.com). In case of sending a bug report, attaching the
 					fight record (download "fight.txt" from the bottom or name it anything else) would be very helpful.
 				</div>,
@@ -106,24 +112,27 @@ const getAcknowledgements = () => {
 			</div>
 			{localize({
 				en: <div className={"paragraph"}>
-					If you have questions or would like to provide feedback, you can message in <a target={"_blank"} href={HELP_CHANNEL_URL} rel="noreferrer">this thread in The Balance</a>.
+					If you have questions or would like to provide feedback, you can message in <a target={"_blank"} href={getHelpChannelUrl(job)} rel="noreferrer">this thread in The Balance</a>.
 					You can also find me directly on discord (@shanzhe in The Balance), or file an issue on GitHub (link below). In case of sending a bug report, attaching the
 					fight record (download "fight.txt" from the bottom or name it anything else) would be very helpful.
 					</div>,
 				zh: <div className={"paragraph"}>
-					如果你遇到了任何问题或想提供建议，你可以在The Balance的discord频道中的<a target={"_blank"} href={HELP_CHANNEL_URL} rel="noreferrer">【这个分支】</a>留言。你也可以直接在discord上找到我（在The Balance的频道中@shanzhe），或者在GitHub上报问题（链接在下面）。
+					如果你遇到了任何问题或想提供建议，你可以在The Balance的discord频道中的<a target={"_blank"} href={getHelpChannelUrl(job)} rel="noreferrer">【这个分支】</a>留言。你也可以直接在discord上找到我（在The Balance的频道中@shanzhe），或者在GitHub上报问题（链接在下面）。
 					如果是反馈bug，最好把能够复现bug的战斗记录文件（下方的下载战斗记录-txt格式，随意命名）一起发过来。
 					如果不方便翻墙或者想用中文反馈，也可以联系yuyuka代为传达（QQ：865835107，加时请注明来意）
 				</div>
 			})}
 			</>
 		),
-	}[ShellInfo.job];
+	}[job];
 };
 
-export function IntroSection(props: {}) {
+export function IntroSection(props: {
+	job: ShellJob,
+}) {
 	let smallGap: CSSProperties = { marginBottom: 5 };
 	let colors = getCurrentThemeColors();
+	const job = props.job;
 	return <div>
 		<Expandable
 			defaultShow={true}
@@ -256,21 +265,21 @@ export function IntroSection(props: {}) {
 					en: "This is a FFXIV " + {
 						[ShellJob.BLM]: "black mage",
 						[ShellJob.PCT]: "pictomancer",
-					}[ShellInfo.job] + " simulator & rotation planner.",
+					}[job] + " simulator & rotation planner.",
 					zh: "是个" + {
 						[ShellJob.BLM]: "黑魔",
 						[ShellJob.PCT]: "绘灵法师",
-					}[ShellInfo.job] + "模拟器/排轴工具。",
+					}[job] + "模拟器/排轴工具。",
 					ja: "FF14 " + {
 						[ShellJob.BLM]: "黒魔道士",
 						[ShellJob.PCT]: "ピクトマンサー",
-					}[ShellInfo.job] + "のスキルローテーションシミュレーターです。"})}
+					}[job] + "のスキルローテーションシミュレーターです。"})}
 				</div>
-				{getAcknowledgements()}
+				{getAcknowledgements(job)}
 				<div className="paragraph">{localize({en: "Some links:", zh: "一些链接：", ja: "リンク集"})}</div>
 				{localize({
 					en: <ul>
-						{ShellInfo.job === ShellJob.BLM && <>
+						{job === ShellJob.BLM && <>
 						<li><a href={GITHUB_URL}>Github repository</a></li>
 						<li><a href={"https://picto.zqsz.me/"}>Pictomancer in the Shell</a> by <b>shanzhe</b>, for those of you who picked up the paint brush</li>
 						<li><a href={"https://akairyugestalter.github.io/ffxiv-blm-rotation/"}>Black Mage in the Shell (Dawntrail at LV90)</a>: a variation for planning fights at LV90, created by <b>Akairyu</b></li>
@@ -278,49 +287,49 @@ export function IntroSection(props: {}) {
 						<li><a href={"https://spide-r.github.io/ffxiv-blm-rotation/"}>Black Mage in the Bozjan Shell</a>: a variation for Save the Queens areas, created by <b>A'zhek Silvaire @ Zalera</b></li>
 						<li><a href={"https://na.finalfantasyxiv.com/jobguide/blackmage/"}>Official FFXIV black mage job guide</a></li>
 						</>}
-						{ShellInfo.job === ShellJob.PCT && <>
+						{job === ShellJob.PCT && <>
 						<li><a href={GITHUB_URL}>Github repository</a></li>
 						<li><a href={"https://miyehn.me/ffxiv-blm-rotation/"}>Black Mage in the Shell</a></li>
 						<li><a href={"https://na.finalfantasyxiv.com/jobguide/pictomancer/"}>Official FFXIV pictomancer job guide</a></li>
 						</>}
-						<li><a target={"_blank"} href={RESOURCE_CHANNEL_URL} rel="noreferrer">
-							{ShellInfo.job} resources channel on The Balance</a> (make sure you've already joined the server)</li>
+						<li><a target={"_blank"} href={getResourceChannel(job)} rel="noreferrer">
+							{job} resources channel on The Balance</a> (make sure you've already joined the server)</li>
 					</ul>,
 					zh: <ul>
-						{ShellInfo.job === ShellJob.BLM && <>
+						{job === ShellJob.BLM && <>
 						<li><a href={GITHUB_URL}>Github页面</a></li>
 						<li><a href={"https://picto.zqsz.me/"}>绘灵法师排轴器</a>，由<b>shanzhe</b>制作并维护，给那些拾起了画笔的黑黑</li>
 						<li><a href={"https://akairyugestalter.github.io/ffxiv-blm-rotation/"}>7.x版排轴器（90级）</a>，可以用来给TOP等副本排轴，作者是<b>Akairyu</b></li>
 						<li><a href={"https://miyehn.me/ffxiv-blm-rotation-endwalker/"}>6.x版排轴器</a>，历史版本。那里也公开展示着一些6.x时期的轴作为纪念。</li>
 						<li><a href={"https://spide-r.github.io/ffxiv-blm-rotation/"}>博兹雅版排轴器（Black Mage in the Bozjan Shell）</a>: 本工具的博兹雅/天佑女王版。制作者： <b>A'zhek Silvaire @ Zalera</b></li>
 						<li><a href={"https://na.finalfantasyxiv.com/jobguide/blackmage/"}>官方的黑魔法师职业介绍</a></li>
-						<li><a target={"_blank"} href={RESOURCE_CHANNEL_URL} rel="noreferrer">
+						<li><a target={"_blank"} href={getResourceChannel(job)} rel="noreferrer">
 							The Balance服务器里的黑魔频道</a> （需要先加入Discord服务器）</li>
 						</>}
-						{ShellInfo.job === ShellJob.PCT && <>
+						{job === ShellJob.PCT && <>
 						<li><a href={GITHUB_URL}>Github页面</a></li>
 						<li><a href={"https://miyehn.me/ffxiv-blm-rotation/"}>Black Mage in the Shell</a></li>
-						<li><a target={"_blank"} href={RESOURCE_CHANNEL_URL} rel="noreferrer">
+						<li><a target={"_blank"} href={getResourceChannel(job)} rel="noreferrer">
 							The Balance服务器里的PCT频道</a> （需要先加入Discord服务器）</li>
 						</>}
 					</ul>,
 					ja: <ul>
-						{ShellInfo.job === ShellJob.BLM && <>
+						{job === ShellJob.BLM && <>
 						<li><a href={"https://github.com/miyehn/ffxiv-blm-rotation"}>Github repository</a></li>
 						<li><a href={"https://spide-r.github.io/ffxiv-blm-rotation/"}>Black Mage in the Bozjan Shell</a>: 南方ボズヤ戦線向けのツール。作者：<b>A'zhek Silvaire @ Zalera</b></li>
 						<li><a href={"https://na.finalfantasyxiv.com/jobguide/blackmage/"}>Official FFXIV black mage job guide</a></li>
-						<li><a target={"_blank"} href={RESOURCE_CHANNEL_URL} rel="noreferrer">
+						<li><a target={"_blank"} href={getResourceChannel(job)} rel="noreferrer">
 							BLM resources channel on The Balance</a> （ぜひDiscordサーバーに参加してください。） </li>
 						</>}
-						{ShellInfo.job === ShellJob.PCT && <>
+						{job === ShellJob.PCT && <>
 						<li><a href={GITHUB_URL}>Github repository</a></li>
 						<li><a href={"https://miyehn.me/ffxiv-blm-rotation/"}>Black Mage in the Shell</a></li>
-						<li><a target={"_blank"} href={RESOURCE_CHANNEL_URL} rel="noreferrer">
-							{ShellInfo.job} resources channel on The Balance</a> （ぜひDiscordサーバーに参加してください。） </li>
+						<li><a target={"_blank"} href={getResourceChannel(job)} rel="noreferrer">
+							{job} resources channel on The Balance</a> （ぜひDiscordサーバーに参加してください。） </li>
 						</>}
 					</ul>,
 				})}
-				{ShellInfo.job === ShellJob.PCT &&
+				{job === ShellJob.PCT &&
 				<div className="paragraph"><Expandable title={"Known issues"} titleNode={localize({en: "Known issues"})} defaultShow={false} content={
 					<div>
 					{localize({
@@ -343,7 +352,7 @@ export function IntroSection(props: {}) {
 				}/>
 				</div>
 				}
-				{ShellInfo.job === ShellJob.BLM &&
+				{job === ShellJob.BLM &&
 				<div className="paragraph"><Expandable title={"Implementation notes"} titleNode={localize({en: "Implementation notes", zh: "实现细节", ja: "実装に関するメモ"})} defaultShow={false} content={
 					<div>
 						{localize({

--- a/src/Components/Skills.tsx
+++ b/src/Components/Skills.tsx
@@ -2,7 +2,6 @@ import React, {FormEvent, FormEventHandler} from 'react'
 import {Clickable, ContentNode, Help, parseTime, ValueChangeEvent} from "./Common";
 import {Debug, SkillName, SkillReadyStatus} from "../Game/Common";
 import {controller} from "../Controller/Controller";
-import {ShellInfo} from "../Controller/Common";
 import {Tooltip as ReactTooltip} from 'react-tooltip';
 import {ActionType} from "../Controller/Record";
 import {localize, localizeSkillName} from "./Localization";
@@ -19,7 +18,7 @@ export const getSkillIconPath = (skillName: SkillName | undefined) => {
 	if (!skillName) {
 		return undefined;
 	}
-	const skill = getSkill(ShellInfo.job, skillName);
+	const skill = getSkill(controller.getActiveJob(), skillName);
 	if (skill) {
 		return require(`./Asset/Skills/${skill.assetPath}`);
 	}
@@ -30,7 +29,7 @@ export const getSkillIconImage = (skillName: SkillName) => {
 	if (skillIconImages.has(skillName)) {
 		return skillIconImages.get(skillName);
 	}
-	const skill = getSkill(ShellInfo.job, skillName);
+	const skill = getSkill(controller.getActiveJob(), skillName);
 	if (skill) {
 		let imgObj = new Image();
 		imgObj.src = require(`./Asset/Skills/${skill.assetPath}`);

--- a/src/Components/Skills.tsx
+++ b/src/Components/Skills.tsx
@@ -8,7 +8,7 @@ import {localize, localizeSkillName} from "./Localization";
 import {updateTimelineView} from "./Timeline";
 import * as ReactDOMServer from 'react-dom/server';
 import {getCurrentThemeColors} from "./ColorTheme";
-import {getSkill} from "../Game/Skills";
+import {getSkillAssetPath} from "../Game/Skills";
 
 // Game/Jobs/* must be run first to ensure all skills have been registered, so we need to
 // load images lazily to ensure we're not dependent on webpack's module resolution order.
@@ -18,9 +18,9 @@ export const getSkillIconPath = (skillName: SkillName | undefined) => {
 	if (!skillName) {
 		return undefined;
 	}
-	const skill = getSkill(controller.getActiveJob(), skillName);
-	if (skill) {
-		return require(`./Asset/Skills/${skill.assetPath}`);
+	const assetPath = getSkillAssetPath(skillName);
+	if (assetPath) {
+		return require(`./Asset/Skills/${assetPath}`);
 	}
 	return undefined;
 };
@@ -29,10 +29,10 @@ export const getSkillIconImage = (skillName: SkillName) => {
 	if (skillIconImages.has(skillName)) {
 		return skillIconImages.get(skillName);
 	}
-	const skill = getSkill(controller.getActiveJob(), skillName);
-	if (skill) {
+	const assetPath = getSkillAssetPath(skillName);
+	if (assetPath) {
 		let imgObj = new Image();
-		imgObj.src = require(`./Asset/Skills/${skill.assetPath}`);
+		imgObj.src = require(`./Asset/Skills/${assetPath}`);
 		imgObj.onload = () => updateTimelineView();
 		skillIconImages.set(skillName, imgObj);
 		return imgObj;

--- a/src/Components/TimelineMarkers.tsx
+++ b/src/Components/TimelineMarkers.tsx
@@ -10,7 +10,7 @@ import {
 	SaveToFile
 } from "./Common";
 import {controller} from "../Controller/Controller";
-import {ShellInfo, ShellJob} from "../Controller/Common";
+import {ShellJob} from "../Controller/Common";
 import {ElemType, MarkerElem, MarkerType, UntargetableMarkerTrack} from "../Controller/Timeline";
 import {localize, localizeBuffType} from "./Localization";
 import {getCurrentThemeColors, MarkerColor} from "./ColorTheme";
@@ -22,7 +22,7 @@ export let setEditingMarkerValues = (marker: MarkerElem)=>{};
 
 export let updateMarkers_TimelineMarkerPresets = (trackBins: Map<number, MarkerElem[]>) => {};
 
-const PRESET_MARKERS_BASE = (ShellInfo.job === ShellJob.BLM) ? "/ffxiv-blm-rotation/presets/markers/" : "/presets/markers/";
+const PRESET_MARKERS_BASE = "/presets/markers/";
 
 type TimelineMarkersProp = {};
 type TimelineMarkersState = {
@@ -238,7 +238,7 @@ export class TimelineMarkers extends React.Component {
 		let buffCollection: JSX.Element[] = [];
 		buffInfos.forEach(info => {
 			// prevent starry from being selectable if we're the pictomancer
-			if (!(ShellInfo.job === ShellJob.PCT && info.name === BuffType.StarryMuse)) {
+			if (!(controller.getActiveJob() === ShellJob.PCT && info.name === BuffType.StarryMuse)) {
 				buffCollection.push(<option key={info.name} value={info.name}>{localizeBuffType(info.name)}</option>)
 			}
 		});

--- a/src/Controller/Common.ts
+++ b/src/Controller/Common.ts
@@ -17,14 +17,24 @@ export const enum TickMode {
 	Manual = 2
 }
 
+// Enum representing major updates that affect serialized or in-localStorage representations
+// of timelines.
 export const enum ShellVersion {
 	Initial = 0,
-	FpsTax = 1
+	FpsTax = 1, // extra FPS field added to GameConfig
+	DynamicJob = 2, // job moved from global variable to per-GameState variable
 }
 
 export const enum ShellJob {
 	BLM = "BLM",
 	PCT = "PCT",
+}
+
+export function getLongJobName(job: ShellJob) {
+	switch (job) {
+		case ShellJob.BLM: return "Black Mage";
+		case ShellJob.PCT: return "Pictomancer";
+	}
 }
 
 // can't get this automatically from a const enum
@@ -36,8 +46,7 @@ export const enum Expansion {
 }
 
 export const ShellInfo = {
-	version: ShellVersion.FpsTax,
-	job: ShellJob.BLM,
+	version: ShellVersion.DynamicJob,
 	// thisExpansion is not exported so it stays local outside
 };
 

--- a/src/Controller/Common.ts
+++ b/src/Controller/Common.ts
@@ -17,12 +17,9 @@ export const enum TickMode {
 	Manual = 2
 }
 
-// Enum representing major updates that affect serialized or in-localStorage representations
-// of timelines.
 export const enum ShellVersion {
 	Initial = 0,
 	FpsTax = 1, // extra FPS field added to GameConfig
-	DynamicJob = 2, // job moved from global variable to per-GameState variable
 }
 
 export const enum ShellJob {
@@ -46,7 +43,7 @@ export const enum Expansion {
 }
 
 export const ShellInfo = {
-	version: ShellVersion.DynamicJob,
+	version: ShellVersion.FpsTax,
 	// thisExpansion is not exported so it stays local outside
 };
 

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -376,7 +376,6 @@ class Controller {
 		if (content.config.job === undefined) {
 			// infer the job based on actions present
 			content.config.job = inferJobFromActions(content.actions);
-			content.config.shellVersion = ShellVersion.DynamicJob;
 		}
 
 		let gameConfig = new GameConfig(content.config);

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -6,10 +6,11 @@ import {
 	ShellInfo,
 	ShellJob,
 	ShellVersion,
-	TickMode
+	TickMode,
+	ALL_JOBS,
 } from "./Common";
 import {GameState} from "../Game/GameState";
-import {getAutoReplacedSkillName, getConditionalReplacement, getNormalizedSkillName} from "../Game/Skills";
+import {getAutoReplacedSkillName, getConditionalReplacement, getNormalizedSkillName, jobHasSkill} from "../Game/Skills";
 import {BLMState} from "../Game/Jobs/BLM";
 import {PCTState} from "../Game/Jobs/PCT";
 import {Buff} from "../Game/Buffs";
@@ -20,7 +21,7 @@ import {PCTStatusPropsGenerator} from "../Components/Jobs/PCT";
 import {updateStatusDisplay} from "../Components/StatusDisplay";
 import {updateSkillButtons} from "../Components/Skills";
 import {updateConfigDisplay} from "../Components/PlaybackControl"
-import {setHistorical, setRealTime} from "../Components/Main";
+import {setJob, setHistorical, setRealTime} from "../Components/Main";
 import {ElemType, MAX_TIMELINE_SLOTS, Timeline} from "./Timeline"
 import {scrollTimelineTo, updateTimelineView} from "../Components/Timeline";
 import {ActionNode, ActionType, Line, Record} from "./Record";
@@ -45,10 +46,29 @@ require("../Game/Jobs/RoleActions");
 type Fixme = any;
 
 const newGameState = (config: GameConfig) => {
-	if (ShellInfo.job === ShellJob.PCT) {
+	if (config.job === ShellJob.PCT) {
 		return new PCTState(config);
 	}
 	return new BLMState(config);
+};
+
+const inferJobFromActions = (actions: object[]) => {
+	// Iterate over the whole record and return the number of actions that occur in each job.
+	// If two jobs are tied (like if there's only a Swiftcast/Sprint in the timeline), just
+	// take the first that appears since it doesn't really matter.
+	let maxJob = ALL_JOBS[0];
+	let maxCount = 0;
+	ALL_JOBS.forEach((job) => {
+		const count = actions.reduce(
+			(acc, skill) => (skill as any).skillName && jobHasSkill(job, getNormalizedSkillName((skill as any).skillName)!) ? acc + 1 : acc,
+			0,
+		);
+		if (count > maxCount) {
+			maxJob = job;
+			maxCount = count;
+		}
+	});
+	return maxJob;
 };
 
 class Controller {
@@ -353,6 +373,11 @@ class Controller {
 		if (content.config.shellVersion === undefined) {
 			content.config.shellVersion = ShellVersion.Initial;
 		}
+		if (content.config.job === undefined) {
+			// infer the job based on actions present
+			content.config.job = inferJobFromActions(content.actions);
+			content.config.shellVersion = ShellVersion.DynamicJob;
+		}
 
 		let gameConfig = new GameConfig(content.config);
 
@@ -643,7 +668,7 @@ class Controller {
 			canMove: game.resources.get(ResourceType.Movement).available(1),
 		};
 		if (typeof updateStatusDisplay !== "undefined") {
-			const propsGenerator = ShellInfo.job === ShellJob.PCT
+			const propsGenerator = game.job === ShellJob.PCT
 				? new PCTStatusPropsGenerator(game as PCTState)
 				: new BLMStatusPropsGenerator(game as BLMState);
 			updateStatusDisplay({
@@ -710,6 +735,7 @@ class Controller {
 	}
 
 	setConfigAndRestart(props: {
+		job: ShellJob,
 		level: LevelSync,
 		spellSpeed: number,
 		criticalHit: number,
@@ -724,6 +750,7 @@ class Controller {
 		procMode: ProcMode,
 		initialResourceOverrides: any[],
 	}) {
+		const oldJob = this.gameConfig.job;
 		this.gameConfig = new GameConfig({
 			...props,
 			shellVersion: ShellInfo.version,
@@ -734,12 +761,21 @@ class Controller {
 
 		this.#requestRestart();
 		this.#applyResourceOverrides(this.gameConfig);
+		// Propagate changes to the intro section (definitely not idiomatic react... maybe we
+		// should just make the text static for all jobs)
+		if (oldJob !== props.job) {
+			setJob(props.job);
+		}
 
 		this.autoSave();
 	}
 
 	getDisplayedGame() : GameState {
 		return this.displayingUpToDateGameState ? this.game : this.savedHistoricalGame;
+	}
+
+	getActiveJob(): ShellJob {
+		return this.getDisplayedGame().job;
 	}
 
 	getSkillInfo(props: {game: GameState, skillName: SkillName}) {

--- a/src/Controller/DamageStatistics.ts
+++ b/src/Controller/DamageStatistics.ts
@@ -10,7 +10,7 @@ import {
 } from "../Components/DamageStatistics";
 import {PotencyModifier, PotencyModifierType} from "../Game/Potency";
 import type {BLMState} from "../Game/Jobs/BLM";
-import {ShellInfo, ShellJob} from "./Common";
+import {ShellJob} from "./Common";
 
 // TODO autogenerate everything here
 
@@ -167,9 +167,7 @@ function expandNode(node: ActionNode) : ExpandedNode {
 				const tag = modifier.source;
 				if (tag !== PotencyModifierType.ENO && tag !== PotencyModifierType.POT) {
 					res.displayedModifiers.push(tag);
-					if (ShellInfo.job === ShellJob.BLM) {
-						break;
-					}
+					break;
 				}
 			}
 		} else if (enoSkills.has(node.skillName)) {

--- a/src/Game/GameConfig.ts
+++ b/src/Game/GameConfig.ts
@@ -4,6 +4,7 @@ import {ShellInfo, ShellJob, ShellVersion} from "../Controller/Common";
 import {XIVMath} from "./XIVMath";
 
 export type ConfigData = {
+	job: ShellJob,
 	shellVersion: ShellVersion,
 	level: LevelSync,
 	spellSpeed: number,
@@ -20,7 +21,8 @@ export type ConfigData = {
 	initialResourceOverrides: ResourceOverrideData[]
 }
 
-const DEFAULT_BLM_CONFIG: ConfigData = {
+export const DEFAULT_BLM_CONFIG: ConfigData = {
+	job: ShellJob.BLM,
 	shellVersion: ShellInfo.version,
 	level: LevelSync.lvl100,
 	// 2.37 GCD
@@ -38,7 +40,8 @@ const DEFAULT_BLM_CONFIG: ConfigData = {
 	initialResourceOverrides: []
 };
 
-const DEFAULT_PCT_CONFIG: ConfigData = {
+export const DEFAULT_PCT_CONFIG: ConfigData = {
+	job: ShellJob.PCT,
 	shellVersion: ShellInfo.version,
 	level: LevelSync.lvl100,
 	// 7.05 2.5 GCD bis https://xivgear.app/?page=sl%7C4c102326-839a-43c8-84ae-11ffdb6ef4a2
@@ -56,16 +59,18 @@ const DEFAULT_PCT_CONFIG: ConfigData = {
 	initialResourceOverrides: []
 };
 
-export const DEFAULT_CONFIG: ConfigData = {
-	[ShellJob.BLM]: DEFAULT_BLM_CONFIG,
-	[ShellJob.PCT]: DEFAULT_PCT_CONFIG,
-}[ShellInfo.job];
+export const DEFAULT_CONFIG: ConfigData = DEFAULT_BLM_CONFIG; // TODO
+// {
+// 	[ShellJob.BLM]: DEFAULT_BLM_CONFIG,
+// 	[ShellJob.PCT]: DEFAULT_PCT_CONFIG,
+// }[ShellInfo.job];
 
 export type SerializedConfig = ConfigData & {
 	casterTax: number, // still want this bc don't want to break cached timelines
 }
 
 export class GameConfig {
+	readonly job: ShellJob;
 	readonly shellVersion = ShellInfo.version;
 	readonly level: LevelSync;
 	readonly spellSpeed: number;
@@ -83,6 +88,7 @@ export class GameConfig {
 	readonly legacy_casterTax: number;
 
 	constructor(props: {
+		job: ShellJob,
 		shellVersion: ShellVersion,
 		level: LevelSync,
 		spellSpeed: number,
@@ -99,6 +105,7 @@ export class GameConfig {
 		initialResourceOverrides: (ResourceOverrideData & {enabled?: boolean})[],
 		casterTax?: number, // legacy
 	}) {
+		this.job = props.job;
 		this.shellVersion = props.shellVersion;
 		this.level = props.level ?? DEFAULT_CONFIG.level;
 		this.spellSpeed = props.spellSpeed;
@@ -175,6 +182,7 @@ export class GameConfig {
 
 	serialized() {
 		return {
+			job: this.job,
 			shellVersion: this.shellVersion,
 			level: this.level,
 			spellSpeed: this.spellSpeed,

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -21,7 +21,7 @@ import {
 
 import {controller} from "../Controller/Controller";
 import {ActionNode} from "../Controller/Record";
-import {ShellInfo, ShellJob} from "../Controller/Common";
+import {ShellJob} from "../Controller/Common";
 import {Potency, PotencyModifier, PotencyModifierType} from "./Potency";
 import {Buff} from "./Buffs";
 
@@ -49,7 +49,7 @@ export abstract class GameState {
 
 	constructor(config: GameConfig) {
 		this.config = config;
-		this.job = ShellInfo.job; // TODO make this configurable
+		this.job = config.job;
 		this.rng = new SeedRandom(config.randomSeed);
 		this.nonProcRng = new SeedRandom(config.randomSeed + "_nonProcs");
 		this.lucidTickOffset = this.nonProcRng() * 3.0;

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -36,7 +36,6 @@ type RNG = any;
 // GameState := resources + events queue
 export abstract class GameState {
 	config: GameConfig;
-	job: ShellJob;
 	rng: RNG;
 	nonProcRng: RNG; // use this for things other than procs (actor tick offsets, for example)
 	lucidTickOffset: number;
@@ -49,7 +48,6 @@ export abstract class GameState {
 
 	constructor(config: GameConfig) {
 		this.config = config;
-		this.job = config.job;
 		this.rng = new SeedRandom(config.randomSeed);
 		this.nonProcRng = new SeedRandom(config.randomSeed + "_nonProcs");
 		this.lucidTickOffset = this.nonProcRng() * 3.0;
@@ -94,6 +92,10 @@ export abstract class GameState {
 		// SKILLS (instantiated once, read-only later)
 		this.skillsList = new SkillsList(this);
 		this.displayedSkills = new DisplayedSkills(this.job, config.level);
+	}
+
+	get job(): ShellJob {
+		return this.config.job;
 	}
 
 	/**

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -1,5 +1,5 @@
 import {Debug, ResourceType} from "./Common"
-import {ShellInfo, ShellJob, ALL_JOBS} from "../Controller/Common";
+import {ShellJob, ALL_JOBS} from "../Controller/Common";
 import {GameState} from "./GameState";
 import {ActionNode} from "../Controller/Record";
 import {BLMState} from "./Jobs/BLM";
@@ -383,7 +383,7 @@ export class ResourceOverride {
 	// other buffs: time till drop
 	// MP, AF, UI, UH, Paradox, Polyglot: amount (stacks)
 	applyTo(game: GameState) {
-		let info = getAllResources(ShellInfo.job).get(this.type);
+		let info = getAllResources(game.job).get(this.type);
 		if (!info) {
 			console.assert(false);
 			return;

--- a/src/Game/Skills.ts
+++ b/src/Game/Skills.ts
@@ -147,6 +147,8 @@ export type Skill<T extends PlayerState> = Spell<T> | Weaponskill<T> | Ability<T
 // Unfortunately, I [sz] don't really know of a good way to encode the relationship between
 // the ShellJob and Skill<T>, so we'll just have to live with performing casts at certain locations.
 const skillMap: Map<ShellJob, Map<SkillName, Skill<PlayerState>>> = new Map();
+// Track asset paths for all skills so we can load icons for multiple timelines
+const skillAssetPaths: Map<SkillName, string> = new Map();
 
 const normalizedSkillNameMap = new Map<string, SkillName>();
 /**
@@ -165,6 +167,10 @@ export function getSkill<T extends PlayerState>(job: ShellJob, skillName: SkillN
 	return skillMap.get(job)!.get(skillName)!;
 }
 
+export function getSkillAssetPath(skillName: SkillName): string | undefined {
+	return skillAssetPaths.get(skillName);
+}
+
 // Return true if the provided skill is valid for the job.
 export function jobHasSkill(job: ShellJob, skillName: SkillName): boolean {
 	return skillMap.get(job)!.has(skillName);
@@ -178,6 +184,7 @@ export function getAllSkills<T extends PlayerState>(job: ShellJob): Map<SkillNam
 function setSkill<T extends PlayerState>(job: ShellJob, skillName: SkillName, skill: Skill<T>) {
 	skillMap.get(job)!.set(skillName, skill as Skill<PlayerState>);
 	normalizedSkillNameMap.set(skillName.toLowerCase(), skillName);
+	skillAssetPaths.set(skillName, skill.assetPath);
 }
 
 ALL_JOBS.forEach((job) => skillMap.set(job, new Map()));

--- a/src/PctTraitPotencies.test.ts
+++ b/src/PctTraitPotencies.test.ts
@@ -2,19 +2,11 @@ import {ShellInfo, ShellJob} from "./Controller/Common";
 import {controller} from "./Controller/Controller";
 import {LevelSync, SkillName} from "./Game/Common";
 import {getSkill} from "./Game/Skills"
+import {DEFAULT_PCT_CONFIG} from "./Game/GameConfig";
 
 // test the potency of Fire in Red since it gets changed by trait at every level sync
 const testRedPotency = (level: LevelSync, expectedPotency: number) => {
-    // jest doesn't have great built-in skipping capabilities, so just don't run the test
-    // if the current job isn't PCT
-    // TODO: revisit when we can set the job dynamically
-    if (ShellInfo.job !== ShellJob.PCT) {
-        console.log("skipped");
-        return;
-    }
-    let newConfig = {
-        ...controller.gameConfig
-    };
+    const newConfig = {...DEFAULT_PCT_CONFIG};
     newConfig["level"] = level;
     controller.setConfigAndRestart(newConfig);
     const red = getSkill(ShellJob.PCT, SkillName.FireInRed);


### PR DESCRIPTION
Adds dynamic job swapping.

![image](https://github.com/user-attachments/assets/369cb36c-d304-417c-9e96-94392c4457c1)

I've punted on UI decisions in this PR ([see discord discussion](https://discord.com/channels/277897135515762698/1255782490862387360/1297036718972600410)), and just added it as a generic config variable, feel free to push to this branch to change @miyehn (or just change it after this is merged).

Notes:
- A new `job` field is added to the `GameConfig` class, and `ShellVersion` has been incremented.
- Changing the configured job won't take effect until "apply and reset" is hit and the timeline is wiped clean, just as with any other configuration variable.
- There's a minor stutter for icons to reload when a job-swapping configuration is applied--it's not super major since it happens pretty fast, but adding a loading spinner or similar would make it look nicer.
- Any old fight plans in localStorage (or loaded via import) have a job inferred from actions in the timeline.
- Text in `IntroSection.tsx` is updated with an explicit update call from the controller, we may need to double check if this causes any perf/load time regression since it doesn't match up well with the natural react lifecycle. We could also consider just using a single unified `IntroSection` for all jobs (maybe just swapping the help channel/resources links) since we'll all be on the same website.