### PR TITLE
Fix Standard/Technical Finish highlighting

### DIFF
--- a/src/Game/Jobs/DNC.ts
+++ b/src/Game/Jobs/DNC.ts
@@ -574,7 +574,8 @@ standardFinishes.forEach((finish) => {
             state.applyStandardFinish(bonusLevel)
         },
         recastTime: 1.5,
-        validateAttempt: (state) => state.hasResourceAvailable(ResourceType.StandardStep) && state.getCurrentDanceStatus() === 2,
+        validateAttempt: (state) => state.hasResourceAvailable(ResourceType.StandardStep),
+        highlightIf: (state) => state.hasResourceAvailable(ResourceType.StandardStep) && state.getCurrentDanceStatus() === 2,
     })
 });
 
@@ -712,7 +713,8 @@ technicalFinishes.forEach((params) => {
             }
         },
         recastTime: 1.5,
-        validateAttempt: (state) => state.hasResourceAvailable(ResourceType.TechnicalStep) && state.getCurrentDanceStatus() === 4,
+        validateAttempt: (state) => state.hasResourceAvailable(ResourceType.TechnicalStep),
+        highlightIf: (state) => state.hasResourceAvailable(ResourceType.TechnicalStep) && state.getCurrentDanceStatus() === 4,
     })
 })
 

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,6 +1,6 @@
 [
 	{
-		"date": "11/19/24",
+		"date": "11/20/24",
 		"changes": [
 			"[DNC] Added initial DNC support",
 			"Added support for skill speed in addition to spell speed"


### PR DESCRIPTION
The finishes were validating on having the right number of dance moves, instead of highlighting on it. Technically it's the result you want, but it's not accurate to game behavior!