### PR TITLE
Make stats tables only include selected nodes when there is selection

### DIFF
--- a/src/BlmRotations.test.ts
+++ b/src/BlmRotations.test.ts
@@ -16,12 +16,12 @@
 
 import fs from "node:fs";
 import {controller} from "./Controller/Controller";
-import {TickMode, ShellJob} from "./Controller/Common";
+import {TickMode} from "./Controller/Common";
 import {DEFAULT_BLM_CONFIG, GameConfig} from "./Game/GameConfig";
 import {PotencyModifierType} from "./Game/Potency";
 import {ResourceType, SkillName} from "./Game/Common";
 import {BLMState} from "./Game/Jobs/BLM";
-import {DamageStatisticsData, mockDamageStatUpdateFn} from "./Components/DamageStatistics";
+import {DamageStatisticsData, DamageStatisticsMode, mockDamageStatUpdateFn} from "./Components/DamageStatistics";
 
 
 // If this configuration flag is set to `true`, then the fight record of each test run
@@ -58,7 +58,7 @@ const resetDamageData = () => {
 			totalPotPotency: 0,
 			totalPartyBuffPotency: 0,
 		},
-		historical: false,
+		mode: DamageStatisticsMode.Normal
 	};
 };
 

--- a/src/BlmRotations.test.ts
+++ b/src/BlmRotations.test.ts
@@ -75,8 +75,8 @@ beforeEach(() => {
 	// clear stats from the last run
 	resetDamageData();
 	// monkeypatch the updateDamageStats function to avoid needing to initialize the frontend
-	mockDamageStatUpdateFn((newData: DamageStatisticsData) => {
-		damageData = newData;
+	mockDamageStatUpdateFn((newData: Partial<DamageStatisticsData>) => {
+		damageData = {...damageData, ...newData};
 	});
 	// config reset is handled in testWithConfig helper
 });

--- a/src/Components/DamageStatistics.tsx
+++ b/src/Components/DamageStatistics.tsx
@@ -59,6 +59,12 @@ export type SelectedStatisticsData = {
 	}
 }
 
+export enum DamageStatisticsMode {
+	Normal,
+	Historical,
+	Selected
+}
+
 export type DamageStatisticsData = {
 	time: number,
 	tinctureBuffPercentage: number,
@@ -91,7 +97,7 @@ export type DamageStatisticsData = {
 		totalPotPotency: number,
 		totalPartyBuffPotency: number,
 	},
-	historical: boolean,
+	mode: DamageStatisticsMode,
 }
 
 export let updateDamageStats = (data: DamageStatisticsData) => {};
@@ -409,7 +415,7 @@ export class DamageStatistics extends React.Component {
 			totalPotPotency: 0,
 			totalPartyBuffPotency: 0,
 		},
-		historical: false,
+		mode: DamageStatisticsMode.Normal,
 	};
 
 	constructor(props: {}) {
@@ -478,7 +484,7 @@ export class DamageStatistics extends React.Component {
 		let selected: React.ReactNode | undefined = undefined;
 		let selectedPPSAvailable = this.selected.targetableDuration > 0;
 		if (this.selected.totalDuration > 0) {
-			selected = <div style={{flex: 1}}>
+			selected = <div style={{flex: 1, color: colors.accent}}>
 				<div>{localize({en: "Selected duration", zh: "选中时长"})}{colon}{this.selected.totalDuration.toFixed(3)}</div>
 				<div>{selectedPotencyStr}</div>
 				<div>{localize({en: "Selected PPS", zh: "选中部分PPS"})}{colon}{selectedPPSAvailable ? (this.selected.potency.applied / this.selected.targetableDuration).toFixed(2) : "N/A"}</div>
@@ -488,7 +494,7 @@ export class DamageStatistics extends React.Component {
 
 		let summary = <div style={{display: "flex", marginBottom: 10, flexDirection: "row"}}>
 			<div style={{flex: 1}}>
-				<div style={{color: this.data.historical ? colors.historical : colors.text}}>
+				<div style={{color: this.data.mode !== DamageStatisticsMode.Normal ? colors.historical : colors.text}}>
 					<div>{localize({en: "Last damage application time", zh: "最后伤害结算时间"})}{colon}{lastDamageApplicationTimeDisplay}</div>
 					<div>{potencyStr}</div>
 					<div>PPS <Help topic={"ppsNotes"} content={
@@ -745,7 +751,7 @@ export class DamageStatistics extends React.Component {
 		} else if (controller.game.job === ShellJob.MCH) {
 			dotHeaderStr = localize({en: "Bioblaster"})
 		}
-		if (this.data.historical) {
+		if (this.data.mode === DamageStatisticsMode.Historical) {
 			let t = (this.data.time - this.data.countdown).toFixed(3) + "s";
 			let upTillStr = lparen + localize({
 				en: "up till " + t,
@@ -753,7 +759,17 @@ export class DamageStatistics extends React.Component {
 			}) + rparen;
 			mainHeaderStr += upTillStr;
 			dotHeaderStr += upTillStr;
+		} else if (this.data.mode === DamageStatisticsMode.Selected) {
+			const selectedStr = lparen + localize({
+				en: "selected",
+				zh: "选中部分"
+			}) + rparen;
+			mainHeaderStr += selectedStr;
+			dotHeaderStr += selectedStr;
 		}
+		let titleColor = colors.text;
+		if (this.data.mode === DamageStatisticsMode.Historical) titleColor = colors.historical;
+		else if (this.data.mode === DamageStatisticsMode.Selected) titleColor = colors.accent;
 		let mainTable = <div id="damageTable" style={{
 			position: "relative",
 			margin: "0 auto",
@@ -761,7 +777,7 @@ export class DamageStatistics extends React.Component {
 			maxWidth: 960,
 		}}>
 			<div style={{...cell(100), ...{textAlign: "center", marginBottom: 10}}}>
-				<b style={this.data.historical ? {color: colors.historical}:undefined}>{mainHeaderStr}</b>
+				<b style={{color: titleColor}}>{mainHeaderStr}</b>
 			</div>
 			<div style={{outline: "1px solid " + colors.bgMediumContrast}}>
 				<div>
@@ -799,7 +815,7 @@ export class DamageStatistics extends React.Component {
 			maxWidth: 960,
 		}}>
 			<div style={{...cell(100), ...{textAlign: "center", marginBottom: 10}}}>
-				<b style={this.data.historical ? {color: colors.historical}:undefined}>{dotHeaderStr}</b>
+				<b style={{color: titleColor}}>{dotHeaderStr}</b>
 			</div>
 			<div style={{outline: "1px solid " + colors.bgMediumContrast}}>
 				<div>

--- a/src/Components/DamageStatistics.tsx
+++ b/src/Components/DamageStatistics.tsx
@@ -761,8 +761,8 @@ export class DamageStatistics extends React.Component {
 			dotHeaderStr += upTillStr;
 		} else if (this.data.mode === DamageStatisticsMode.Selected) {
 			const selectedStr = lparen + localize({
-				en: "selected",
-				zh: "选中部分"
+				en: "from selected skills",
+				zh: "来自选中技能"
 			}) + rparen;
 			mainHeaderStr += selectedStr;
 			dotHeaderStr += selectedStr;

--- a/src/Components/DamageStatistics.tsx
+++ b/src/Components/DamageStatistics.tsx
@@ -100,11 +100,11 @@ export type DamageStatisticsData = {
 	mode: DamageStatisticsMode,
 }
 
-export let updateDamageStats = (data: DamageStatisticsData) => {};
-export let updateSelectedStats = (data: SelectedStatisticsData) => {};
+export let updateDamageStats = (data: Partial<DamageStatisticsData>) => {};
+export let updateSelectedStats = (data: Partial<SelectedStatisticsData>) => {};
 
 // hook for tests to access damage stats
-export const mockDamageStatUpdateFn = (updateFn: (update: DamageStatisticsData) => void) => {
+export const mockDamageStatUpdateFn = (updateFn: (update: Partial<DamageStatisticsData>) => void) => {
 	updateDamageStats = updateFn;
 };
 
@@ -420,18 +420,18 @@ export class DamageStatistics extends React.Component {
 
 	constructor(props: {}) {
 		super(props);
-		updateDamageStats = ((data: DamageStatisticsData) => {
-			this.data = data;
+		updateDamageStats = ((data: Partial<DamageStatisticsData>) => {
+			this.data = {...this.data, ...data};
 			this.forceUpdate();
 		});
-		updateSelectedStats = ((selected: SelectedStatisticsData) => {
-			this.selected = selected;
+		updateSelectedStats = ((selected: Partial<SelectedStatisticsData>) => {
+			this.selected = {...this.selected, ...selected};
 			this.forceUpdate();
 		});
 	}
 
 	componentWillUnmount() {
-		updateDamageStats = (data: DamageStatisticsData) => {}
+		updateDamageStats = (data: Partial<DamageStatisticsData>) => {}
 	}
 
 	render() {

--- a/src/Components/IntroSection.tsx
+++ b/src/Components/IntroSection.tsx
@@ -131,7 +131,7 @@ export function IntroSection(props: {
 				{localize({
 					en: <ul>
 						<li style={smallGap}>Holding <ButtonIndicator text={"shift"}/> lets you scroll horizontally</li>
-						<li style={smallGap}>Click to select a skill on the timeline. Shift click to select a sequence of skills</li>
+						<li style={smallGap}>Click to select/unselect a single skill on the timeline. Shift click to select a sequence of skills</li>
 						<li style={smallGap}><ButtonIndicator text={"backspace"}/> or <ButtonIndicator text={"delete"}/> to delete the selected skill and everything after it</li>
 						<li style={smallGap}>Click on the timeline's ruler-like header to view historical game states.
 							While doing so, the main control region will have an <b style={{color: "darkorange"}}>orange</b> border
@@ -140,7 +140,7 @@ export function IntroSection(props: {
 					</ul>,
 					zh: <ul>
 						<li style={smallGap}>按住 <ButtonIndicator text={"shift"}/> 时滑动鼠标滚轮可以横向滚动时间线。</li>
-						<li style={smallGap}>单击可以选中时间轴上的技能。已经选中一个技能时，按住 <ButtonIndicator text={"shift"}/> 点击另一个技能会选中期间的所有操作。</li>
+						<li style={smallGap}>单击选中/取消选中时间轴上的单个技能。已经选中一个技能时，按住 <ButtonIndicator text={"shift"}/> 点击另一个技能会选中期间的所有操作。</li>
 						<li style={smallGap}>按 <ButtonIndicator text={"backspace"}/> 或 <ButtonIndicator text={"delete"}/> 删除选中技能及其之后的所有操作。</li>
 						<li style={smallGap}>选中某技能或者刻度上的某时间时，可以看到相应时间的职业资源状态。此时控制区域边框变为<b style={{color: "darkorange"}}>橙色</b>且无法使用技能。点击控制区域或时间轴空白处取消。
 						</li>

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -253,7 +253,7 @@ class Controller {
 
 		let rawTime = displayTime + this.gameConfig.countdown;
 
-		const selectedMoreThanOne = this.record.getFirstSelection() !== this.record.getLastSelection();
+		const hasSelected = this.record.getFirstSelection() !== undefined;
 		this.#sandboxEnvironment(()=>{
 			let tmpRecord = this.record;
 			this.game = newGameState(this.gameConfig);
@@ -287,7 +287,7 @@ class Controller {
 
 			// if nothing is selected, call stats update here to get data up to selected timestamp:
 			// otherwise do the update outside of sandbox
-			if (!selectedMoreThanOne) {
+			if (!hasSelected) {
 				this.#updateTotalDamageStats();
 			}
 
@@ -298,7 +298,7 @@ class Controller {
 		this.lastAttemptedSkill = "";
 		setHistorical(true);
 
-		if (selectedMoreThanOne) {
+		if (hasSelected) {
 			this.#updateTotalDamageStats();
 		}
 		this.#updateSelectedDamageStats();

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -39,7 +39,7 @@ import {refreshTimelineEditor} from "../Components/TimelineEditor";
 import {DEFAULT_TIMELINE_OPTIONS, StaticFn, TimelineDrawOptions} from "../Components/Common";
 import {TimelineRenderingProps} from "../Components/TimelineCanvas";
 import {Potency, PotencyModifierType} from "../Game/Potency";
-import {updateDamageStats, updateSelectedStats} from "../Components/DamageStatistics";
+import {DamageStatisticsData, updateDamageStats, updateSelectedStats} from "../Components/DamageStatistics";
 import {
 	bossIsUntargetable,
 	calculateDamageStats,
@@ -284,12 +284,7 @@ class Controller {
 			this.updateStatusDisplay(this.game);
 			this.updateSkillButtons(this.game);
 			updateSkillSequencePresetsView();
-
-			// if nothing is selected, call stats update here to get data up to selected timestamp:
-			// otherwise do the update outside of sandbox
-			if (!hasSelected) {
-				this.#updateTotalDamageStats();
-			}
+			this.#updateTotalDamageStats();
 
 			// timeline
 			this.timeline.drawElements();
@@ -299,7 +294,7 @@ class Controller {
 		setHistorical(true);
 
 		if (hasSelected) {
-			this.#updateTotalDamageStats();
+			this.#updateTotalDamageStats(true);
 		}
 		this.#updateSelectedDamageStats();
 	}
@@ -475,12 +470,21 @@ class Controller {
 		this.autoSave();
 	}
 
-	#updateTotalDamageStats() {
+	#updateTotalDamageStats(tablesOnly: boolean = false) {
 		if (!this.#skipViewUpdates) {
-			let damageStats = calculateDamageStats({
+			let damageStats: Partial<DamageStatisticsData> = calculateDamageStats({
 				tinctureBuffPercentage: this.#tinctureBuffPercentage,
 				lastDamageApplicationTime: this.#lastDamageApplicationTime
 			});
+			if (tablesOnly) {
+				damageStats = {
+					mainTable: damageStats.mainTable,
+					mainTableSummary: damageStats.mainTableSummary,
+					dotTable: damageStats.dotTable,
+					dotTableSummary: damageStats.dotTableSummary,
+					mode: damageStats.mode,
+				};
+			}
 			// display
 			updateDamageStats(damageStats);
 		}

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -253,6 +253,7 @@ class Controller {
 
 		let rawTime = displayTime + this.gameConfig.countdown;
 
+		const selectedMoreThanOne = this.record.getFirstSelection() !== this.record.getLastSelection();
 		this.#sandboxEnvironment(()=>{
 			let tmpRecord = this.record;
 			this.game = newGameState(this.gameConfig);
@@ -283,7 +284,13 @@ class Controller {
 			this.updateStatusDisplay(this.game);
 			this.updateSkillButtons(this.game);
 			updateSkillSequencePresetsView();
-			this.#updateTotalDamageStats();
+
+			// if nothing is selected, call stats update here to get data up to selected timestamp:
+			// otherwise do the update outside of sandbox
+			if (!selectedMoreThanOne) {
+				this.#updateTotalDamageStats();
+			}
+
 			// timeline
 			this.timeline.drawElements();
 		});
@@ -291,6 +298,9 @@ class Controller {
 		this.lastAttemptedSkill = "";
 		setHistorical(true);
 
+		if (selectedMoreThanOne) {
+			this.#updateTotalDamageStats();
+		}
 		this.#updateSelectedDamageStats();
 	}
 

--- a/src/Controller/Record.ts
+++ b/src/Controller/Record.ts
@@ -333,7 +333,12 @@ export class Record extends Line {
 		if (bShift) {
 			this.selectUntil(node);
 		} else {
-			this.selectSingle(node);
+			// if this is already the only selected node, unselect it
+			if (this.selectionStart === node && this.selectionEnd === node) {
+				this.unselectAll();
+			} else {
+				this.selectSingle(node);
+			}
 		}
 	}
 	moveSelected(offset: number) { // positive: move right; negative: move left

--- a/src/Controller/Timeline.ts
+++ b/src/Controller/Timeline.ts
@@ -482,6 +482,8 @@ export class Timeline {
 		let firstNode = controller.record.getFirstSelection();
 		if (firstNode) {
 			controller.displayHistoricalState(-Infinity, firstNode);
+		} else { // just clicked on the only selected node and unselected it. Still show historical state
+			controller.displayHistoricalState(-Infinity, node);
 		}
 	}
 

--- a/src/RdmRotations.test.ts
+++ b/src/RdmRotations.test.ts
@@ -10,7 +10,7 @@ import {DEFAULT_BLM_CONFIG, GameConfig} from "./Game/GameConfig";
 import {PotencyModifierType} from "./Game/Potency";
 import {ResourceType, SkillName} from "./Game/Common";
 import {RDMState} from "./Game/Jobs/RDM";
-import {DamageStatisticsData, mockDamageStatUpdateFn} from "./Components/DamageStatistics";
+import {DamageStatisticsData, DamageStatisticsMode, mockDamageStatUpdateFn} from "./Components/DamageStatistics";
 
 // TODO figure out how to share test code :3
 
@@ -54,7 +54,7 @@ const resetDamageData = () => {
             totalPotPotency: 0,
             totalPartyBuffPotency: 0,
         },
-        historical: false,
+        mode: DamageStatisticsMode.Normal
     };
 };
 

--- a/src/RdmRotations.test.ts
+++ b/src/RdmRotations.test.ts
@@ -99,8 +99,8 @@ beforeEach(() => {
     // clear stats from the last run
     resetDamageData();
     // monkeypatch the updateDamageStats function to avoid needing to initialize the frontend
-    mockDamageStatUpdateFn((newData: DamageStatisticsData) => {
-        damageData = newData;
+    mockDamageStatUpdateFn((newData: Partial<DamageStatisticsData>) => {
+        damageData = {...damageData, ...newData};
     });
     // config reset is handled in testWithConfig helper
 });

--- a/src/SamRotations.test.ts
+++ b/src/SamRotations.test.ts
@@ -95,8 +95,8 @@ beforeEach(() => {
 	// clear stats from the last run
 	resetDamageData();
 	// monkeypatch the updateDamageStats function to avoid needing to initialize the frontend
-	mockDamageStatUpdateFn((newData: DamageStatisticsData) => {
-		damageData = newData;
+	mockDamageStatUpdateFn((newData: Partial<DamageStatisticsData>) => {
+		damageData = {...damageData, ...newData};
 	});
 	// config reset is handled in testWithConfig helper
 });

--- a/src/SamRotations.test.ts
+++ b/src/SamRotations.test.ts
@@ -6,7 +6,7 @@ import {PotencyModifierType} from "./Game/Potency";
 import {ResourceType, SkillName} from "./Game/Common";
 import {XIVMath} from "./Game/XIVMath";
 import {SAMState} from "./Game/Jobs/SAM";
-import {DamageStatisticsData, mockDamageStatUpdateFn} from "./Components/DamageStatistics";
+import {DamageStatisticsData, DamageStatisticsMode, mockDamageStatUpdateFn} from "./Components/DamageStatistics";
 
 // TODO figure out how to share test code :3
 
@@ -50,7 +50,7 @@ const resetDamageData = () => {
 			totalPotPotency: 0,
 			totalPartyBuffPotency: 0,
 		},
-		historical: false,
+		mode: DamageStatisticsMode.Normal
 	};
 };
 

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -2,7 +2,8 @@
 	{
 		"date": "12/8/24",
 		"changes": [
-			"Updated Chinese FRU tracks to latest (12/8 ver)"
+			"Updated Chinese FRU tracks to latest (12/8 ver)",
+			"Make stats tables only include selected skills when there is selection"
 		]
 	},
 	{


### PR DESCRIPTION
* Make stats table only include selected nodes when there is selection
* Make selection summary purple
* When there is only 1 selected node, can now click on it again to unselect it, but still keep the orange cursor at its beginning

![image](https://github.com/user-attachments/assets/125bed8d-538c-4e9f-ba4d-12193438a179)
![image](https://github.com/user-attachments/assets/39cc45f5-0e13-4e11-a7af-1776ea65c6de)

Some entries in the DoT Table (gap/override, total ticks) may not always be meaningful when there is selection. I'm not sure what to do with them and just kept them for now.
![image](https://github.com/user-attachments/assets/16dc03de-8654-48b0-8394-61e8fc649357)
