### PR TITLE
Can now label jobs as testing and it'll show a warning for users

### DIFF
--- a/src/Components/ColorTheme.tsx
+++ b/src/Components/ColorTheme.tsx
@@ -190,7 +190,7 @@ export let getCurrentThemeColors: ()=>ThemeColors = () => {
 			text: "#000000",
 			emphasis: "#000000",
 			success: "mediumseagreen",
-			warning: "#f85210",
+			warning: "#ff4d07",
 			background: "#ffffff",
 			tipBackground: "#ffffff",
 			bgLowContrast: "#efefef",

--- a/src/Components/PlaybackControl.tsx
+++ b/src/Components/PlaybackControl.tsx
@@ -161,7 +161,7 @@ export function ConfigSummary(props: { job: ShellJob, dirty: boolean }) {
 	let testingWarning = <p style={{
 		color: warningColor
 	}}>{localize({
-		en: "WARNING: This job is developed recently and is currently in testing. Save your work elsewhere and save often. There might be upcoming breaking changes.",
+		en: "WARNING: This job was recently added to XIV in the Shell and is still being tested. There may be bugs or changes in the near future, so make sure to frequently export and save timelines for this job to make sure you don't lose your work.",
 		zh: "警告：此职业刚被实现没多久，可能还不是很稳定，目前暂时不要太依赖txt文件，记得勤在别处保存进度。"
 	})}</p>
 

--- a/src/Components/PlaybackControl.tsx
+++ b/src/Components/PlaybackControl.tsx
@@ -1,7 +1,16 @@
 import React, {MouseEventHandler, useEffect, useReducer} from 'react';
 import {controller} from '../Controller/Controller'
 import {ButtonIndicator, Clickable, Expandable, Help, Input, ValueChangeEvent} from "./Common";
-import {getCachedValue, setCachedValue, ShellInfo, ShellJob, ShellVersion, TickMode, ALL_JOBS} from "../Controller/Common";
+import {
+	getCachedValue,
+	setCachedValue,
+	ShellInfo,
+	ShellJob,
+	ShellVersion,
+	TickMode,
+	ALL_JOBS,
+	TESTING_JOBS
+} from "../Controller/Common";
 import {FIXED_BASE_CASTER_TAX, LevelSync, ProcMode, ResourceType} from "../Game/Common";
 import {getAllResources, getResourceInfo, ResourceOverrideData} from "../Game/Resources";
 import {localize} from "./Localization";
@@ -149,11 +158,18 @@ export function ConfigSummary(props: { job: ShellJob, dirty: boolean }) {
 		zh: `警告：此时间轴文件创建于一个更早版本的排轴器，因此计算读条时间时使用的是当时手动输入的读条税${legacyCasterTax}秒（现已过时），而非由下方的“帧率”和“读条时间修正”计算得来。更多信息：`
 	});
 	let warningColor = getCurrentThemeColors().warning;
-	let blurb = localize({
+	let testingWarning = <p style={{
+		color: warningColor
+	}}>{localize({
+		en: "WARNING: This job is developed recently and is currently in testing. Save your work elsewhere and save often. There might be upcoming breaking changes.",
+		zh: "警告：此职业刚被实现没多久，可能还不是很稳定，目前暂时不要太依赖txt文件，记得勤在别处保存进度。"
+	})}</p>
+
+	let legacyCasterTaxBlurbContent = localize({
 		en: <div>
 			<div className={"paragraph"}>
 				The caster tax config is now replaced by 0.1s + FPS tax and is more precise.
-				You can read more about FPS tax in About this tool/Implementation notes.
+				You can read more about FPS tax in the Github repository wiki's implementation notes section.
 			</div>
 			<div className={"paragraph"} style={{color: warningColor}}>
 				You are strongly encouraged to create a new record (in another timeline slot or from 'apply and reset') and migrate your fight plan.
@@ -169,9 +185,11 @@ export function ConfigSummary(props: { job: ShellJob, dirty: boolean }) {
 			</div>
 		</div>
 	});
-	let legacyCasterTaxBlurb = <p className={"paragraph"} style={{color: warningColor}}>{excerpt}<Help topic={"legacy-caster-tax"} content={blurb}/></p>;
+	let legacyCasterTaxBlurb = <p style={{color: warningColor}}>{excerpt}<Help topic={"legacy-caster-tax"} content={legacyCasterTaxBlurbContent}/></p>;
 	return <div style={{textDecoration: props.dirty ? "line-through" : "none", marginLeft: 5, paddingLeft: 10, borderLeft: "1px solid " + getCurrentThemeColors().bgHighContrast}}>
 		{controller.gameConfig.shellVersion < ShellVersion.FpsTax ? legacyCasterTaxBlurb : undefined}
+
+		{TESTING_JOBS.includes(props.job) ? testingWarning : undefined}
 
 		<div>{localize({en: "Lucid tick offset ", zh: "醒梦&跳蓝时间差 "})}<Help topic={"lucidTickOffset"} content={lucidOffsetDesc}/>: {lucidTickOffset}</div>
 
@@ -1120,9 +1138,13 @@ export class Config extends React.Component {
 		let editJobSection = <div style={{marginBottom: 10}}>
 			<span>{localize({en: "job: ", zh: "职业："})}</span>
 			<select style={{outline: "none", color: fieldColor("job")}} value={this.state.job} onChange={this.setJob}>
-				{ALL_JOBS.map((job) =>
-					<option key={job} value={job}>{job}</option>
-				)}
+				{ALL_JOBS.map((job) => {
+					if (TESTING_JOBS.includes(job)) {
+						return <option key={job} value={job}>{job + ` (${localize({en: "testing", zh: "测试中"})})`}</option>
+					} else {
+						return <option key={job} value={job}>{job}</option>
+					}
+				})}
 			</select>
 		</div>;
 		let editStatsSection = <div style={{marginBottom: 16}}>

--- a/src/Controller/Common.ts
+++ b/src/Controller/Common.ts
@@ -36,6 +36,10 @@ export const ALL_JOBS = [
 	ShellJob.PCT,
 ];
 
+export const TESTING_JOBS = [
+	ShellJob.RDM,
+];
+
 export const enum Expansion {
 	EW = "EW",
 	DT = "DT"

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -4,7 +4,8 @@
 		"changes": [
 			"(thank you Wan Shott for reporting a bunch of RDM bugs)",
 			"[RDM] Fixed bugs where Verfire and Grand Impact didn't grant correct mana",
-			"[RDM] Fixed a bug where it was possible to use un-enchanted Moulinet under certain incorrect conditions"
+			"[RDM] Fixed a bug where it was possible to use un-enchanted Moulinet under certain incorrect conditions",
+			"mark newly-implemented jobs as in testing and display a warning message when using those jobs"
 		]
 	},
 	{


### PR DESCRIPTION
Current RDM, for example:
![image](https://github.com/user-attachments/assets/6a786ac9-b5dc-4d2d-8038-f3506e17b380)

And a hypothetical situation with multiple warnings:
![image](https://github.com/user-attachments/assets/930c507b-2c23-4308-9f6c-2ef5a14a5054)
