### PR TITLE
Make SkillReadyStatus able to include multiple unavailable reasons

### DIFF
--- a/src/Components/Skills.tsx
+++ b/src/Components/Skills.tsx
@@ -222,7 +222,7 @@ class SkillButton extends React.Component {
 					const s2 = localize({
 						en: " (next stack ready in " + nextStackReadyIn.toFixed(3) + ")",
 						zh: "（" + nextStackReadyIn.toFixed(3) + "秒后转好下一层CD）"
-					})
+					});
 					s.push(<>{s1}{info.stacksAvailable < info.maxStacks ? s2 : undefined}</>);
 				}
 				if (info.status.unavailableReasons.includes(SkillUnavailableReason.NotInCombat)) {

--- a/src/Components/Skills.tsx
+++ b/src/Components/Skills.tsx
@@ -214,10 +214,16 @@ class SkillButton extends React.Component {
 					}));
 				}
 				if (info.status.unavailableReasons.includes(SkillUnavailableReason.Blocked)) {
-					s.push(localize({
-						en: "possibly ready in " + info.timeTillAvailable.toFixed(3) + " (next stack ready in " + info.timeTillNextStackReady.toFixed(3) + ")",
-						zh: "预计" + info.timeTillAvailable.toFixed(3) + "秒后可释放（" + info.timeTillNextStackReady.toFixed(3) + "秒后转好下一层CD）"
-					}));
+					const nextStackReadyIn = Math.max(info.timeTillNextStackReady, info.timeTillSecondaryReady ?? 0);
+					const s1 = localize({
+						en: "possibly ready in " + info.timeTillAvailable.toFixed(3),
+						zh: "预计" + info.timeTillAvailable.toFixed(3) + "秒后可释放",
+					});
+					const s2 = localize({
+						en: " (next stack ready in " + nextStackReadyIn.toFixed(3) + ")",
+						zh: "（" + nextStackReadyIn.toFixed(3) + "秒后转好下一层CD）"
+					})
+					s.push(<>{s1}{info.stacksAvailable < info.maxStacks ? s2 : undefined}</>);
 				}
 				if (info.status.unavailableReasons.includes(SkillUnavailableReason.NotInCombat)) {
 					s.push(localize({

--- a/src/Components/Skills.tsx
+++ b/src/Components/Skills.tsx
@@ -1,6 +1,6 @@
 import React, {FormEvent, FormEventHandler} from 'react'
 import {Clickable, ContentNode, Help, parseTime, ValueChangeEvent} from "./Common";
-import {Debug, SkillName, SkillReadyStatus} from "../Game/Common";
+import {Debug, SkillName, SkillReadyStatus, SkillUnavailableReason} from "../Game/Common";
 import {controller} from "../Controller/Controller";
 import {Tooltip as ReactTooltip} from 'react-tooltip';
 import {ActionType} from "../Controller/Record";
@@ -192,8 +192,8 @@ class SkillButton extends React.Component {
 				skillName: this.props.skillName
 			});
 			let colors = getCurrentThemeColors();
-			let s: ContentNode = "";
-			if (info.status === SkillReadyStatus.Ready) {
+			let s: ContentNode[] = [];
+			if (info.status.ready()) {
 				let en = "ready (" + info.stacksAvailable;
 				let zh = "可释放 (" + info.stacksAvailable;
 				if (info.timeTillNextStackReady > 0) {
@@ -202,36 +202,43 @@ class SkillButton extends React.Component {
 				}
 				en += ")";
 				zh += ")";
-				s = localize({en: en, zh: zh});
-			}
-			else if (info.status === SkillReadyStatus.RequirementsNotMet) {
-				s += localize({en: " skill requirement(s) not satisfied", zh: " 未满足释放条件"});
-			} else if (info.status === SkillReadyStatus.NotEnoughMP) {
-				s += localize({
-					en: " not enough MP (needs " + info.capturedManaCost + ")",
-					zh: " MP不足（需" + info.capturedManaCost + "）"
-				});
-			} else if (info.status === SkillReadyStatus.Blocked) {
-				s += localize({
-					en: "possibly ready in " + info.timeTillAvailable.toFixed(3) + " (next stack ready in " + info.timeTillNextStackReady.toFixed(3) + ")",
-					zh: "预计" + info.timeTillAvailable.toFixed(3) + "秒后可释放（" + info.timeTillNextStackReady.toFixed(3) + "秒后转好下一层CD）"
-				});
-			} else if (info.status === SkillReadyStatus.NotInCombat) {
-				s += localize({
-					en: "not in combat (wait for first damage application)",
-				});
+				s.push(localize({en: en, zh: zh}));
+			} else {
+				if (info.status.unavailableReasons.includes(SkillUnavailableReason.RequirementsNotMet)) {
+					s.push(localize({en: " skill requirement(s) not satisfied", zh: " 未满足释放条件"}));
+				}
+				if (info.status.unavailableReasons.includes(SkillUnavailableReason.NotEnoughMP)) {
+					s.push(localize({
+						en: " not enough MP (needs " + info.capturedManaCost + ")",
+						zh: " MP不足（需" + info.capturedManaCost + "）"
+					}));
+				}
+				if (info.status.unavailableReasons.includes(SkillUnavailableReason.Blocked)) {
+					s.push(localize({
+						en: "possibly ready in " + info.timeTillAvailable.toFixed(3) + " (next stack ready in " + info.timeTillNextStackReady.toFixed(3) + ")",
+						zh: "预计" + info.timeTillAvailable.toFixed(3) + "秒后可释放（" + info.timeTillNextStackReady.toFixed(3) + "秒后转好下一层CD）"
+					}));
+				}
+				if (info.status.unavailableReasons.includes(SkillUnavailableReason.NotInCombat)) {
+					s.push(localize({
+						en: "not in combat (wait for first damage application)",
+						zh: "不在战斗中（需先等第一次伤害结算）"
+					}));
+				}
 			}
 			// if ready, also show captured cast time & time till damage application
 			let actualCastTime = info.instantCast ? 0 : info.castTime;
 			let infoString = "";
-			if (info.status === SkillReadyStatus.Ready) {
+			if (info.status.ready()) {
 				infoString += localize({en: "cast: ", zh: "读条："}) + actualCastTime.toFixed(3);
 				if (info.llCovered && actualCastTime > Debug.epsilon) infoString += " (LL)";
 				infoString += localize({en: ", cast+delay: ", zh: " 读条+生效延迟："}) + info.timeTillDamageApplication.toFixed(3);
 			}
 			let content = <div style={{color: controller.displayingUpToDateGameState ? colors.text : colors.historical}}>
 				<div className="paragraph"><b>{localizeSkillName(this.props.skillName)}</b></div>
-				<div className="paragraph">{s}</div>
+				<div className="paragraph">{s.map((line, i) => <span key={i}>
+					{line}<br/>
+				</span>)}</div>
 				<div className="paragraph">{infoString}</div>
 			</div>;
 			this.setState({skillDescription: content});
@@ -388,7 +395,6 @@ enum WaitSince {
 export type SkillButtonViewInfo = {
 	skillName: SkillName,
 	status: SkillReadyStatus,
-	statusExcludingCd: SkillReadyStatus,
 	stacksAvailable: number,
 	maxStacks: number,
 	castTime: number,
@@ -509,12 +515,15 @@ export class SkillsWindow extends React.Component {
 			let skillName = this.state.statusList[i].skillName;
 			let info = this.state.statusList[i];
 
+			const readyAsideFromCd = info ? (
+				!info.status.unavailableReasons.some(reason => reason !== SkillUnavailableReason.Blocked)
+			) : false;
 			let btn = <SkillButton
 				key={i}
 				highlight={info ? info.highlight : false}
 				skillName={skillName}
-				ready={info ? info.status===SkillReadyStatus.Ready : false}
-				readyAsideFromCd={info ? info.statusExcludingCd===SkillReadyStatus.Ready : false}
+				ready={info ? info.status.ready() : false}
+				readyAsideFromCd={readyAsideFromCd}
 				cdProgress={info ? 1 - info.timeTillNextStackReady / info.cdRecastTime : 1}
 				secondaryCdProgress={info ? (info.secondaryCdRecastTime && info.timeTillSecondaryReady ? 1 - info.timeTillSecondaryReady/info.secondaryCdRecastTime : 1) : 1}
 				/>

--- a/src/Game/Common.ts
+++ b/src/Game/Common.ts
@@ -83,14 +83,44 @@ export type SkillName = GeneralSkillName
 	| MCHSkillName
 	| RPRSkillName;
 
-export const enum SkillReadyStatus {
-	Ready = "ready",
+export const enum SkillUnavailableReason {
 	Blocked = "blocked by CD, animation lock or caster tax",
 	NotEnoughMP = "not enough MP",
 	NotInCombat = "must be in combat (after first damage application)",
 	RequirementsNotMet = "requirements not met",
 	SkillNotUnlocked = "skill not unlocked at provided level",
 	BuffNoLongerAvailable = "buff no longer available"
+}
+
+export type SkillReadyStatus = {
+	unavailableReasons: SkillUnavailableReason[]
+	ready: () => boolean;
+	toString: () => string;
+	addUnavailableReason: (reason: SkillUnavailableReason) => void;
+	clone: () => SkillReadyStatus;
+};
+
+export function makeSkillReadyStatus(): SkillReadyStatus {
+	return {
+		unavailableReasons: [],
+		ready: function() {
+			return this.unavailableReasons.length === 0;
+		},
+		toString: function() {
+			if (this.ready()) return "ready";
+			return this.unavailableReasons.join("; ");
+		},
+		addUnavailableReason: function(reason: SkillUnavailableReason) {
+			if (!this.unavailableReasons.includes(reason)) {
+				this.unavailableReasons.push(reason);
+			}
+		},
+		clone: function() {
+			const status = makeSkillReadyStatus();
+			this.unavailableReasons.forEach(reason => status.addUnavailableReason(reason));
+			return status;
+		}
+	};
 }
 
 // Add any buffs that you want to have highlighted on the timeline here.

--- a/src/Game/Common.ts
+++ b/src/Game/Common.ts
@@ -85,6 +85,7 @@ export type SkillName = GeneralSkillName
 
 export const enum SkillUnavailableReason {
 	Blocked = "blocked by CD, animation lock or caster tax",
+	SecondaryBlocked = "blocked by secondary CD",
 	NotEnoughMP = "not enough MP",
 	NotInCombat = "must be in combat (after first damage application)",
 	RequirementsNotMet = "requirements not met",

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -698,6 +698,8 @@ export abstract class GameState {
 			// Special case for Meditate
 			if (timeTillAvailable > Debug.epsilon || this.cooldowns.get(ResourceType.cd_GCD).timeTillNextStackAvailable() > Debug.epsilon) {
 				// if the skill is on CD or the GCD is rolling, mark it as blocked
+				const idx = status.unavailableReasons.indexOf(SkillUnavailableReason.RequirementsNotMet);
+				if (idx >= 0) status.unavailableReasons.splice(idx, 1);
 				status.addUnavailableReason(SkillUnavailableReason.Blocked);
 			}
 		}

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -1,20 +1,22 @@
-import {Aspect, BuffType, Debug, ResourceType, SkillName, SkillReadyStatus} from "./Common"
+import {
+	Aspect,
+	BuffType,
+	Debug,
+	makeSkillReadyStatus,
+	ResourceType,
+	SkillName,
+	SkillUnavailableReason
+} from "./Common"
 import {GameConfig} from "./GameConfig"
+import {Ability, DisplayedSkills, SkillsList, Spell, Weaponskill,} from "./Skills"
 import {
-	DisplayedSkills,
-	SkillsList,
-	Spell,
-	Weaponskill,
-	Ability,
-} from "./Skills"
-import {
-	getAllResources,
-	getResourceInfo,
 	CoolDown,
 	CoolDownState,
 	DoTBuff,
 	Event,
 	EventTag,
+	getAllResources,
+	getResourceInfo,
 	Resource,
 	ResourceInfo,
 	ResourceState
@@ -686,29 +688,25 @@ export abstract class GameState {
 		let capturedCastTime = skill.kind === "weaponskill" || skill.kind === "spell" ? skill.castTimeFn(this) : 0;
 		let instantCastAvailable = capturedCastTime === 0 || skill.kind === "ability" || skill.isInstantFn(this);
 		let currentMana = this.resources.get(ResourceType.Mana).availableAmount();
-		let notBlocked = timeTillAvailable <= Debug.epsilon;
+		let blocked = timeTillAvailable > Debug.epsilon;
 		let enoughMana = capturedManaCost <= currentMana;
 		let reqsMet = skill.validateAttempt(this);
 		let skillUnlocked = this.config.level >= skill.unlockLevel;
-		let nonCdStatus = SkillReadyStatus.Ready;
-		let status = SkillReadyStatus.Ready;
-		if (!notBlocked) status = SkillReadyStatus.Blocked;
 
-		if (skill.secondaryCd && this.cooldowns.get(skill.secondaryCd.cdName).stacksAvailable() === 0) nonCdStatus = SkillReadyStatus.Blocked;
-		else if (!skillUnlocked) nonCdStatus = SkillReadyStatus.SkillNotUnlocked;
-		else if (!reqsMet) nonCdStatus = SkillReadyStatus.RequirementsNotMet;
-		else if (!enoughMana) nonCdStatus = SkillReadyStatus.NotEnoughMP;
+		let status = makeSkillReadyStatus();
+
+		if ((skill.secondaryCd && this.cooldowns.get(skill.secondaryCd.cdName).stacksAvailable() === 0) || blocked)
+			status.addUnavailableReason(SkillUnavailableReason.Blocked);
+		if (!skillUnlocked) status.addUnavailableReason(SkillUnavailableReason.SkillNotUnlocked);
+		if (!reqsMet) status.addUnavailableReason(SkillUnavailableReason.RequirementsNotMet);
+		if (!enoughMana) status.addUnavailableReason(SkillUnavailableReason.NotEnoughMP);
 
 		if (skill.name === SkillName.Meditate) {
 			// Special case for Meditate
 			if (timeTillAvailable > Debug.epsilon || this.cooldowns.get(ResourceType.cd_GCD).timeTillNextStackAvailable() > Debug.epsilon) {
-				// if the skill is on CD or the GCD is rolling, mark its non-CD status as Ready
-				// but its CD status Blocked
-				nonCdStatus = SkillReadyStatus.Ready;
-				status = SkillReadyStatus.Blocked;
+				// if the skill is on CD or the GCD is rolling, mark it as blocked
+				status.addUnavailableReason(SkillUnavailableReason.Blocked);
 			}
-		} else if (nonCdStatus !== SkillReadyStatus.Ready) {
-			status = nonCdStatus;
 		}
 
 		// Special case for skills that require being in combat
@@ -717,8 +715,8 @@ export abstract class GameState {
 			SkillName.StarryMuse,
 			SkillName.Manafication,
 			SkillName.Ikishoten,
-		] as SkillName[]).includes(skillName) && status === SkillReadyStatus.RequirementsNotMet) {
-			status = SkillReadyStatus.NotInCombat;
+		] as SkillName[]).includes(skillName) && status.unavailableReasons.includes(SkillUnavailableReason.RequirementsNotMet)) {
+			status.addUnavailableReason(SkillUnavailableReason.NotInCombat);
 			timeTillAvailable = this.timeTillNextDamageEvent();
 		}
 
@@ -747,7 +745,7 @@ export abstract class GameState {
 
 		// to be displayed together when hovered on a skill
 		let timeTillDamageApplication = 0;
-		if (status === SkillReadyStatus.Ready) {
+		if (status.ready()) {
 			if (skill.kind === "spell") {
 				let timeTillCapture = instantCastAvailable ? 0 : (capturedCastTime - GameConfig.getSlidecastWindow(capturedCastTime));
 				timeTillDamageApplication = timeTillCapture + skill.applicationDelay;
@@ -763,7 +761,6 @@ export abstract class GameState {
 		return {
 			skillName: skill.name,
 			status: status,
-			statusExcludingCd: nonCdStatus,
 			stacksAvailable: secondaryMaxStacks > 0 ? secondaryStacksAvailable : primaryStacksAvailable,
 			maxStacks: Math.max(primaryMaxStacks, secondaryMaxStacks),
 			castTime: capturedCastTime,

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -1,12 +1,4 @@
-import {
-	Aspect,
-	BuffType,
-	Debug,
-	makeSkillReadyStatus,
-	ResourceType,
-	SkillName,
-	SkillUnavailableReason
-} from "./Common"
+import {Aspect, BuffType, Debug, makeSkillReadyStatus, ResourceType, SkillName, SkillUnavailableReason} from "./Common"
 import {GameConfig} from "./GameConfig"
 import {Ability, DisplayedSkills, SkillsList, Spell, Weaponskill,} from "./Skills"
 import {
@@ -695,8 +687,9 @@ export abstract class GameState {
 
 		let status = makeSkillReadyStatus();
 
-		if ((skill.secondaryCd && this.cooldowns.get(skill.secondaryCd.cdName).stacksAvailable() === 0) || blocked)
-			status.addUnavailableReason(SkillUnavailableReason.Blocked);
+		if (blocked) status.addUnavailableReason(SkillUnavailableReason.Blocked);
+		if (skill.secondaryCd && this.cooldowns.get(skill.secondaryCd.cdName).stacksAvailable() === 0)
+			status.addUnavailableReason(SkillUnavailableReason.SecondaryBlocked);
 		if (!skillUnlocked) status.addUnavailableReason(SkillUnavailableReason.SkillNotUnlocked);
 		if (!reqsMet) status.addUnavailableReason(SkillUnavailableReason.RequirementsNotMet);
 		if (!enoughMana) status.addUnavailableReason(SkillUnavailableReason.NotEnoughMP);
@@ -723,7 +716,7 @@ export abstract class GameState {
 		let cd = this.cooldowns.get(skill.cdName);
 		const secondaryCd = skill.secondaryCd ? this.cooldowns.get(skill.secondaryCd.cdName) : undefined;
 		let timeTillNextStackReady = this.cooldowns.timeTillNextStackAvailable(skill.cdName);
-		const timeTillSecondaryReady = skill.secondaryCd ? this.cooldowns.timeTillNextStackAvailable(skill.secondaryCd.cdName) : 0
+		const timeTillSecondaryReady = skill.secondaryCd ? this.cooldowns.timeTillNextStackAvailable(skill.secondaryCd.cdName) : undefined;
 		let cdRecastTime = cd.currentStackCd();
 		// special case for meditate: if meditate is off CD, use the GCD cooldown instead if it's rolling
 		// this fails the edge case where a GCD is pressed ~58 seconds after meditate was last pressed

--- a/src/Game/Jobs/SAM.ts
+++ b/src/Game/Jobs/SAM.ts
@@ -1065,7 +1065,7 @@ makeResourceAbility(ShellJob.SAM, SkillName.Meditate, 60, ResourceType.cd_Medita
 	cooldown: 60,
 	applicationDelay: 0.62,
 	// Meditate cannot be used during a GCD roll
-	validateAttempt: (state) => true,
+	validateAttempt: (state) => state.cooldowns.get(ResourceType.cd_GCD).stacksAvailable() > 0,
 	// roll the GCD
 	onConfirm: (state) => {
 		const recastTime = state.config.adjustedSksGCD(

--- a/src/Game/Jobs/SAM.ts
+++ b/src/Game/Jobs/SAM.ts
@@ -1065,7 +1065,7 @@ makeResourceAbility(ShellJob.SAM, SkillName.Meditate, 60, ResourceType.cd_Medita
 	cooldown: 60,
 	applicationDelay: 0.62,
 	// Meditate cannot be used during a GCD roll
-	validateAttempt: (state) => state.cooldowns.get(ResourceType.cd_GCD).stacksAvailable() > 0,
+	validateAttempt: (state) => true,
 	// roll the GCD
 	onConfirm: (state) => {
 		const recastTime = state.config.adjustedSksGCD(

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,11 @@
 [
 	{
+		"date": "12/13/24",
+		"changes": [
+			"Fixed sometimes unable to use skills in manual mode with double click"
+		]
+	},
+	{
 		"date": "12/12/24",
 		"changes": [
 			"Updated English FRU tracks and added P4 + P5"


### PR DESCRIPTION
This fixes [this bug](https://github.com/xivintheshell/xivintheshell/pull/82#issuecomment-2526434551), and combines `status` and `nonCdStatus` in `GameState.getSkillAvailabilityStatus`.

While doing the refactor I also removed `validateAttempt` for SAM's meditate because seems like special case handlings elsewhere already achieved the same effect. Lmk if something broke though 🙏