### PR TITLE
Refactor TraitList into Jobs/Common.ts

### DIFF
--- a/src/Components/Jobs/BLM.tsx
+++ b/src/Components/Jobs/BLM.tsx
@@ -6,8 +6,8 @@ import {
     ResourceDisplayProps,
     StatusPropsGenerator
 } from "../StatusDisplay";
-import {ResourceType} from "../../Game/Common";
-import {TraitName, Traits} from "../../Game/Traits";
+import {ResourceType, TraitName} from "../../Game/Common";
+import {Traits} from "../../Game/Traits";
 import {BLMState} from "../../Game/Jobs/BLM";
 import {getCurrentThemeColors} from "../ColorTheme";
 import {localize} from "../Localization";

--- a/src/Components/Jobs/DNC.tsx
+++ b/src/Components/Jobs/DNC.tsx
@@ -1,6 +1,6 @@
-import { ResourceType } from "../../Game/Common";
+import { ResourceType,TraitName } from "../../Game/Common";
 import { DNCState } from "../../Game/Jobs/DNC";
-import { TraitName, Traits } from "../../Game/Traits";
+import { Traits } from "../../Game/Traits";
 import { getCurrentThemeColors } from "../ColorTheme";
 import { localize } from "../Localization";
 import {

--- a/src/Components/Jobs/PCT.tsx
+++ b/src/Components/Jobs/PCT.tsx
@@ -8,8 +8,8 @@ import {
 	ResourceTextProps,
 	StatusPropsGenerator
 } from "../StatusDisplay";
-import {ResourceType} from "../../Game/Common";
-import {TraitName, Traits} from "../../Game/Traits";
+import {ResourceType,TraitName} from "../../Game/Common";
+import {Traits} from "../../Game/Traits";
 import {PCTState} from "../../Game/Jobs/PCT";
 import {getCurrentThemeColors} from "../ColorTheme";
 import {localize} from "../Localization";

--- a/src/Components/Jobs/RPR.tsx
+++ b/src/Components/Jobs/RPR.tsx
@@ -1,6 +1,6 @@
-import { ResourceType } from "../../Game/Common";
+import { ResourceType, TraitName } from "../../Game/Common";
 import { RPRState } from "../../Game/Jobs/RPR";
-import { TraitName, Traits } from "../../Game/Traits";
+import { Traits } from "../../Game/Traits";
 import { getCurrentThemeColors } from "../ColorTheme";
 import { localize } from "../Localization";
 import { BuffProps, registerBuffIcon, ResourceBarProps, ResourceCounterProps, ResourceDisplayProps, StatusPropsGenerator } from "../StatusDisplay";

--- a/src/Game/Common.ts
+++ b/src/Game/Common.ts
@@ -1,10 +1,12 @@
-import {BLMSkillName, BLMResourceType, BLMCooldownType} from "./Constants/BLM";
-import {PCTSkillName, PCTResourceType, PCTCooldownType} from "./Constants/PCT";
-import {RDMSkillName, RDMResourceType, RDMCooldownType} from "./Constants/RDM";
-import {DNCSkillName, DNCResourceType, DNCCooldownType} from "./Constants/DNC";
-import {SAMSkillName, SAMResourceType, SAMCooldownType} from "./Constants/SAM";
-import {MCHSkillName, MCHResourceType, MCHCooldownType} from "./Constants/MCH";
-import { RPRCooldownType, RPRResourceType, RPRSkillName } from "./Constants/RPR";
+import {BLMSkillName, BLMResourceType, BLMCooldownType, BLMTraitList} from "./Constants/BLM";
+import {PCTSkillName, PCTResourceType, PCTCooldownType, PCTTraitList } from "./Constants/PCT";
+import {RDMSkillName, RDMResourceType, RDMCooldownType, RDMTraitList} from "./Constants/RDM";
+import {DNCSkillName, DNCResourceType, DNCCooldownType, DNCTraitList} from "./Constants/DNC";
+import {SAMSkillName, SAMResourceType, SAMCooldownType, SAMTraitList} from "./Constants/SAM";
+import {MCHSkillName, MCHResourceType, MCHCooldownType, MCHTraitList} from "./Constants/MCH";
+import {RPRSkillName, RPRResourceType, RPRCooldownType, RPRTraitList } from "./Constants/RPR";
+
+import { Trait, TraitName } from "./Traits";
 
 export const Debug = {
 	epsilon: 1e-6,
@@ -243,3 +245,13 @@ export const enum WarningType {
 	MeditationOvercap = "meditation stack overcap",
 	SenOvercap = "sen overcap",
 }
+
+export const TraitList: Map<TraitName, Trait> = new Map<TraitName, Trait>([
+	...BLMTraitList,
+	...PCTTraitList,
+	...RDMTraitList,
+	...DNCTraitList,
+	...SAMTraitList,
+	...MCHTraitList,
+	...RPRTraitList
+].map(([name, level]) => [name, new Trait(name, level)]));

--- a/src/Game/Common.ts
+++ b/src/Game/Common.ts
@@ -1,12 +1,11 @@
-import {BLMSkillName, BLMResourceType, BLMCooldownType, BLMTraitList} from "./Constants/BLM";
-import {PCTSkillName, PCTResourceType, PCTCooldownType, PCTTraitList } from "./Constants/PCT";
-import {RDMSkillName, RDMResourceType, RDMCooldownType, RDMTraitList} from "./Constants/RDM";
-import {DNCSkillName, DNCResourceType, DNCCooldownType, DNCTraitList} from "./Constants/DNC";
-import {SAMSkillName, SAMResourceType, SAMCooldownType, SAMTraitList} from "./Constants/SAM";
-import {MCHSkillName, MCHResourceType, MCHCooldownType, MCHTraitList} from "./Constants/MCH";
-import {RPRSkillName, RPRResourceType, RPRCooldownType, RPRTraitList } from "./Constants/RPR";
+import {BLMSkillName, BLMResourceType, BLMCooldownType, BLMTraitList, BLMTraitName} from "./Constants/BLM";
+import {PCTSkillName, PCTResourceType, PCTCooldownType, PCTTraitList, PCTTraitName } from "./Constants/PCT";
+import {RDMSkillName, RDMResourceType, RDMCooldownType, RDMTraitList, RDMTraitName} from "./Constants/RDM";
+import {DNCSkillName, DNCResourceType, DNCCooldownType, DNCTraitList, DNCTraitName} from "./Constants/DNC";
+import {SAMSkillName, SAMResourceType, SAMCooldownType, SAMTraitList, SAMTraitName} from "./Constants/SAM";
+import {MCHSkillName, MCHResourceType, MCHCooldownType, MCHTraitList, MCHTraitName} from "./Constants/MCH";
+import {RPRSkillName, RPRResourceType, RPRCooldownType, RPRTraitList, RPRTraitName} from "./Constants/RPR";
 
-import { Trait, TraitName } from "./Traits";
 
 export const Debug = {
 	epsilon: 1e-6,
@@ -246,12 +245,72 @@ export const enum WarningType {
 	SenOvercap = "sen overcap",
 }
 
-export const TraitList: Map<TraitName, Trait> = new Map<TraitName, Trait>([
+export enum ReservedTraitName {
+	Never = 0
+}
+
+export enum RoleTraitName {
+	// 0-99 reserved
+	// Healer, Magical Ranged
+	EnhancedSwiftcast = 100,
+	// Magical Ranged
+	EnhancedAddle,
+
+	// Melee, Ranged
+	EnhancedSecondWind,
+	// Melee
+	EnhancedFeint,
+
+	// Tank
+	MeleeMasteryTank,
+	EnhancedRampart,
+	MeleeMasteryIITank,
+	EnhancedReprisal,
+}
+
+const GeneralTraitList: Array<[RoleTraitName, number]> = [
+	[RoleTraitName.EnhancedSwiftcast, 94],
+	[RoleTraitName.EnhancedAddle, 98],
+
+	[RoleTraitName.EnhancedSecondWind, 94],
+	[RoleTraitName.EnhancedFeint, 98],
+
+	[RoleTraitName.MeleeMasteryTank, 84],
+	[RoleTraitName.EnhancedRampart, 94],
+	[RoleTraitName.MeleeMasteryIITank, 94],
+	[RoleTraitName.EnhancedReprisal, 98],
+]
+
+export const TraitName = {
+	...RoleTraitName,  //  100-1000
+	...BLMTraitName,   // 1000-1999
+	...PCTTraitName,   // 2000-2999
+	...DNCTraitName,   // 3000-3999
+	...RDMTraitName,   // 4000-4999
+	...SAMTraitName,   // 5000-5999
+	...MCHTraitName,   // 6000-6999
+	...RPRTraitName,   // 7000-7999
+	...ReservedTraitName, // 0, for now
+}
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type TraitName = RoleTraitName
+	| BLMTraitName
+	| PCTTraitName
+	| DNCTraitName
+	| RDMTraitName
+	| SAMTraitName
+	| MCHTraitName
+	| RPRTraitName
+	| ReservedTraitName;
+
+export const TraitList: Array<[TraitName, number]> = [
+	...GeneralTraitList,
 	...BLMTraitList,
 	...PCTTraitList,
 	...RDMTraitList,
 	...DNCTraitList,
 	...SAMTraitList,
 	...MCHTraitList,
-	...RPRTraitList
-].map(([name, level]) => [name, new Trait(name, level)]));
+	...RPRTraitList,
+]

--- a/src/Game/Constants/BLM.ts
+++ b/src/Game/Constants/BLM.ts
@@ -1,5 +1,3 @@
-import { TraitName } from "../Traits"
-
 export enum BLMSkillName {
     Blizzard = "Blizzard",
     Fire = "Fire",
@@ -63,19 +61,32 @@ export enum BLMCooldownType {
     cd_Retrace = "cd_Retrace", // [0, 1x]
 }
 
-export const BLMTraitList: Array<[TraitName, number]> = [
-    [TraitName.EnhancedEnochianII, 78],
-    [TraitName.EnhancedPolyglot, 80],
-    [TraitName.EnhancedFoul, 80],
-    [TraitName.AspectMasteryIV, 82],
-    [TraitName.EnhancedManafont, 84],
-    [TraitName.EnhancedEnochianIII, 86],
-    [TraitName.AspectMasteryV, 90],
-    [TraitName.ThunderMasteryIII, 92],
-    [TraitName.EnhancedSwiftcast, 94],
-    [TraitName.EnhancedLeyLines, 96],
-    [TraitName.EnhancedEnochianIV, 96],
-    [TraitName.EnhancedPolyglotII, 98],
-    [TraitName.EnhancedAddle, 98],
-    [TraitName.EnhancedAstralFire, 100],
+export enum BLMTraitName {
+    EnhancedEnochianII = 1000,
+    EnhancedPolyglot,
+    EnhancedFoul,
+    AspectMasteryIV,
+    EnhancedManafont,
+    EnhancedEnochianIII,
+    AspectMasteryV,
+    ThunderMasteryIII,
+    EnhancedLeyLines,
+    EnhancedEnochianIV,
+    EnhancedPolyglotII,
+    EnhancedAstralFire,
+}
+
+export const BLMTraitList: Array<[BLMTraitName, number]> = [
+    [BLMTraitName.EnhancedEnochianII, 78],
+    [BLMTraitName.EnhancedPolyglot, 80],
+    [BLMTraitName.EnhancedFoul, 80],
+    [BLMTraitName.AspectMasteryIV, 82],
+    [BLMTraitName.EnhancedManafont, 84],
+    [BLMTraitName.EnhancedEnochianIII, 86],
+    [BLMTraitName.AspectMasteryV, 90],
+    [BLMTraitName.ThunderMasteryIII, 92],
+    [BLMTraitName.EnhancedLeyLines, 96],
+    [BLMTraitName.EnhancedEnochianIV, 96],
+    [BLMTraitName.EnhancedPolyglotII, 98],
+    [BLMTraitName.EnhancedAstralFire, 100],
 ];

--- a/src/Game/Constants/BLM.ts
+++ b/src/Game/Constants/BLM.ts
@@ -1,3 +1,5 @@
+import { TraitName } from "../Traits"
+
 export enum BLMSkillName {
     Blizzard = "Blizzard",
     Fire = "Fire",
@@ -60,3 +62,20 @@ export enum BLMCooldownType {
     cd_Amplifier = "cd_Amplifier", // [0, 1x]
     cd_Retrace = "cd_Retrace", // [0, 1x]
 }
+
+export const BLMTraitList: Array<[TraitName, number]> = [
+    [TraitName.EnhancedEnochianII, 78],
+    [TraitName.EnhancedPolyglot, 80],
+    [TraitName.EnhancedFoul, 80],
+    [TraitName.AspectMasteryIV, 82],
+    [TraitName.EnhancedManafont, 84],
+    [TraitName.EnhancedEnochianIII, 86],
+    [TraitName.AspectMasteryV, 90],
+    [TraitName.ThunderMasteryIII, 92],
+    [TraitName.EnhancedSwiftcast, 94],
+    [TraitName.EnhancedLeyLines, 96],
+    [TraitName.EnhancedEnochianIV, 96],
+    [TraitName.EnhancedPolyglotII, 98],
+    [TraitName.EnhancedAddle, 98],
+    [TraitName.EnhancedAstralFire, 100],
+];

--- a/src/Game/Constants/DNC.ts
+++ b/src/Game/Constants/DNC.ts
@@ -1,3 +1,5 @@
+import { TraitName } from "../Traits";
+
 export enum DNCSkillName {
     StandardFinish = "Standard Finish",
     SingleStandardFinish = "Single Standard Finish",
@@ -105,3 +107,17 @@ export enum DNCCooldownType {
     cd_CuringWaltz = "cd_CuringWaltz",
     cd_Ending = "cd_Ending",
 }
+
+export const DNCTraitList: Array<[TraitName, number]> = [
+    [TraitName.Esprit, 76],
+    [TraitName.EnhancedEnAvantII, 78],
+    [TraitName.EnhancedTechnicalFinish, 82],
+    [TraitName.EnhancedEsprit, 84],
+    [TraitName.EnhancedFlourish, 86],
+    [TraitName.EnhancedShieldSamba, 88],
+    [TraitName.EnhancedDevilment, 90],
+    [TraitName.EnhancedStandardFinish, 92],
+    [TraitName.DynamicDancer, 94],
+    [TraitName.EnhancedFlourishII, 96],
+    [TraitName.EnhancedTechnicalFinishII, 100],
+];

--- a/src/Game/Constants/DNC.ts
+++ b/src/Game/Constants/DNC.ts
@@ -1,5 +1,3 @@
-import { TraitName } from "../Traits";
-
 export enum DNCSkillName {
     StandardFinish = "Standard Finish",
     SingleStandardFinish = "Single Standard Finish",
@@ -108,16 +106,31 @@ export enum DNCCooldownType {
     cd_Ending = "cd_Ending",
 }
 
-export const DNCTraitList: Array<[TraitName, number]> = [
-    [TraitName.Esprit, 76],
-    [TraitName.EnhancedEnAvantII, 78],
-    [TraitName.EnhancedTechnicalFinish, 82],
-    [TraitName.EnhancedEsprit, 84],
-    [TraitName.EnhancedFlourish, 86],
-    [TraitName.EnhancedShieldSamba, 88],
-    [TraitName.EnhancedDevilment, 90],
-    [TraitName.EnhancedStandardFinish, 92],
-    [TraitName.DynamicDancer, 94],
-    [TraitName.EnhancedFlourishII, 96],
-    [TraitName.EnhancedTechnicalFinishII, 100],
+export enum DNCTraitName {
+    Esprit = 2000,
+    EnhancedEnAvantII,
+    EnhancedTechnicalFinish,
+    EnhancedEsprit,
+    EnhancedFlourish,
+    EnhancedShieldSamba,
+    EnhancedDevilment,
+    EnhancedStandardFinish,
+    DynamicDancer,
+    EnhancedFlourishII,
+    EnhancedTechnicalFinishII,
+}
+
+
+export const DNCTraitList: Array<[DNCTraitName, number]> = [
+    [DNCTraitName.Esprit, 76],
+    [DNCTraitName.EnhancedEnAvantII, 78],
+    [DNCTraitName.EnhancedTechnicalFinish, 82],
+    [DNCTraitName.EnhancedEsprit, 84],
+    [DNCTraitName.EnhancedFlourish, 86],
+    [DNCTraitName.EnhancedShieldSamba, 88],
+    [DNCTraitName.EnhancedDevilment, 90],
+    [DNCTraitName.EnhancedStandardFinish, 92],
+    [DNCTraitName.DynamicDancer, 94],
+    [DNCTraitName.EnhancedFlourishII, 96],
+    [DNCTraitName.EnhancedTechnicalFinishII, 100],
 ];

--- a/src/Game/Constants/MCH.ts
+++ b/src/Game/Constants/MCH.ts
@@ -1,3 +1,5 @@
+import { TraitName } from "../Traits";
+
 export enum MCHSkillName {
     HeatedSplitShot = "Heated Split Shot",
     HeatedSlugShot = "Heated Slug Shot",
@@ -81,3 +83,20 @@ export enum MCHCooldownType {
     cd_Hypercharge = "cd_Hypercharge",
     cd_Detonator = "cd_Detonator",
 }
+
+export const MCHTraitList: Array<[TraitName, number]> = [
+    [TraitName.ChargedActionMastery, 74],
+    [TraitName.HotShotMastery, 76],
+    [TraitName.EnhancedWildfire, 88],
+    [TraitName.Promotion, 80],
+    [TraitName.SpreadShotMastery, 82],
+    [TraitName.EnhancedReassemble, 84],
+    [TraitName.MarksmansMastery, 84],
+    [TraitName.QueensGambit, 86],
+    [TraitName.EnhancedTactician, 88],
+    [TraitName.DoubleBarrelMastery, 92],
+    [TraitName.EnhancedMultiWeapon, 94],
+    [TraitName.MarksmansMasteryII, 94],
+    [TraitName.EnhancedMultiWeaponII, 96],
+    [TraitName.EnhancedBarrelStabilizer, 100],
+]

--- a/src/Game/Constants/MCH.ts
+++ b/src/Game/Constants/MCH.ts
@@ -1,5 +1,3 @@
-import { TraitName } from "../Traits";
-
 export enum MCHSkillName {
     HeatedSplitShot = "Heated Split Shot",
     HeatedSlugShot = "Heated Slug Shot",
@@ -84,19 +82,36 @@ export enum MCHCooldownType {
     cd_Detonator = "cd_Detonator",
 }
 
-export const MCHTraitList: Array<[TraitName, number]> = [
-    [TraitName.ChargedActionMastery, 74],
-    [TraitName.HotShotMastery, 76],
-    [TraitName.EnhancedWildfire, 88],
-    [TraitName.Promotion, 80],
-    [TraitName.SpreadShotMastery, 82],
-    [TraitName.EnhancedReassemble, 84],
-    [TraitName.MarksmansMastery, 84],
-    [TraitName.QueensGambit, 86],
-    [TraitName.EnhancedTactician, 88],
-    [TraitName.DoubleBarrelMastery, 92],
-    [TraitName.EnhancedMultiWeapon, 94],
-    [TraitName.MarksmansMasteryII, 94],
-    [TraitName.EnhancedMultiWeaponII, 96],
-    [TraitName.EnhancedBarrelStabilizer, 100],
+export enum MCHTraitName {
+	ChargedActionMastery = 3000,
+	HotShotMastery,
+	EnhancedWildfire,
+	Promotion,
+	SpreadShotMastery,
+	EnhancedReassemble,
+	MarksmansMastery,
+	QueensGambit,
+	EnhancedTactician,
+	DoubleBarrelMastery,
+	EnhancedMultiWeapon,
+	MarksmansMasteryII,
+	EnhancedMultiWeaponII,
+	EnhancedBarrelStabilizer,
+}
+
+export const MCHTraitList: Array<[MCHTraitName, number]> = [
+    [MCHTraitName.ChargedActionMastery, 74],
+    [MCHTraitName.HotShotMastery, 76],
+    [MCHTraitName.EnhancedWildfire, 88],
+    [MCHTraitName.Promotion, 80],
+    [MCHTraitName.SpreadShotMastery, 82],
+    [MCHTraitName.EnhancedReassemble, 84],
+    [MCHTraitName.MarksmansMastery, 84],
+    [MCHTraitName.QueensGambit, 86],
+    [MCHTraitName.EnhancedTactician, 88],
+    [MCHTraitName.DoubleBarrelMastery, 92],
+    [MCHTraitName.EnhancedMultiWeapon, 94],
+    [MCHTraitName.MarksmansMasteryII, 94],
+    [MCHTraitName.EnhancedMultiWeaponII, 96],
+    [MCHTraitName.EnhancedBarrelStabilizer, 100],
 ]

--- a/src/Game/Constants/PCT.ts
+++ b/src/Game/Constants/PCT.ts
@@ -1,5 +1,3 @@
-import { TraitName } from "../Traits";
-
 export enum PCTSkillName {
     FireInRed = "Fire in Red",
     AeroInGreen = "Aero in Green",
@@ -91,17 +89,32 @@ export enum PCTCooldownType {
     cd_TemperaPop = "cd_TemperaPop", // [0, 1], also not real
 }
 
-export const PCTTraitList: Array<[TraitName, number]> = [
-    [TraitName.PictomancyMasteryII, 74],
-    [TraitName.EnhancedArtistry, 80],
-    [TraitName.EnhancedPictomancy, 82],
-    [TraitName.EnhancedSmudge, 84],
-    [TraitName.PictomancyMasteryIII, 84],
-    [TraitName.EnhancedPictomancyII, 86],
-    [TraitName.EnhancedTempera, 88],
-    [TraitName.EnhancedTempera, 90],
-    [TraitName.EnhancedPictomancyIII, 92],
-    [TraitName.PictomancyMasteryIV, 94],
-    [TraitName.EnhancedPictomancyIV, 96],
-    [TraitName.EnhancedPictomancyV, 100],
+export enum PCTTraitName {
+    PictomancyMasteryII = 4000,
+	EnhancedArtistry,
+	EnhancedPictomancy,
+	EnhancedSmudge,
+	PictomancyMasteryIII,
+	EnhancedPictomancyII,
+	EnhancedTempera,
+	EnhancedPalette,
+	EnhancedPictomancyIII,
+	PictomancyMasteryIV,
+	EnhancedPictomancyIV,
+	EnhancedPictomancyV,
+}
+
+export const PCTTraitList: Array<[PCTTraitName, number]> = [
+    [PCTTraitName.PictomancyMasteryII, 74],
+    [PCTTraitName.EnhancedArtistry, 80],
+    [PCTTraitName.EnhancedPictomancy, 82],
+    [PCTTraitName.EnhancedSmudge, 84],
+    [PCTTraitName.PictomancyMasteryIII, 84],
+    [PCTTraitName.EnhancedPictomancyII, 86],
+    [PCTTraitName.EnhancedTempera, 88],
+    [PCTTraitName.EnhancedPalette, 90],
+    [PCTTraitName.EnhancedPictomancyIII, 92],
+    [PCTTraitName.PictomancyMasteryIV, 94],
+    [PCTTraitName.EnhancedPictomancyIV, 96],
+    [PCTTraitName.EnhancedPictomancyV, 100],
 ];

--- a/src/Game/Constants/PCT.ts
+++ b/src/Game/Constants/PCT.ts
@@ -1,3 +1,5 @@
+import { TraitName } from "../Traits";
+
 export enum PCTSkillName {
     FireInRed = "Fire in Red",
     AeroInGreen = "Aero in Green",
@@ -88,3 +90,18 @@ export enum PCTCooldownType {
     cd_Grassa = "cd_Grassa", // [0, 1], not real
     cd_TemperaPop = "cd_TemperaPop", // [0, 1], also not real
 }
+
+export const PCTTraitList: Array<[TraitName, number]> = [
+    [TraitName.PictomancyMasteryII, 74],
+    [TraitName.EnhancedArtistry, 80],
+    [TraitName.EnhancedPictomancy, 82],
+    [TraitName.EnhancedSmudge, 84],
+    [TraitName.PictomancyMasteryIII, 84],
+    [TraitName.EnhancedPictomancyII, 86],
+    [TraitName.EnhancedTempera, 88],
+    [TraitName.EnhancedTempera, 90],
+    [TraitName.EnhancedPictomancyIII, 92],
+    [TraitName.PictomancyMasteryIV, 94],
+    [TraitName.EnhancedPictomancyIV, 96],
+    [TraitName.EnhancedPictomancyV, 100],
+];

--- a/src/Game/Constants/RDM.ts
+++ b/src/Game/Constants/RDM.ts
@@ -1,3 +1,5 @@
+import { TraitName } from "../Traits";
+
 export enum RDMSkillName {
 	Riposte = "Riposte",
 	// Jolt = "Jolt",
@@ -82,3 +84,17 @@ export enum RDMCooldownType {
 	cd_ViceOfThorns = "cd_ViceOfThorns",
 	cd_Prefulgence = "cd_Prefulgence",
 }
+
+export const RDMTraitList: Array<[TraitName, number]> = [
+	[TraitName.EnhancedDisplacement, 72],
+	[TraitName.RedMagicMastery, 74],
+	[TraitName.EnhancedManafication, 78],
+	[TraitName.RedMagicMasteryII, 82],
+	[TraitName.RedMagicMasteryIII, 84],
+	[TraitName.EnhancedAcceleration, 88],
+	[TraitName.EnhancedManaficationII, 90],
+	[TraitName.EnhancedEmbolden, 92],
+	[TraitName.EnchantedBladeMastery, 94],
+	[TraitName.EnhancedAccelerationII, 96],
+	[TraitName.EnhancedManaficationIII, 100],
+];

--- a/src/Game/Constants/RDM.ts
+++ b/src/Game/Constants/RDM.ts
@@ -1,5 +1,3 @@
-import { TraitName } from "../Traits";
-
 export enum RDMSkillName {
 	Riposte = "Riposte",
 	// Jolt = "Jolt",
@@ -85,16 +83,30 @@ export enum RDMCooldownType {
 	cd_Prefulgence = "cd_Prefulgence",
 }
 
-export const RDMTraitList: Array<[TraitName, number]> = [
-	[TraitName.EnhancedDisplacement, 72],
-	[TraitName.RedMagicMastery, 74],
-	[TraitName.EnhancedManafication, 78],
-	[TraitName.RedMagicMasteryII, 82],
-	[TraitName.RedMagicMasteryIII, 84],
-	[TraitName.EnhancedAcceleration, 88],
-	[TraitName.EnhancedManaficationII, 90],
-	[TraitName.EnhancedEmbolden, 92],
-	[TraitName.EnchantedBladeMastery, 94],
-	[TraitName.EnhancedAccelerationII, 96],
-	[TraitName.EnhancedManaficationIII, 100],
+export enum RDMTraitName {
+	EnhancedDisplacement = 5000,
+	RedMagicMastery,
+	EnhancedManafication,
+	RedMagicMasteryII,
+	RedMagicMasteryIII,
+	EnhancedAcceleration,
+	EnhancedManaficationII,
+	EnhancedEmbolden,
+	EnchantedBladeMastery,
+	EnhancedAccelerationII,
+	EnhancedManaficationIII,
+}
+
+export const RDMTraitList: Array<[RDMTraitName, number]> = [
+	[RDMTraitName.EnhancedDisplacement, 72],
+	[RDMTraitName.RedMagicMastery, 74],
+	[RDMTraitName.EnhancedManafication, 78],
+	[RDMTraitName.RedMagicMasteryII, 82],
+	[RDMTraitName.RedMagicMasteryIII, 84],
+	[RDMTraitName.EnhancedAcceleration, 88],
+	[RDMTraitName.EnhancedManaficationII, 90],
+	[RDMTraitName.EnhancedEmbolden, 92],
+	[RDMTraitName.EnchantedBladeMastery, 94],
+	[RDMTraitName.EnhancedAccelerationII, 96],
+	[RDMTraitName.EnhancedManaficationIII, 100],
 ];

--- a/src/Game/Constants/RPR.ts
+++ b/src/Game/Constants/RPR.ts
@@ -1,3 +1,5 @@
+import { TraitName } from "../Traits";
+
 export enum RPRSkillName {
     /** Single-target GCD */
     Slice = "Slice",
@@ -106,3 +108,18 @@ export enum RPRCooldownType {
     cd_LemuresSlice = "cd_LemuresSlice",
     cd_Sacrificium = "cd_Sacrificium",
 }
+
+export const RPRTraitList: Array<[TraitName, number]> = [
+    [TraitName.Hellsgate, 74],
+    [TraitName.TemperedSoul, 78],
+    [TraitName.ShroudGauge, 80],
+    [TraitName.EnhancedArcaneCrest, 84],
+    [TraitName.MeleeMasteryII, 84],
+    [TraitName.VoidSoul, 86],
+    [TraitName.EnhancedArcaneCircle, 88],
+    [TraitName.EnhancedEnshroud, 92],
+    [TraitName.EnhancedSecondWind, 94],
+    [TraitName.MeleeMasteryIII, 94],
+    [TraitName.EnhancedGluttony, 96],
+    [TraitName.EnhancedPlentifulHarvest, 100],
+]

--- a/src/Game/Constants/RPR.ts
+++ b/src/Game/Constants/RPR.ts
@@ -1,5 +1,3 @@
-import { TraitName } from "../Traits";
-
 export enum RPRSkillName {
     /** Single-target GCD */
     Slice = "Slice",
@@ -109,17 +107,30 @@ export enum RPRCooldownType {
     cd_Sacrificium = "cd_Sacrificium",
 }
 
-export const RPRTraitList: Array<[TraitName, number]> = [
-    [TraitName.Hellsgate, 74],
-    [TraitName.TemperedSoul, 78],
-    [TraitName.ShroudGauge, 80],
-    [TraitName.EnhancedArcaneCrest, 84],
-    [TraitName.MeleeMasteryII, 84],
-    [TraitName.VoidSoul, 86],
-    [TraitName.EnhancedArcaneCircle, 88],
-    [TraitName.EnhancedEnshroud, 92],
-    [TraitName.EnhancedSecondWind, 94],
-    [TraitName.MeleeMasteryIII, 94],
-    [TraitName.EnhancedGluttony, 96],
-    [TraitName.EnhancedPlentifulHarvest, 100],
+export enum RPRTraitName {
+    Hellsgate = 6000,
+    TemperedSoul,
+    ShroudGauge,
+    EnhancedArcaneCrest,
+    MeleeMasteryIIRPR,
+    VoidSoul,
+    EnhancedArcaneCircle,
+    EnhancedEnshroud,
+    MeleeMasteryIIIRPR,
+    EnhancedGluttony,
+    EnhancedPlentifulHarvest,
+}
+
+export const RPRTraitList: Array<[RPRTraitName, number]> = [
+    [RPRTraitName.Hellsgate, 74],
+    [RPRTraitName.TemperedSoul, 78],
+    [RPRTraitName.ShroudGauge, 80],
+    [RPRTraitName.EnhancedArcaneCrest, 84],
+    [RPRTraitName.MeleeMasteryIIRPR, 84],
+    [RPRTraitName.VoidSoul, 86],
+    [RPRTraitName.EnhancedArcaneCircle, 88],
+    [RPRTraitName.EnhancedEnshroud, 92],
+    [RPRTraitName.MeleeMasteryIIIRPR, 94],
+    [RPRTraitName.EnhancedGluttony, 96],
+    [RPRTraitName.EnhancedPlentifulHarvest, 100],
 ]

--- a/src/Game/Constants/SAM.ts
+++ b/src/Game/Constants/SAM.ts
@@ -1,3 +1,5 @@
+import { TraitName } from "../Traits";
+
 export enum SAMSkillName {
 	Enpi = "Enpi",
 	Hakaze = "Hakaze",
@@ -92,3 +94,19 @@ export enum SAMCooldownType {
 	cd_ThirdEye = "cd_ThirdEye",
 	cd_ThirdEyePop = "cd_ThirdEyePop", // [0, 1,], not real
 }
+
+export const SAMTraitList: Array<[TraitName, number]> = [
+	[TraitName.EnhancedIaijutsu, 74],
+	[TraitName.EnhancedMeikyoShisui, 76],
+	[TraitName.EnhancedFugetsuAndFuka, 78],
+	[TraitName.ThirdEyeMastery, 82],
+	[TraitName.WayOfTheSamuraiII, 84],
+	[TraitName.FugaMastery, 86],
+	[TraitName.EnhancedIkishoten, 90],
+	[TraitName.HakazeMastery, 92],
+	[TraitName.EnhancedHissatsu, 94],
+	[TraitName.WayOfTheSamuraiIII, 94],
+	[TraitName.EnhancedIkishotenII, 96],
+	[TraitName.EnhancedMeikyoShisuiII, 100],
+	[TraitName.EnhancedFeint, 98],
+];

--- a/src/Game/Constants/SAM.ts
+++ b/src/Game/Constants/SAM.ts
@@ -1,5 +1,3 @@
-import { TraitName } from "../Traits";
-
 export enum SAMSkillName {
 	Enpi = "Enpi",
 	Hakaze = "Hakaze",
@@ -95,18 +93,33 @@ export enum SAMCooldownType {
 	cd_ThirdEyePop = "cd_ThirdEyePop", // [0, 1,], not real
 }
 
-export const SAMTraitList: Array<[TraitName, number]> = [
-	[TraitName.EnhancedIaijutsu, 74],
-	[TraitName.EnhancedMeikyoShisui, 76],
-	[TraitName.EnhancedFugetsuAndFuka, 78],
-	[TraitName.ThirdEyeMastery, 82],
-	[TraitName.WayOfTheSamuraiII, 84],
-	[TraitName.FugaMastery, 86],
-	[TraitName.EnhancedIkishoten, 90],
-	[TraitName.HakazeMastery, 92],
-	[TraitName.EnhancedHissatsu, 94],
-	[TraitName.WayOfTheSamuraiIII, 94],
-	[TraitName.EnhancedIkishotenII, 96],
-	[TraitName.EnhancedMeikyoShisuiII, 100],
-	[TraitName.EnhancedFeint, 98],
+export enum SAMTraitName {
+	EnhancedIaijutsu = 7000,
+	EnhancedMeikyoShisui,
+	EnhancedFugetsuAndFuka,
+	ThirdEyeMastery,
+	WayOfTheSamuraiII,
+	FugaMastery,
+	EnhancedIkishoten,
+	HakazeMastery,
+	EnhancedHissatsu,
+	WayOfTheSamuraiIII,
+	EnhancedIkishotenII,
+	EnhancedMeikyoShisuiII,
+}
+
+export const SAMTraitList: Array<[SAMTraitName, number]> = [
+	[SAMTraitName.EnhancedIaijutsu, 74],
+	[SAMTraitName.EnhancedMeikyoShisui, 76],
+	[SAMTraitName.EnhancedMeikyoShisui, 76],
+	[SAMTraitName.EnhancedFugetsuAndFuka, 78],
+	[SAMTraitName.ThirdEyeMastery, 82],
+	[SAMTraitName.WayOfTheSamuraiII, 84],
+	[SAMTraitName.FugaMastery, 86],
+	[SAMTraitName.EnhancedIkishoten, 90],
+	[SAMTraitName.HakazeMastery, 92],
+	[SAMTraitName.EnhancedHissatsu, 94],
+	[SAMTraitName.WayOfTheSamuraiIII, 94],
+	[SAMTraitName.EnhancedIkishotenII, 96],
+	[SAMTraitName.EnhancedMeikyoShisuiII, 100],
 ];

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -3,7 +3,7 @@
 import {controller} from "../../Controller/Controller";
 import {ActionNode} from "../../Controller/Record";
 import {ShellJob} from "../../Controller/Common";
-import {Aspect, BuffType, Debug, ProcMode, ResourceType, SkillName, WarningType} from "../Common";
+import {Aspect, BuffType, Debug, ProcMode, ResourceType, SkillName, TraitName, WarningType} from "../Common";
 import {Modifiers, Potency, PotencyModifierType, PotencyMultiplier} from "../Potency";
 import {
 	Ability,
@@ -19,7 +19,7 @@ import {
 	Spell,
 	StatePredicate,
 } from "../Skills";
-import {TraitName, Traits} from "../Traits";
+import {Traits} from "../Traits";
 import {GameState, PlayerState} from "../GameState";
 import {getResourceInfo, makeResource, CoolDown, DoTBuff, Event, Resource, ResourceInfo} from "../Resources"
 import {GameConfig} from "../GameConfig";
@@ -60,7 +60,7 @@ export class BLMState extends GameState {
 
 		this.thunderTickOffset = this.nonProcRng() * 3.0;
 
-		const polyglotStacks = 
+		const polyglotStacks =
 			(Traits.hasUnlocked(TraitName.EnhancedPolyglotII, this.config.level) && 3) ||
 			(Traits.hasUnlocked(TraitName.EnhancedPolyglot, this.config.level) && 2) ||
 			1;
@@ -167,7 +167,7 @@ export class BLMState extends GameState {
 			if (Traits.hasUnlocked(TraitName.AspectMasteryV, this.config.level)) {
 				if (ui.available(3) && uh.available(3)) {
 					paradox.gain(1);
-				}  
+				}
 			}
 
 			ui.consume(ui.availableAmount());

--- a/src/Game/Jobs/DNC.ts
+++ b/src/Game/Jobs/DNC.ts
@@ -1,13 +1,13 @@
 import { ShellJob } from "../../Controller/Common"
 import { controller } from "../../Controller/Controller";
-import { ProcMode, ResourceType, SkillName, WarningType } from "../Common";
+import { ProcMode, ResourceType, SkillName, TraitName, WarningType } from "../Common";
 import { DNCResourceType } from "../Constants/DNC";
 import { GameConfig } from "../GameConfig";
 import { GameState } from "../GameState";
 import { makeComboModifier, Modifiers, PotencyModifier } from "../Potency";
 import { CoolDown, getResourceInfo, makeResource, Resource, ResourceInfo } from "../Resources"
 import { Ability, combineEffects, ConditionalSkillReplace, CooldownGroupProperies, EffectFn, getBasePotency, makeAbility, makeResourceAbility, makeWeaponskill, NO_EFFECT, ResourceCalculationFn, StatePredicate, Weaponskill } from "../Skills";
-import { TraitName, Traits } from "../Traits";
+import { Traits } from "../Traits";
 
 const makeDNCResource = (rsc: ResourceType, maxValue: number, params? : {timeout?: number, default?: number}) => {
     makeResource(ShellJob.DNC, rsc, maxValue, params ?? {});

--- a/src/Game/Jobs/MCH.ts
+++ b/src/Game/Jobs/MCH.ts
@@ -1,7 +1,7 @@
 import { ShellJob } from "../../Controller/Common";
 import { controller } from "../../Controller/Controller";
 import { ActionNode } from "../../Controller/Record";
-import { Aspect, BuffType, ResourceType, SkillName, WarningType } from "../Common";
+import { Aspect, BuffType, ResourceType, SkillName, TraitName, WarningType } from "../Common";
 import { MCHResourceType } from "../Constants/MCH";
 import { GameConfig } from "../GameConfig";
 import { GameState } from "../GameState";
@@ -23,7 +23,7 @@ import {
     StatePredicate, 
     Weaponskill 
 } from "../Skills";
-import { TraitName, Traits } from "../Traits";
+import { Traits } from "../Traits";
 
 const makeMCHResource = (rsc: ResourceType, maxValue: number, params? : {timeout?: number, default?: number}) => {
     makeResource(ShellJob.MCH, rsc, maxValue, params ?? {});

--- a/src/Game/Jobs/PCT.ts
+++ b/src/Game/Jobs/PCT.ts
@@ -2,7 +2,7 @@
 
 import {controller} from "../../Controller/Controller";
 import {ShellJob} from "../../Controller/Common";
-import {ResourceType, SkillName, WarningType} from "../Common";
+import {ResourceType, SkillName, TraitName, WarningType} from "../Common";
 import {Modifiers, PotencyModifier} from "../Potency";
 import {
 	Ability,
@@ -17,7 +17,7 @@ import {
 	Spell,
 	StatePredicate,
 } from "../Skills";
-import {TraitName, Traits} from "../Traits";
+import {Traits} from "../Traits";
 import {GameState} from "../GameState";
 import {getResourceInfo, makeResource, CoolDown, ResourceInfo} from "../Resources"
 import {GameConfig} from "../GameConfig";

--- a/src/Game/Jobs/RDM.ts
+++ b/src/Game/Jobs/RDM.ts
@@ -2,7 +2,7 @@
 
 import {controller} from "../../Controller/Controller";
 import {ShellJob} from "../../Controller/Common";
-import {Aspect, ProcMode, ResourceType, SkillName, WarningType} from "../Common";
+import {Aspect, ProcMode, ResourceType, SkillName, TraitName, WarningType} from "../Common";
 import {makeComboModifier, Modifiers, PotencyModifier} from "../Potency";
 import {
 	Ability,
@@ -21,7 +21,7 @@ import {
 	StatePredicate,
 	Weaponskill,
 } from "../Skills";
-import {TraitName, Traits} from "../Traits";
+import {Traits} from "../Traits";
 import {GameState} from "../GameState";
 import {getResourceInfo, makeResource, CoolDown, Resource, ResourceInfo} from "../Resources"
 import {GameConfig} from "../GameConfig";

--- a/src/Game/Jobs/RPR.ts
+++ b/src/Game/Jobs/RPR.ts
@@ -1,12 +1,12 @@
 import { ShellJob } from "../../Controller/Common";
-import { Aspect, ResourceType, SkillName } from "../Common";
+import { Aspect, ResourceType, SkillName, TraitName } from "../Common";
 import { RPRResourceType, RPRSkillName } from "../Constants/RPR";
 import { GameConfig } from "../GameConfig";
 import { GameState } from "../GameState";
 import { makeComboModifier, makePositionalModifier, Modifiers, PotencyModifier } from "../Potency";
 import { CoolDown, makeResource } from "../Resources";
 import { Ability, combineEffects, combinePredicatesAnd, ConditionalSkillReplace, CooldownGroupProperies, EffectFn, getBasePotency, getSkill, makeAbility, makeResourceAbility, makeSpell, makeWeaponskill, NO_EFFECT, ResourceCalculationFn, Spell, StatePredicate, Weaponskill } from "../Skills";
-import { TraitName, Traits } from "../Traits";
+import { Traits } from "../Traits";
 
 function makeRPRResource(type: ResourceType, maxValue: number, params?: { timeout?: number, default?: number }) {
     makeResource(ShellJob.RPR, type, maxValue, params ?? {});
@@ -501,8 +501,8 @@ makeRPRWeaponskill(SkillName.ShadowOfDeath, 10, {
 makeRPRWeaponskill(SkillName.Slice, 1, {
     potency: [
         [TraitName.Never, 260],
-        [TraitName.MeleeMasteryII, 320],
-        [TraitName.MeleeMasteryIII, 460]
+        [TraitName.MeleeMasteryIIIRPR, 320],
+        [TraitName.MeleeMasteryIIIRPR, 460]
     ],
     aspect: Aspect.Physical,
     recastTime: 2.5,
@@ -512,14 +512,14 @@ makeRPRWeaponskill(SkillName.Slice, 1, {
 makeRPRWeaponskill(SkillName.WaxingSlice, 5, {
     potency: [
         [TraitName.Never, 100],
-        [TraitName.MeleeMasteryII, 160],
-        [TraitName.MeleeMasteryIII, 260]
+        [TraitName.MeleeMasteryIIRPR, 160],
+        [TraitName.MeleeMasteryIIIRPR, 260]
     ],
     combo: {
         potency: [
             [TraitName.Never, 340],
-            [TraitName.MeleeMasteryII, 400],
-            [TraitName.MeleeMasteryIII, 500],
+            [TraitName.MeleeMasteryIIRPR, 400],
+            [TraitName.MeleeMasteryIIIRPR, 500],
         ],
         resource: ResourceType.RPRCombo,
         resourceValue: 1,
@@ -535,14 +535,14 @@ makeRPRWeaponskill(SkillName.WaxingSlice, 5, {
 makeRPRWeaponskill(SkillName.InfernalSlice, 30, {
     potency: [
         [TraitName.Never, 100],
-        [TraitName.MeleeMasteryII, 180],
-        [TraitName.MeleeMasteryIII, 280],
+        [TraitName.MeleeMasteryIIRPR, 180],
+        [TraitName.MeleeMasteryIIIRPR, 280],
     ],
     combo: {
         potency: [
             [TraitName.Never, 420],
-            [TraitName.MeleeMasteryII, 500],
-            [TraitName.MeleeMasteryIII, 600],
+            [TraitName.MeleeMasteryIIRPR, 500],
+            [TraitName.MeleeMasteryIIIRPR, 600],
         ],
         resource: ResourceType.RPRCombo,
         resourceValue: 2,
@@ -559,7 +559,7 @@ makeRPRWeaponskill(SkillName.InfernalSlice, 30, {
 makeRPRWeaponskill(SkillName.SoulSlice, 60, {
     potency: [
         [TraitName.Never, 460],
-        [TraitName.MeleeMasteryIII, 520]
+        [TraitName.MeleeMasteryIIIRPR, 520]
     ],
     aspect: Aspect.Physical,
     recastTime: 2.5,
@@ -584,12 +584,12 @@ makeRPRWeaponskill(SkillName.Gibbet, 70, {
     ],
     potency: [
         [TraitName.Never, 460],
-        [TraitName.MeleeMasteryIII, 500],
+        [TraitName.MeleeMasteryIIIRPR, 500],
     ],
     positional: {
         potency: [
             [TraitName.Never, 520],
-            [TraitName.MeleeMasteryIII, 560],
+            [TraitName.MeleeMasteryIIIRPR, 560],
         ],
         location: "flank"
     },
@@ -617,12 +617,12 @@ makeRPRWeaponskill(SkillName.Gallows, 70, {
     ],
     potency: [
         [TraitName.Never, 460],
-        [TraitName.MeleeMasteryIII, 500],
+        [TraitName.MeleeMasteryIIIRPR, 500],
     ],
     positional: {
         potency: [
             [TraitName.Never, 520],
-            [TraitName.MeleeMasteryIII, 560],
+            [TraitName.MeleeMasteryIIIRPR, 560],
         ],
         location: "rear"
     },
@@ -743,7 +743,7 @@ makeRPRSpell(SkillName.Soulsow, 82, {
 makeRPRSpell(SkillName.HarvestMoon, 82, {
     potency: [
         [TraitName.Never, 600],
-        [TraitName.MeleeMasteryIII, 800],
+        [TraitName.MeleeMasteryIIIRPR, 800],
     ],
     startOnHotbar: false,
     aspect: Aspect.Other,
@@ -835,7 +835,7 @@ makeRPRAbility(SkillName.LemuresSlice, 86, ResourceType.cd_BloodStalk, {
     isPhysical: true,
     potency: [
         [TraitName.Never, 240],
-        [TraitName.MeleeMasteryIII, 280]
+        [TraitName.MeleeMasteryIIIRPR, 280]
     ],
     startOnHotbar: false,
     applicationDelay: 0.7,
@@ -877,7 +877,7 @@ makeRPRWeaponskill(SkillName.VoidReaping, 80, {
     startOnHotbar: false,
     potency: [
         [TraitName.Never, 460],
-        [TraitName.MeleeMasteryIII, 500],
+        [TraitName.MeleeMasteryIIIRPR, 500],
     ],
     aspect: Aspect.Physical,
     recastTime: 1.5,
@@ -900,7 +900,7 @@ makeRPRWeaponskill(SkillName.CrossReaping, 80, {
     startOnHotbar: false,
     potency: [
         [TraitName.Never, 460],
-        [TraitName.MeleeMasteryIII, 500],
+        [TraitName.MeleeMasteryIIIRPR, 500],
     ],
     aspect: Aspect.Physical,
     recastTime: 1.5,

--- a/src/Game/Jobs/RoleActions.ts
+++ b/src/Game/Jobs/RoleActions.ts
@@ -1,8 +1,8 @@
 import {ALL_JOBS, CASTER_JOBS, HEALER_JOBS, MELEE_JOBS, PHYSICAL_RANGED_JOBS, ShellJob, TANK_JOBS} from "../../Controller/Common";
-import {SkillName, ResourceType, WarningType} from "../Common";
+import {SkillName, ResourceType, TraitName, WarningType} from "../Common";
 import {combineEffects, makeAbility, makeResourceAbility} from "../Skills";
 import {DoTBuff, EventTag, makeResource} from "../Resources"
-import {Traits, TraitName} from "../Traits";
+import {Traits} from "../Traits";
 import type {GameState} from "../GameState";
 import {controller} from "../../Controller/Controller";
 

--- a/src/Game/Jobs/SAM.ts
+++ b/src/Game/Jobs/SAM.ts
@@ -3,7 +3,7 @@
 import {controller} from "../../Controller/Controller";
 import {ActionNode} from "../../Controller/Record";
 import {ShellJob} from "../../Controller/Common";
-import {Aspect, BuffType, ResourceType, SkillName, WarningType} from "../Common";
+import {Aspect, BuffType, ResourceType, SkillName, TraitName, WarningType} from "../Common";
 import {makeComboModifier, makePositionalModifier, Modifiers, Potency, PotencyModifier} from "../Potency";
 import {
 	Ability,
@@ -21,7 +21,7 @@ import {
 	StatePredicate,
 	Weaponskill,
 } from "../Skills";
-import {TraitName, Traits} from "../Traits";
+import {Traits} from "../Traits";
 import {GameState} from "../GameState";
 import {makeResource, CoolDown, DoTBuff, Event, EventTag} from "../Resources"
 import {GameConfig} from "../GameConfig";

--- a/src/Game/Skills.ts
+++ b/src/Game/Skills.ts
@@ -1,8 +1,8 @@
-import {Aspect, LevelSync, ResourceType, SkillName} from './Common'
+import {Aspect, LevelSync, ResourceType, SkillName, TraitName} from './Common'
 import {ShellJob, ALL_JOBS} from "../Controller/Common";
 import {ActionNode} from "../Controller/Record";
 import {PlayerState, GameState} from "./GameState";
-import {TraitName, Traits} from './Traits';
+import {Traits} from './Traits';
 import {makeCooldown, getResourceInfo, ResourceInfo} from "./Resources";
 import {PotencyModifier} from "./Potency";
 

--- a/src/Game/Traits.ts
+++ b/src/Game/Traits.ts
@@ -1,4 +1,4 @@
-import {LevelSync} from "./Common";
+import { LevelSync, TraitList } from "./Common";
 
 export class Trait {
 	readonly name: TraitName;
@@ -112,111 +112,9 @@ export const enum TraitName {
 	Never,
 }
 
-// TODO move this out to Common.ts/job-specific files
 export class Traits {
-	static list: Map<TraitName, Trait> = this.buildList();
-	static buildList() {
-		return new Map<TraitName, Trait>([
-			[TraitName.EnhancedEnochianII, 78],
-			[TraitName.EnhancedPolyglot, 80],
-			[TraitName.EnhancedFoul, 80],
-			[TraitName.AspectMasteryIV, 82],
-			[TraitName.EnhancedManafont, 84],
-			[TraitName.EnhancedEnochianIII, 86],
-			[TraitName.AspectMasteryV, 90],
-			[TraitName.ThunderMasteryIII, 92],
-			[TraitName.EnhancedSwiftcast, 94],
-			[TraitName.EnhancedLeyLines, 96],
-			[TraitName.EnhancedEnochianIV, 96],
-			[TraitName.EnhancedPolyglotII, 98],
-			[TraitName.EnhancedAddle, 98],
-			[TraitName.EnhancedAstralFire, 100],
-
-			[TraitName.PictomancyMasteryII, 74],
-			[TraitName.EnhancedArtistry, 80],
-			[TraitName.EnhancedPictomancy, 82],
-			[TraitName.EnhancedSmudge, 84],
-			[TraitName.PictomancyMasteryIII, 84],
-			[TraitName.EnhancedPictomancyII, 86],
-			[TraitName.EnhancedTempera, 88],
-			[TraitName.EnhancedTempera, 90],
-			[TraitName.EnhancedPictomancyIII, 92],
-			[TraitName.PictomancyMasteryIV, 94],
-			[TraitName.EnhancedPictomancyIV, 96],
-			[TraitName.EnhancedPictomancyV, 100],
-
-			[TraitName.EnhancedDisplacement, 72],
-			[TraitName.RedMagicMastery, 74],
-			[TraitName.EnhancedManafication, 78],
-			[TraitName.RedMagicMasteryII, 82],
-			[TraitName.RedMagicMasteryIII, 84],
-			[TraitName.EnhancedAcceleration, 88],
-			[TraitName.EnhancedManaficationII, 90],
-			[TraitName.EnhancedEmbolden, 92],
-			[TraitName.EnchantedBladeMastery, 94],
-			[TraitName.EnhancedAccelerationII, 96],
-			[TraitName.EnhancedManaficationIII, 100],
-			
-			[TraitName.Hellsgate, 74],
-			[TraitName.TemperedSoul, 78],
-			[TraitName.ShroudGauge, 80],
-			[TraitName.EnhancedArcaneCrest, 84],
-			[TraitName.MeleeMasteryII, 84],
-			[TraitName.VoidSoul, 86],
-			[TraitName.EnhancedArcaneCircle, 88],
-			[TraitName.EnhancedEnshroud, 92],
-			[TraitName.EnhancedSecondWind, 94],
-			[TraitName.MeleeMasteryIII, 94],
-			[TraitName.EnhancedGluttony, 96],
-			[TraitName.EnhancedPlentifulHarvest, 100],
-
-
-			[TraitName.Esprit, 76],
-			[TraitName.EnhancedEnAvantII, 78],
-			[TraitName.EnhancedTechnicalFinish, 82],
-			[TraitName.EnhancedEsprit, 84],
-			[TraitName.EnhancedFlourish, 86],
-			[TraitName.EnhancedShieldSamba, 88],
-			[TraitName.EnhancedDevilment, 90],
-			[TraitName.EnhancedStandardFinish, 92],
-			[TraitName.DynamicDancer, 94],
-			[TraitName.EnhancedFlourishII, 96],
-			[TraitName.EnhancedTechnicalFinishII, 100],
-
-			[TraitName.EnhancedIaijutsu, 74],
-			[TraitName.EnhancedMeikyoShisui, 76],
-			[TraitName.EnhancedFugetsuAndFuka, 78],
-			[TraitName.ThirdEyeMastery, 82],
-			[TraitName.WayOfTheSamuraiII, 84],
-			[TraitName.FugaMastery, 86],
-			[TraitName.EnhancedIkishoten, 90],
-			[TraitName.HakazeMastery, 92],
-			[TraitName.EnhancedHissatsu, 94],
-			[TraitName.WayOfTheSamuraiIII, 94],
-			[TraitName.EnhancedIkishotenII, 96],
-			[TraitName.EnhancedMeikyoShisuiII, 100],
-			[TraitName.EnhancedFeint, 98],
-			
-			[TraitName.ChargedActionMastery, 74],
-			[TraitName.HotShotMastery, 76],
-			[TraitName.EnhancedWildfire, 88],
-			[TraitName.Promotion, 80],
-			[TraitName.SpreadShotMastery, 82],
-			[TraitName.EnhancedReassemble, 84],
-			[TraitName.MarksmansMastery, 84],
-			[TraitName.QueensGambit, 86],
-			[TraitName.EnhancedTactician, 88],
-			[TraitName.DoubleBarrelMastery, 92],
-			[TraitName.EnhancedMultiWeapon, 94],
-			[TraitName.MarksmansMasteryII, 94],
-			[TraitName.EnhancedMultiWeaponII, 96],
-			[TraitName.EnhancedBarrelStabilizer, 100],
-
-		].map(([name, level]) => [name, new Trait(name, level)]));
-	}
-
 	static hasUnlocked(traitName: TraitName, level: LevelSync) {
-		const trait = this.list.get(traitName) || new Trait(TraitName.Never, 1);
+		const trait = TraitList.get(traitName) || new Trait(TraitName.Never, 1);
 		return level >= trait.level;
 	}
 }

--- a/src/Game/Traits.ts
+++ b/src/Game/Traits.ts
@@ -1,4 +1,4 @@
-import { LevelSync, TraitList } from "./Common";
+import { LevelSync, TraitList, TraitName } from "./Common";
 
 export class Trait {
 	readonly name: TraitName;
@@ -10,111 +10,14 @@ export class Trait {
 	}
 }
 
-export const enum TraitName {
-	// BLM
-	EnhancedEnochianII,
-	EnhancedPolyglot,
-	EnhancedFoul,
-	AspectMasteryIV,
-	EnhancedManafont,
-	EnhancedEnochianIII,
-	AspectMasteryV,
-	ThunderMasteryIII,
-	EnhancedSwiftcast,
-	EnhancedLeyLines,
-	EnhancedEnochianIV,
-	EnhancedPolyglotII,
-	EnhancedAddle,
-	EnhancedAstralFire,
-
-	// PCT
-	PictomancyMasteryII,
-	EnhancedArtistry,
-	EnhancedPictomancy,
-	EnhancedSmudge,
-	PictomancyMasteryIII,
-	EnhancedPictomancyII,
-	EnhancedTempera,
-	EnhancedPalette,
-	EnhancedPictomancyIII,
-	PictomancyMasteryIV,
-	EnhancedPictomancyIV,
-	EnhancedPictomancyV,
-
-	// RDM
-	EnhancedDisplacement,
-	RedMagicMastery,
-	EnhancedManafication,
-	RedMagicMasteryII,
-	RedMagicMasteryIII,
-	EnhancedAcceleration,
-	EnhancedManaficationII,
-	EnhancedEmbolden,
-	EnchantedBladeMastery,
-	EnhancedAccelerationII,
-	EnhancedManaficationIII,
-
-	Hellsgate,
-	TemperedSoul,
-	ShroudGauge,
-	EnhancedArcaneCrest,
-	MeleeMasteryII,
-	VoidSoul,
-	EnhancedArcaneCircle,
-	EnhancedEnshroud,
-	EnhancedSecondWind,
-	MeleeMasteryIII,
-	EnhancedGluttony,
-	EnhancedPlentifulHarvest,
-	// DNC
-	Esprit,
-	EnhancedEnAvantII,
-	EnhancedTechnicalFinish,
-	EnhancedEsprit,
-	EnhancedFlourish,
-	EnhancedShieldSamba,
-	EnhancedDevilment,
-	EnhancedStandardFinish,
-	DynamicDancer,
-	EnhancedFlourishII,
-	EnhancedTechnicalFinishII,
-
-	EnhancedIaijutsu,
-	EnhancedMeikyoShisui,
-	EnhancedFugetsuAndFuka,
-	ThirdEyeMastery,
-	WayOfTheSamuraiII,
-	FugaMastery,
-	EnhancedIkishoten,
-	HakazeMastery,
-	EnhancedHissatsu,
-	WayOfTheSamuraiIII,
-	EnhancedIkishotenII,
-	EnhancedMeikyoShisuiII,
-	EnhancedFeint,
-
-	// MCH
-	ChargedActionMastery,
-	HotShotMastery,
-	EnhancedWildfire,
-	Promotion,
-	SpreadShotMastery,
-	EnhancedReassemble,
-	MarksmansMastery,
-	QueensGambit,
-	EnhancedTactician,
-	DoubleBarrelMastery,
-	EnhancedMultiWeapon,
-	MarksmansMasteryII,
-	EnhancedMultiWeaponII,
-	EnhancedBarrelStabilizer,
-
-	Never,
-}
-
 export class Traits {
+	static map: Map<TraitName, Trait> = this.buildMap();
+	static buildMap() {
+		return new Map<TraitName,Trait>(TraitList.map(([name, level]) => [name, new Trait(name, level)]));
+	}
+
 	static hasUnlocked(traitName: TraitName, level: LevelSync) {
-		const trait = TraitList.get(traitName) || new Trait(TraitName.Never, 1);
+		const trait = this.map.get(traitName) || new Trait(TraitName.Never, 1);
 		return level >= trait.level;
 	}
 }

--- a/src/Game/XIVMath.ts
+++ b/src/Game/XIVMath.ts
@@ -1,5 +1,5 @@
-import { LevelSync, ResourceType } from "./Common";
-import { Traits, TraitName } from "./Traits";
+import { LevelSync, ResourceType, TraitName } from "./Common";
+import { Traits } from "./Traits";
 
 export class XIVMath {
 	static getMainstatBase(level: LevelSync) {

--- a/src/traits.test.js
+++ b/src/traits.test.js
@@ -1,0 +1,53 @@
+import {TraitName,ReservedTraitName} from "./Game/Common"
+import {Traits} from "./Game/Traits"
+
+function GetTraits() {
+    const traitNameArr = Object.keys(TraitName).filter((v) => isNaN(Number(v)))
+    const traitNumberArr = Object.values(TraitName).filter((v) => !isNaN(Number(v)));
+    return  traitNameArr
+        .map((e, i) => [e, traitNumberArr[i]])
+        .filter(([name, value]) => !(Object.keys(ReservedTraitName).includes(name)));
+}
+
+// for helpful error messages
+expect.extend({
+    toBeGreaterExt([name, value], expected) {
+        return {
+            message: () => `${name} = ${value}. Must be greater than ${expected} (values 0-${expected} are reserved)`,
+            pass: value > expected
+        }
+    },
+    toBeUnique([name, value], map) {
+        return {
+            message: () => `${name} conflicts with ${map.get(value)}. Both have a value of ${value}.`,
+            pass: !map.has(value)
+        }
+    },
+    toBeLockedAtLevel0([name, value]) {
+        return {
+            message: () => `${name} is missing from Traits lookup. Make sure it is included in the TraitList`,
+            pass: !Traits.hasUnlocked(value, 0)
+        }
+    }
+  });
+
+// If this test fails, a Job's TraitName enum start was not set
+it("has no traits with value less than 100", async () => {
+    GetTraits().forEach(([name, value]) => {
+        expect([name, value]).toBeGreaterExt(99);
+    })
+})
+
+it("has unique trait values", async () => {
+    let map = new Map();
+    GetTraits().forEach(([name, value]) => {
+        expect([name, value]).toBeUnique(map);
+        map.set(value, name);
+    })
+})
+
+it("allows lookup of all traits", async () => {
+    GetTraits().forEach(([name, value]) => {
+        expect([name,value]).toBeLockedAtLevel0();
+    });
+})


### PR DESCRIPTION
Not sure if there's a better way to do this that avoids an apparent circular import between Common and Traits.
I tried to define TraitName elsewhere and only build the map from Trait.ts, but I was running into static initialization errors with `Trait:buildList()` referencing `Common.ts:TraitList` before it was initialized.