### PR TITLE
[MCH] Overheated stacks should not be consumed by (most) AoE skills

### DIFF
--- a/src/Game/Jobs/MCH.ts
+++ b/src/Game/Jobs/MCH.ts
@@ -57,6 +57,14 @@ makeMCHResource(ResourceType.BatteryBonus, 50)
 const COMBO_GCDS: SkillName[] = [SkillName.HeatedCleanShot, SkillName.HeatedSlugShot, SkillName.HeatedSplitShot,
     SkillName.SpreadShot, SkillName.Scattergun // Including AoE GCDs that break the combo, even though they don't combo themselves
 ]
+
+// Skills that don't consume overheat - these are all AoE skills
+// The only AoE skill that consumes overheat is Auto Crossbow
+const WEAPONSKILLS_THAT_DONT_CONSUME_OVERHEAT: SkillName[] = [
+    SkillName.Chainsaw, SkillName.Excavator, SkillName.FullMetalField,
+    SkillName.Scattergun, SkillName.Bioblaster
+];
+
 export class MCHState extends GameState {
     dotTickOffset: number
 
@@ -259,7 +267,6 @@ const makeWeaponskill_MCH = (name: SkillName, unlockLevel: number, params: {
     highlightIf?: StatePredicate<MCHState>,
     onApplication?: EffectFn<MCHState>,
     secondaryCooldown?: CooldownGroupProperies,
-    isCleave?: boolean,
 }): Weaponskill<MCHState> => {
     const onConfirm: EffectFn<MCHState> = combineEffects(
         params.onConfirm ?? NO_EFFECT,
@@ -277,11 +284,10 @@ const makeWeaponskill_MCH = (name: SkillName, unlockLevel: number, params: {
         // All single-target weaponskills executed during overheat will consume a stack
         // AoE weaponskills will NOT consume a stack (with the exception of auto crossbow)
         (state) => {
-            if (!(params.isCleave ?? false)) {
+            if (!WEAPONSKILLS_THAT_DONT_CONSUME_OVERHEAT.includes(name)) {
                 state.tryConsumeResource(ResourceType.Overheated)
             }
         }
-
     );
     const onApplication: EffectFn<MCHState> = params.onApplication ?? NO_EFFECT;
     return makeWeaponskill(ShellJob.MCH, name, unlockLevel, {
@@ -470,7 +476,6 @@ makeWeaponskill_MCH(SkillName.Chainsaw, 90, {
         cooldown: 60, // cooldown edited in constructor to be affected by skill speed
         maxCharges: 1
     },
-    isCleave: true
 })
 makeWeaponskill_MCH(SkillName.Excavator, 90, {
     startOnHotbar: false,
@@ -483,7 +488,6 @@ makeWeaponskill_MCH(SkillName.Excavator, 90, {
     },
     validateAttempt: (state) => state.hasResourceAvailable(ResourceType.ExcavatorReady),
     highlightIf: (state) => state.hasResourceAvailable(ResourceType.ExcavatorReady),
-    isCleave: true
 })
 
 makeAbility_MCH(SkillName.BarrelStabilizer, 66, ResourceType.cd_BarrelStabilizer, {
@@ -510,7 +514,6 @@ makeWeaponskill_MCH(SkillName.FullMetalField, 100, {
     onConfirm: (state) => state.tryConsumeResource(ResourceType.FullMetalMachinist),
     validateAttempt: (state) => state.hasResourceAvailable(ResourceType.FullMetalMachinist),
     highlightIf: (state) => state.hasResourceAvailable(ResourceType.FullMetalMachinist),
-    isCleave: true
 })
 
 makeResourceAbility_MCH(SkillName.Hypercharge, 30, ResourceType.cd_Hypercharge, {
@@ -852,10 +855,6 @@ makeWeaponskill_MCH(SkillName.AutoCrossbow, 52, {
     ],
     applicationDelay: 0.89,
     recastTime: 1.5,
-    isCleave: true,
-    onConfirm: (state) =>  {
-        state.tryConsumeResource(ResourceType.Overheated)
-    },
     validateAttempt: (state) => state.hasResourceAvailable(ResourceType.Overheated),
     highlightIf: (state) => state.hasResourceAvailable(ResourceType.Overheated),
 })

--- a/src/Game/Jobs/MCH.ts
+++ b/src/Game/Jobs/MCH.ts
@@ -259,6 +259,7 @@ const makeWeaponskill_MCH = (name: SkillName, unlockLevel: number, params: {
     highlightIf?: StatePredicate<MCHState>,
     onApplication?: EffectFn<MCHState>,
     secondaryCooldown?: CooldownGroupProperies,
+    isCleave?: boolean,
 }): Weaponskill<MCHState> => {
     const onConfirm: EffectFn<MCHState> = combineEffects(
         params.onConfirm ?? NO_EFFECT,
@@ -273,7 +274,14 @@ const makeWeaponskill_MCH = (name: SkillName, unlockLevel: number, params: {
                 state.resources.get(ResourceType.WildfireHits).gain(1)
             }
         },
-        (state) => state.tryConsumeResource(ResourceType.Overheated) // All weaponskills executed during overheat will consume a stack
+        // All single-target weaponskills executed during overheat will consume a stack
+        // AoE weaponskills will NOT consume a stack (with the exception of auto crossbow)
+        (state) => {
+            if (!(params.isCleave ?? false)) {
+                state.tryConsumeResource(ResourceType.Overheated)
+            }
+        }
+
     );
     const onApplication: EffectFn<MCHState> = params.onApplication ?? NO_EFFECT;
     return makeWeaponskill(ShellJob.MCH, name, unlockLevel, {
@@ -461,7 +469,8 @@ makeWeaponskill_MCH(SkillName.Chainsaw, 90, {
         cdName: ResourceType.cd_Chainsaw,
         cooldown: 60, // cooldown edited in constructor to be affected by skill speed
         maxCharges: 1
-    }
+    },
+    isCleave: true
 })
 makeWeaponskill_MCH(SkillName.Excavator, 90, {
     startOnHotbar: false,
@@ -473,7 +482,8 @@ makeWeaponskill_MCH(SkillName.Excavator, 90, {
         state.tryConsumeResource(ResourceType.ExcavatorReady)
     },
     validateAttempt: (state) => state.hasResourceAvailable(ResourceType.ExcavatorReady),
-    highlightIf: (state) => state.hasResourceAvailable(ResourceType.ExcavatorReady)
+    highlightIf: (state) => state.hasResourceAvailable(ResourceType.ExcavatorReady),
+    isCleave: true
 })
 
 makeAbility_MCH(SkillName.BarrelStabilizer, 66, ResourceType.cd_BarrelStabilizer, {
@@ -500,6 +510,7 @@ makeWeaponskill_MCH(SkillName.FullMetalField, 100, {
     onConfirm: (state) => state.tryConsumeResource(ResourceType.FullMetalMachinist),
     validateAttempt: (state) => state.hasResourceAvailable(ResourceType.FullMetalMachinist),
     highlightIf: (state) => state.hasResourceAvailable(ResourceType.FullMetalMachinist),
+    isCleave: true
 })
 
 makeResourceAbility_MCH(SkillName.Hypercharge, 30, ResourceType.cd_Hypercharge, {
@@ -841,6 +852,7 @@ makeWeaponskill_MCH(SkillName.AutoCrossbow, 52, {
     ],
     applicationDelay: 0.89,
     recastTime: 1.5,
+    isCleave: true,
     onConfirm: (state) =>  {
         state.tryConsumeResource(ResourceType.Overheated)
     },

--- a/src/Game/Jobs/MCH.ts
+++ b/src/Game/Jobs/MCH.ts
@@ -282,7 +282,6 @@ const makeWeaponskill_MCH = (name: SkillName, unlockLevel: number, params: {
             }
         },
         // All single-target weaponskills executed during overheat will consume a stack
-        // AoE weaponskills will NOT consume a stack (with the exception of auto crossbow)
         (state) => {
             if (!WEAPONSKILLS_THAT_DONT_CONSUME_OVERHEAT.includes(name)) {
                 state.tryConsumeResource(ResourceType.Overheated)

--- a/src/Game/Jobs/MCH.ts
+++ b/src/Game/Jobs/MCH.ts
@@ -62,7 +62,7 @@ const COMBO_GCDS: SkillName[] = [SkillName.HeatedCleanShot, SkillName.HeatedSlug
 // The only AoE skill that consumes overheat is Auto Crossbow
 const WEAPONSKILLS_THAT_DONT_CONSUME_OVERHEAT: SkillName[] = [
     SkillName.Chainsaw, SkillName.Excavator, SkillName.FullMetalField,
-    SkillName.Scattergun, SkillName.Bioblaster
+    SkillName.Scattergun, SkillName.Bioblaster, SkillName.SpreadShot
 ];
 
 export class MCHState extends GameState {

--- a/src/Game/Skills.ts
+++ b/src/Game/Skills.ts
@@ -115,9 +115,6 @@ interface BaseSkill<T extends PlayerState> {
 
 	// The simulation delay, in seconds, between which `onConfirm` and `onApplication` are called.
 	readonly applicationDelay: number;
-
-	// Does the attack cleave?
-	readonly isCleave?: boolean;
 }
 
 export type GCD<T extends PlayerState> = BaseSkill<T> & {
@@ -331,7 +328,6 @@ export function makeWeaponskill<T extends PlayerState>(jobs: ShellJob | ShellJob
 	applicationDelay: number,
 	validateAttempt: StatePredicate<T>,
 	isInstantFn: StatePredicate<T>,
-	isCleave?: boolean,
 	onConfirm: EffectFn<T>,
 	onApplication: EffectFn<T>,
 	secondaryCooldown?: CooldownGroupProperies,
@@ -362,7 +358,6 @@ export function makeWeaponskill<T extends PlayerState>(jobs: ShellJob | ShellJob
 		onConfirm: params.onConfirm ?? NO_EFFECT,
 		onApplication: params.onApplication ?? NO_EFFECT,
 		applicationDelay: params.applicationDelay ?? 0,
-		isCleave: params.isCleave ?? false,
 	};
 	jobs.forEach((job) => setSkill(job, info.name, info));
 	if (params.secondaryCooldown !== undefined) {

--- a/src/Game/Skills.ts
+++ b/src/Game/Skills.ts
@@ -115,6 +115,9 @@ interface BaseSkill<T extends PlayerState> {
 
 	// The simulation delay, in seconds, between which `onConfirm` and `onApplication` are called.
 	readonly applicationDelay: number;
+
+	// Does the attack cleave?
+	readonly isCleave?: boolean;
 }
 
 export type GCD<T extends PlayerState> = BaseSkill<T> & {
@@ -328,6 +331,7 @@ export function makeWeaponskill<T extends PlayerState>(jobs: ShellJob | ShellJob
 	applicationDelay: number,
 	validateAttempt: StatePredicate<T>,
 	isInstantFn: StatePredicate<T>,
+	isCleave?: boolean,
 	onConfirm: EffectFn<T>,
 	onApplication: EffectFn<T>,
 	secondaryCooldown?: CooldownGroupProperies,
@@ -358,6 +362,7 @@ export function makeWeaponskill<T extends PlayerState>(jobs: ShellJob | ShellJob
 		onConfirm: params.onConfirm ?? NO_EFFECT,
 		onApplication: params.onApplication ?? NO_EFFECT,
 		applicationDelay: params.applicationDelay ?? 0,
+		isCleave: params.isCleave ?? false,
 	};
 	jobs.forEach((job) => setSkill(job, info.name, info));
 	if (params.secondaryCooldown !== undefined) {


### PR DESCRIPTION
Per the job guide:

```
Grants 5 stacks of Overheated, each stack allowing the execution of Blazing Shot or Auto Crossbow.
Duration: 10s
Overheated Effect: Increases the potency of single-target weaponskills by 20
Heat Gauge Cost: 50
Overheated effect only applicable to machinist job actions.
```

The only AoE weaponskill to consume stacks of overheated is autocrossbow

this PR adds an `isCleave?` parameter to the `Weaponskill` type, which is used to determine whether we should
eat a stack or not. There was already special-case handling on autocrossbow to eat a stack, which was leading
to it eating 2 stacks per usage. This fixes that too.
