### PR TITLE
Active timeline slot handle color based on job; PCT resource color adjustments

### DIFF
--- a/src/Components/ColorTheme.tsx
+++ b/src/Components/ColorTheme.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {MdDarkMode, MdLightMode} from "react-icons/md";
-import {getCachedValue, setCachedValue} from "../Controller/Common";
+import {getCachedValue, setCachedValue, ShellJob} from "../Controller/Common";
 import {controller} from "../Controller/Controller";
 
 export type ColorTheme = "Light" | "Dark";
@@ -41,8 +41,14 @@ export type PCTResourceColors = {
 	starryBuff: string,
 }
 
+export type JobAccentColors = {
+	[ShellJob.BLM]: string,
+	[ShellJob.PCT]: string
+}
+
 export type ThemeColors = {
 	accent: string,
+	jobAccents: JobAccentColors,
 	realTime: string,
 	historical: string,
 	fileDownload: string,
@@ -86,7 +92,11 @@ export let getCurrentThemeColors: ()=>ThemeColors = () => {
 	let currentColorTheme = getCurrentColorTheme();
 	if (currentColorTheme === "Dark") {
 		return {
-			accent: "#9370db", // medium purple
+			accent: "mediumpurple",
+			jobAccents: {
+				[ShellJob.BLM]: "#9370db", // mediumpurple
+				[ShellJob.PCT]: "#e176c2",
+			},
 			realTime: "mediumseagreen",
 			historical: "#ff8c00", // darkorange
 			fileDownload: "#798c3f",
@@ -116,12 +126,12 @@ export let getCurrentThemeColors: ()=>ThemeColors = () => {
 				polyStacks: "#b138ee",
 			},
 			pct: {
-				creatureCanvas: "#863ab5",
-				weaponCanvas: "#8d3741",
-				landscapeCanvas: "#264195",
+				creatureCanvas: "#a948e3",
+				weaponCanvas: "#a53535",
+				landscapeCanvas: "#2e51dd",
 				paletteGauge: "#b69241",
-				holyPaint: "#dde0e5",  // blue-ish light gray
-				cometPaint: "#500050",  // purple-ish black
+				holyPaint: "#cacdd5",  // blue-ish light gray
+				cometPaint: "#7e19aa",  // purple-ish black
 				starryBuff: "#509bd5",
 			},
 			timeline: {
@@ -142,9 +152,13 @@ export let getCurrentThemeColors: ()=>ThemeColors = () => {
 				markerAlpha: "4f"
 			}
 		};
-	} else {
+	} else { // Light mode
 		return {
-			accent: "#9370db", // mediumpurple
+			accent: "mediumpurple",
+			jobAccents: {
+				[ShellJob.BLM]: "#9370db", // mediumpurple
+				[ShellJob.PCT]: "#f485d6",
+			},
 			realTime: "mediumseagreen",
 			historical: "#ff8c00", // darkorange
 			fileDownload: "#798c3f",
@@ -174,12 +188,12 @@ export let getCurrentThemeColors: ()=>ThemeColors = () => {
 				polyStacks: "#b138ee",
 			},
 			pct: {
-				creatureCanvas: "#863ab5",
-				weaponCanvas: "#8d3741",
-				landscapeCanvas: "#264195",
-				paletteGauge: "#b69241",
-				holyPaint: "#dde0e5",  // blue-ish light gray
-				cometPaint: "#500050",  // purple-ish black
+				creatureCanvas: "#b854e8",
+				weaponCanvas: "#d54d48",
+				landscapeCanvas: "#4568f6",
+				paletteGauge: "#f5cf96",
+				holyPaint: "#cacdd5",  // blue-ish light gray
+				cometPaint: "#9926c8",  // purple-ish black
 				starryBuff: "#66bbff",
 			},
 			timeline: {

--- a/src/Components/ColorTheme.tsx
+++ b/src/Components/ColorTheme.tsx
@@ -130,7 +130,7 @@ export let getCurrentThemeColors: ()=>ThemeColors = () => {
 				weaponCanvas: "#a53535",
 				landscapeCanvas: "#2e51dd",
 				paletteGauge: "#b69241",
-				holyPaint: "#cacdd5",  // blue-ish light gray
+				holyPaint: "#9bc6dd",  // blue-ish light gray
 				cometPaint: "#7e19aa",  // purple-ish black
 				starryBuff: "#509bd5",
 			},
@@ -192,7 +192,7 @@ export let getCurrentThemeColors: ()=>ThemeColors = () => {
 				weaponCanvas: "#d54d48",
 				landscapeCanvas: "#4568f6",
 				paletteGauge: "#f5cf96",
-				holyPaint: "#cacdd5",  // blue-ish light gray
+				holyPaint: "#b7c9d5",  // blue-ish light gray
 				cometPaint: "#9926c8",  // purple-ish black
 				starryBuff: "#66bbff",
 			},

--- a/src/Components/TimelineCanvas.tsx
+++ b/src/Components/TimelineCanvas.tsx
@@ -820,8 +820,7 @@ export function drawTimelines(originX: number, originY: number, isImageExportMod
 			w: 14,
 			h: TimelineDimensions.renderSlotHeight() - 2
 		};
-		// don't think very low contrast works well here so turning it off for now..
-		g_ctx.fillStyle = slot === g_renderingProps.activeSlotIndex ? g_colors.jobAccents[g_renderingProps.slots[slot].job] : g_colors.bgMediumContrast;
+		g_ctx.fillStyle = slot === g_renderingProps.activeSlotIndex ? g_colors.accent : g_colors.bgMediumContrast;
 		g_ctx.fillRect(handle.x, handle.y, handle.w, handle.h);
 		testInteraction(handle, slot===g_renderingProps.activeSlotIndex ? undefined : [localize({en: "set active", zh: "设为当前"}) as string], () => {
 			controller.setActiveSlot(slot);

--- a/src/Components/TimelineCanvas.tsx
+++ b/src/Components/TimelineCanvas.tsx
@@ -24,6 +24,7 @@ import {getCurrentThemeColors, ThemeColors} from "./ColorTheme";
 import {scrollEditorToFirstSelected} from "./TimelineEditor";
 import {bossIsUntargetable} from "../Controller/DamageStatistics";
 import {updateTimelineView} from "./Timeline";
+import {ShellJob} from "../Controller/Common";
 
 export type TimelineRenderingProps = {
 	timelineWidth: number,
@@ -36,7 +37,10 @@ export type TimelineRenderingProps = {
 	untargetableMarkers: MarkerElem[],
 	buffMarkers: MarkerElem[],
 	sharedElements: SharedTimelineElem[],
-	slotElements: SlotTimelineElem[][],
+	slots: {
+		job: ShellJob,
+		elements: SlotTimelineElem[]
+	}[],
 	activeSlotIndex: number,
 	showSelection: boolean,
 	selectionStartDisplayTime: number,
@@ -76,7 +80,7 @@ let g_renderingProps: TimelineRenderingProps = {
 	buffMarkers: [],
 	untargetableMask: true,
 	sharedElements: [],
-	slotElements: [],
+	slots: [],
 	activeSlotIndex: 0,
 	showSelection: false,
 	selectionStartDisplayTime: 0,
@@ -737,7 +741,7 @@ export function drawTimelines(originX: number, originY: number, isImageExportMod
 	// fragCoord.x of displayTime=0
 	const displayOriginX = originX + StaticFn.positionFromTimeAndScale(g_renderingProps.countdown, g_renderingProps.scale);
 
-	for (let slot = 0; slot < g_renderingProps.slotElements.length; slot++) {
+	for (let slot = 0; slot < g_renderingProps.slots.length; slot++) {
 
 		let isActiveSlot = slot === g_renderingProps.activeSlotIndex;
 		let elemBins = new Map<ElemType, TimelineElem[]>();
@@ -745,7 +749,7 @@ export function drawTimelines(originX: number, originY: number, isImageExportMod
 			// Only draw the active timeline in export mode
 			continue;
 		}
-		g_renderingProps.slotElements[slot].forEach(e=>{
+		g_renderingProps.slots[slot].elements.forEach(e=>{
 			let arr = elemBins.get(e.type) ?? [];
 			arr.push(e);
 			elemBins.set(e.type, arr);
@@ -796,8 +800,8 @@ export function drawTimelines(originX: number, originY: number, isImageExportMod
 	}
 	// countdown grey rect
 	let countdownWidth = StaticFn.positionFromTimeAndScale(g_renderingProps.countdown, g_renderingProps.scale);
-	let countdownHeight = TimelineDimensions.renderSlotHeight() * g_renderingProps.slotElements.length;
-	if (g_renderingProps.slotElements.length < MAX_TIMELINE_SLOTS) countdownHeight += TimelineDimensions.addSlotButtonHeight;
+	let countdownHeight = TimelineDimensions.renderSlotHeight() * g_renderingProps.slots.length;
+	if (g_renderingProps.slots.length < MAX_TIMELINE_SLOTS) countdownHeight += TimelineDimensions.addSlotButtonHeight;
 	g_ctx.fillStyle = g_colors.timeline.countdown;
 	// make it cover the left padding as well:
 	g_ctx.fillRect(originX - TimelineDimensions.leftBufferWidth, originY, countdownWidth + TimelineDimensions.leftBufferWidth, countdownHeight);
@@ -808,7 +812,7 @@ export function drawTimelines(originX: number, originY: number, isImageExportMod
 	}
 
 	// slot selection bars
-	for (let slot = 0; slot < g_renderingProps.slotElements.length; slot++) {
+	for (let slot = 0; slot < g_renderingProps.slots.length; slot++) {
 		let currentY = originY + slot * TimelineDimensions.renderSlotHeight();
 		let handle : Rect = {
 			x: 0,
@@ -816,14 +820,15 @@ export function drawTimelines(originX: number, originY: number, isImageExportMod
 			w: 14,
 			h: TimelineDimensions.renderSlotHeight() - 2
 		};
-		g_ctx.fillStyle = slot === g_renderingProps.activeSlotIndex ? g_colors.accent : g_colors.bgMediumContrast;
+		// don't think very low contrast works well here so turning it off for now..
+		g_ctx.fillStyle = slot === g_renderingProps.activeSlotIndex ? g_colors.jobAccents[g_renderingProps.slots[slot].job] : g_colors.bgMediumContrast;
 		g_ctx.fillRect(handle.x, handle.y, handle.w, handle.h);
 		testInteraction(handle, slot===g_renderingProps.activeSlotIndex ? undefined : [localize({en: "set active", zh: "设为当前"}) as string], () => {
 			controller.setActiveSlot(slot);
 		}, true);
 
 		// delete btn
-		if (g_renderingProps.slotElements.length > 1) {
+		if (g_renderingProps.slots.length > 1) {
 			g_ctx.fillStyle = g_colors.emphasis;
 			g_ctx.font = "bold 14px monospace";
 			g_ctx.textAlign = "center";
@@ -840,11 +845,11 @@ export function drawTimelines(originX: number, originY: number, isImageExportMod
 			}, true);
 		}
 	}
-	let timelineSectionHeight = TimelineDimensions.renderSlotHeight() * g_renderingProps.slotElements.length;
+	let timelineSectionHeight = TimelineDimensions.renderSlotHeight() * g_renderingProps.slots.length;
 
 	// add button
-	if (g_renderingProps.slotElements.length < MAX_TIMELINE_SLOTS) {
-		let currentY = originY + g_renderingProps.slotElements.length * TimelineDimensions.renderSlotHeight();
+	if (g_renderingProps.slots.length < MAX_TIMELINE_SLOTS) {
+		let currentY = originY + g_renderingProps.slots.length * TimelineDimensions.renderSlotHeight();
 		let handle : Rect = {
 			x: 4,
 			y: currentY + 2,

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -544,7 +544,7 @@ class Controller {
 			tincturePotencyMultiplier: this.getTincturePotencyMultiplier(),
 			untargetableMask: this.#untargetableMask,
 			sharedElements: this.timeline.sharedElements,
-			slotElements: this.timeline.slots,
+			slots: this.timeline.slots,
 			activeSlotIndex: this.timeline.activeSlotIndex,
 			allMarkers: this.timeline.getAllMarkers(),
 			untargetableMarkers: this.timeline.getUntargetableMarkers(),


### PR DESCRIPTION
Timeline slot handle:
![image](https://github.com/user-attachments/assets/a4437b0c-a7e8-491b-8b6e-7f7557e6483d)
![image](https://github.com/user-attachments/assets/71285a84-8270-4da7-b1ea-4c0a45f5e15c)
I kept inactive slot grey because job colors at low transparency either look very dull and hard to differentiate anyway, or too bright and hard to tell if the slot is active or not. 

I'm also proposing some resource color adjustments for PCT referencing the job gauge, mostly checked their contrast against the background to make them readable & recognizable:
![image](https://github.com/user-attachments/assets/bba23b6a-54be-4ae8-a101-e2ccb723cf81)

(now that I look at it again I think holy could be more blue and slightly darker... but lmk if the general direction looks okay, especially if people are used to the current colors already)