### PR TITLE
Filter preset lines by job

### DIFF
--- a/src/Controller/PresetLinesManager.ts
+++ b/src/Controller/PresetLinesManager.ts
@@ -1,12 +1,34 @@
-import {FileType, getCachedValue, setCachedValue} from "./Common";
+import {ShellJob, ALL_JOBS, FileType, getCachedValue, setCachedValue} from "./Common";
 import {ActionNode, Line} from "./Record";
-import {getNormalizedSkillName} from "../Game/Skills";
+import {getNormalizedSkillName, jobHasSkill} from "../Game/Skills";
+import {SkillName} from "../Game/Common";
 import {updateSkillSequencePresetsView} from "../Components/SkillSequencePresets";
 
 type Fixme = any;
 
+export function inferJobFromSkillNames(actions: SkillName[]): ShellJob {
+	// Helper function used for migrating from BLM/PCT in the Shell to multi-job support.
+	//
+	// Iterate over the whole record and return the number of actions that occur in each job.
+	// If two jobs are tied (like if there's only a Swiftcast/Sprint in the timeline), just
+	// take the first that appears since it doesn't really matter.
+	let maxJob = ALL_JOBS[0];
+	let maxCount = 0;
+	ALL_JOBS.forEach((job) => {
+		const count = actions.reduce(
+			(acc, skill) => jobHasSkill(job, skill) ? acc + 1 : acc,
+			0,
+		);
+		if (count > maxCount) {
+			maxJob = job;
+			maxCount = count;
+		}
+	});
+	return maxJob;
+};
+
 export class PresetLinesManager {
-	presetLines: Line[] = [];
+	presetLines: {actions: Line, job: ShellJob}[] = [];
 
 	constructor() {
 		this.#load();
@@ -29,39 +51,43 @@ export class PresetLinesManager {
 	serialized() {
 		return {
 			fileType: FileType.SkillSequencePresets,
-			presets: this.presetLines.map(line=>{
-				return line.serialized();
-			}),
+			presets: this.presetLines.map(({actions, job}) => actions.serialized()),
 		}
 	}
 
 	deserializeAndAppend(content: Fixme) {
 		for (let i = 0; i < content.presets.length; i++) {
-			let line = new Line();
+			const skillNames = [];
+			const line = new Line();
 			line.name = content.presets[i].name;
 			for (let j = 0; j < content.presets[i].actions.length; j++) {
-				let action = content.presets[i].actions[j];
-				let node = new ActionNode(action.type);
+				const action = content.presets[i].actions[j];
+				const node = new ActionNode(action.type);
 				if (action.skillName) {
 					node.skillName = getNormalizedSkillName(action.skillName)!;
+					skillNames.push(node.skillName);
 				}
 				node.waitDuration = action.waitDuration;
 				node.buffName = action.buffName;
 				line.addActionNode(node);
 			}
-			this.addLine(line);
+			this.addLine(line, inferJobFromSkillNames(skillNames));
 		}
 	}
 
-	addLine(line: Line) {
-		this.presetLines.push(line);
+	getLinesForJob(currentJob: ShellJob): Line[] {
+		return this.presetLines.flatMap(({actions, job}) => job === currentJob ? [actions] : []);
+	}
+
+	addLine(line: Line, job: ShellJob) {
+		this.presetLines.push({actions: line, job: job});
 		updateSkillSequencePresetsView();
 		this.#save();
 	}
 
 	deleteLine(line: Line) {
 		for (let i = 0; i < this.presetLines.length; i++) {
-			if (this.presetLines[i] === line) {
+			if (this.presetLines[i].actions === line) {
 				this.presetLines.splice(i, 1);
 				updateSkillSequencePresetsView();
 				this.#save();

--- a/src/Controller/PresetLinesManager.ts
+++ b/src/Controller/PresetLinesManager.ts
@@ -71,7 +71,7 @@ export class PresetLinesManager {
 				node.buffName = action.buffName;
 				line.addActionNode(node);
 			}
-			this.addLine(line, inferJobFromSkillNames(skillNames));
+			this.addLine(line, content.presets[i].job ?? inferJobFromSkillNames(skillNames));
 		}
 	}
 


### PR DESCRIPTION
Trying to add a preset line to a different job causes an error (just shows up in console and doesn't break anything). This PR associates a job with all preset lines, and hides lines that don't belong to the current job.

Only issue is that there's now some layout shift if the skill preset menu is open. If we want to avoid this behavior, we can error if trying to add a line from a different job instead, but I don't think it makes sense to display preset lines if adding them would cause an error.