### PR TITLE
MCH - Add Flamethrower

### DIFF
--- a/src/Components/DamageStatistics.tsx
+++ b/src/Components/DamageStatistics.tsx
@@ -1231,7 +1231,7 @@ export class DamageStatistics extends React.Component {
 						<div style={cell(20)} />
 						<div style={cell(8)}>
 							{
-								/* The total dick denominator isn't terribly useful for DoTs that aren't maintained full-time */
+								/* The total tick denominator isn't terribly useful for DoTs that aren't maintained full-time */
 								controller.game.fullTimeDoTs.includes(dotTable.dotName) ? (
 									<>
 										{dotTableSummary.totalTicks}/{dotTableSummary.maxTicks}

--- a/src/Components/DamageStatistics.tsx
+++ b/src/Components/DamageStatistics.tsx
@@ -1230,7 +1230,16 @@ export class DamageStatistics extends React.Component {
 						<div style={cell(10)}>{dotTableSummary.cumulativeOverride.toFixed(3)}</div>
 						<div style={cell(20)} />
 						<div style={cell(8)}>
-							{dotTableSummary.totalTicks}/{dotTableSummary.maxTicks}
+							{
+								/* The total dick denominator isn't terribly useful for DoTs that aren't maintained full-time */
+								controller.game.fullTimeDoTs.includes(dotTable.dotName) ? (
+									<>
+										{dotTableSummary.totalTicks}/{dotTableSummary.maxTicks}
+									</>
+								) : (
+									<>{dotTableSummary.totalTicks}</>
+								)
+							}
 						</div>
 						<div style={cell(24)}>
 							{dotTableSummary.totalPotencyWithoutPot.toFixed(2)}

--- a/src/Controller/DamageStatistics.ts
+++ b/src/Controller/DamageStatistics.ts
@@ -459,6 +459,7 @@ export function calculateDamageStats(props: {
 				// cast higanbana and the ability has not yet hit), don't add an entry yet
 				node.getAllDotPotencies().forEach((potenciesArr, rscType) => {
 					let dotTrackingData = dotTables.get(rscType);
+					const excludeStandardTicks = ctl.game.excludedDoTs.includes(rscType);
 					if (!dotTrackingData) {
 						dotTrackingData = {
 							tableRows: [],
@@ -467,7 +468,11 @@ export function calculateDamageStats(props: {
 								cumulativeOverride: 0,
 								timeSinceLastDoTDropped: 0,
 								totalTicks: 0,
-								maxTicks: ctl.getMaxTicks(ctl.game.time),
+								maxTicks: ctl.getMaxTicks(
+									ctl.game.time,
+									rscType,
+									excludeStandardTicks,
+								),
 								dotCoverageTimeFraction: ctl.getDotCoverageTimeFraction(
 									ctl.game.getDisplayTime(),
 									rscType,

--- a/src/Game/Constants/MCH.ts
+++ b/src/Game/Constants/MCH.ts
@@ -80,6 +80,7 @@ export enum MCHCooldownType {
 	cd_Tactician = "cd_Tactician",
 	cd_Hypercharge = "cd_Hypercharge",
 	cd_Detonator = "cd_Detonator",
+	cd_Flamethrower = "cd_Flamethrower",
 }
 
 export enum MCHTraitName {

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -374,19 +374,12 @@ export abstract class GameState {
 	handleDoTTick(dotResource: ResourceType) {
 		const dotBuff = this.resources.get(dotResource) as DoTBuff;
 		if (dotBuff.available(1)) {
-			let maxTicks = 0;
 			if (dotBuff.node) {
-				const dotPotencies = dotBuff.node.getDotPotencies(dotResource);
-				const p = dotPotencies[dotBuff.tickCount];
-				maxTicks = dotPotencies.length;
+				const p = dotBuff.node.getDotPotencies(dotResource)[dotBuff.tickCount];
 				controller.resolvePotency(p);
 				this.jobSpecificOnResolveDotTick(dotResource);
 			}
 			dotBuff.tickCount++;
-			// If we've resolved all of the potencies, clear the node
-			if (dotBuff.tickCount >= maxTicks) {
-				dotBuff.node = undefined;
-			}
 		} else {
 			if (dotBuff.node) {
 				dotBuff.node.removeUnresolvedDoTPotencies();

--- a/src/Game/Jobs/DNC.ts
+++ b/src/Game/Jobs/DNC.ts
@@ -388,6 +388,7 @@ const makeAbility_DNC = (
 	unlockLevel: number,
 	cdName: ResourceType,
 	params: {
+		requiresCombat?: boolean;
 		potency?: number | Array<[TraitName, number]>;
 		replaceIf?: ConditionalSkillReplace<DNCState>[];
 		highlightIf?: StatePredicate<DNCState>;
@@ -731,7 +732,8 @@ standardFinishes.forEach((finish) => {
 
 makeAbility_DNC(SkillName.Flourish, 72, ResourceType.cd_Flourish, {
 	cooldown: 60,
-	validateAttempt: (state) => !isDancing(state) && state.isInCombat(),
+	requiresCombat: true,
+	validateAttempt: (state) => !isDancing(state),
 	onConfirm: (state) => {
 		state.gainProc(ResourceType.FlourishingSymmetry);
 		state.gainProc(ResourceType.FlourishingFlow);

--- a/src/Game/Jobs/DNC.ts
+++ b/src/Game/Jobs/DNC.ts
@@ -121,6 +121,11 @@ export class DNCState extends GameState {
 		}
 	}
 
+	override cancelChanneledSkills(): void {
+		this.tryConsumeResource(ResourceType.Improvisation);
+		this.tryConsumeResource(ResourceType.RisingRhythm, true);
+	}
+
 	processComboStatus(skill: SkillName) {
 		if (!COMBO_GCDS.includes(skill)) {
 			return;
@@ -273,11 +278,6 @@ export class DNCState extends GameState {
 			this.gainProc(ResourceType.LastDanceReady);
 		}
 	}
-
-	cancelImprovisation() {
-		this.tryConsumeResource(ResourceType.Improvisation);
-		this.tryConsumeResource(ResourceType.RisingRhythm, true);
-	}
 }
 
 const isDancing = (state: Readonly<DNCState>) =>
@@ -337,7 +337,6 @@ const makeGCD_DNC = (
 	return makeWeaponskill(ShellJob.DNC, name, unlockLevel, {
 		...params,
 		onConfirm: onConfirm,
-		onExecute: (state) => state.cancelImprovisation(),
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = [];
 			if (
@@ -406,7 +405,6 @@ const makeAbility_DNC = (
 	return makeAbility(ShellJob.DNC, name, unlockLevel, cdName, {
 		...params,
 		onConfirm: params.onConfirm,
-		onExecute: (state) => state.cancelImprovisation(),
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = [];
 			if (state.hasResourceAvailable(ResourceType.StandardFinish)) {
@@ -456,7 +454,6 @@ const makeResourceAbility_DNC = (
 ): Ability<DNCState> => {
 	return makeResourceAbility(ShellJob.DNC, name, unlockLevel, cdName, {
 		...params,
-		onExecute: (state) => state.cancelImprovisation(),
 	});
 };
 

--- a/src/Game/Jobs/MCH.ts
+++ b/src/Game/Jobs/MCH.ts
@@ -384,6 +384,7 @@ const makeAbility_MCH = (
 	cdName: ResourceType,
 	params: {
 		autoUpgrade?: SkillAutoReplace;
+		requiresCombat?: boolean;
 		potency?: number | Array<[TraitName, number]>;
 		replaceIf?: ConditionalSkillReplace<MCHState>[];
 		highlightIf?: StatePredicate<MCHState>;
@@ -579,13 +580,13 @@ makeAbility_MCH(SkillName.BarrelStabilizer, 66, ResourceType.cd_BarrelStabilizer
 	applicationDelay: 0,
 	cooldown: 120,
 	maxCharges: 1,
+	requiresCombat: true,
 	onConfirm: (state) => {
 		state.gainStatus(ResourceType.Hypercharged);
 		if (state.hasTraitUnlocked(TraitName.EnhancedBarrelStabilizer)) {
 			state.gainStatus(ResourceType.FullMetalMachinist);
 		}
 	},
-	validateAttempt: (state) => state.isInCombat(),
 });
 makeWeaponskill_MCH(SkillName.FullMetalField, 100, {
 	startOnHotbar: false,

--- a/src/Game/Jobs/MCH.ts
+++ b/src/Game/Jobs/MCH.ts
@@ -2,7 +2,6 @@ import { ShellJob } from "../../Controller/Common";
 import { controller } from "../../Controller/Controller";
 import { ActionNode } from "../../Controller/Record";
 import { Aspect, ResourceType, SkillName, TraitName, WarningType } from "../Common";
-import { MCHResourceType } from "../Constants/MCH";
 import { GameConfig } from "../GameConfig";
 import { GameState } from "../GameState";
 import { makeComboModifier, Modifiers, Potency, PotencyModifier } from "../Potency";
@@ -118,7 +117,7 @@ export class MCHState extends GameState {
 			this.cooldowns.set(new CoolDown(ResourceType.cd_Tactician, 120, 1, 1));
 		}
 
-		super.registerRecurringEvents([
+		this.registerRecurringEvents([
 			{
 				groupedDots: [
 					{
@@ -127,7 +126,46 @@ export class MCHState extends GameState {
 					},
 				],
 			},
+			{
+				groupedDots: [
+					{
+						dotName: ResourceType.Flamethrower,
+						appliedBy: [SkillName.Flamethrower],
+						isGroundTargeted: true,
+						exclude: true,
+					},
+				],
+			},
 		]);
+	}
+
+	// Flamethrower works like a DoT, but ticks every second instead, so we need to handle that separately
+	override jobSpecificRegisterRecurringEvents(): void {
+		let recurringFlamethrowerTick = () => {
+			this.handleDoTTick(ResourceType.Flamethrower);
+
+			// increment count
+			if (this.getDisplayTime() >= 0) {
+				controller.reportDotTick(this.time, ResourceType.Flamethrower);
+			}
+
+			// Flamethrower ticks every second, instead of every three, the way most DoTs do
+			this.addEvent(
+				new Event("Flamethrower tick", 1, () => {
+					recurringFlamethrowerTick();
+				}),
+			);
+		};
+
+		let timeTillFirstFlamethrowerTick = this.config.timeTillFirstManaTick + this.dotTickOffset;
+		while (timeTillFirstFlamethrowerTick > 1) timeTillFirstFlamethrowerTick--;
+		this.addEvent(
+			new Event(
+				"initial Flamethrower tick",
+				timeTillFirstFlamethrowerTick,
+				recurringFlamethrowerTick,
+			),
+		);
 	}
 
 	processComboStatus(skill: SkillName) {
@@ -161,16 +199,6 @@ export class MCHState extends GameState {
 			);
 		}
 		this.resources.get(rscType).gain(amount);
-	}
-
-	gainProc(proc: MCHResourceType) {
-		const duration = (getResourceInfo(ShellJob.MCH, proc) as ResourceInfo).maxTimeout;
-		if (this.resources.get(proc).available(1)) {
-			this.resources.get(proc).overrideTimer(this, duration);
-		} else {
-			this.resources.get(proc).gain(1);
-			this.enqueueResourceDrop(proc, duration);
-		}
 	}
 
 	handleQueenPunch = () => {
@@ -319,8 +347,9 @@ const makeWeaponskill_MCH = (
 	const onApplication: EffectFn<MCHState> = params.onApplication ?? NO_EFFECT;
 	return makeWeaponskill(ShellJob.MCH, name, unlockLevel, {
 		...params,
-		onConfirm: onConfirm,
-		onApplication: onApplication,
+		onExecute: (state) => state.tryConsumeResource(ResourceType.Flamethrower),
+		onConfirm,
+		onApplication,
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = [];
 			if (
@@ -515,7 +544,7 @@ makeWeaponskill_MCH(SkillName.Chainsaw, 90, {
 	onConfirm: (state) => {
 		state.gainResource(ResourceType.BatteryGauge, 20);
 		if (state.hasTraitUnlocked(TraitName.EnhancedMultiWeaponII)) {
-			state.gainProc(ResourceType.ExcavatorReady);
+			state.gainStatus(ResourceType.ExcavatorReady);
 		}
 	},
 	secondaryCooldown: {
@@ -548,9 +577,9 @@ makeAbility_MCH(SkillName.BarrelStabilizer, 66, ResourceType.cd_BarrelStabilizer
 	cooldown: 120,
 	maxCharges: 1,
 	onConfirm: (state) => {
-		state.gainProc(ResourceType.Hypercharged);
+		state.gainStatus(ResourceType.Hypercharged);
 		if (state.hasTraitUnlocked(TraitName.EnhancedBarrelStabilizer)) {
-			state.gainProc(ResourceType.FullMetalMachinist);
+			state.gainStatus(ResourceType.FullMetalMachinist);
 		}
 	},
 	validateAttempt: (state) => state.isInCombat(),
@@ -596,7 +625,7 @@ makeAbility_MCH(SkillName.Wildfire, 45, ResourceType.cd_Wildfire, {
 	cooldown: 120,
 	maxCharges: 1,
 	onConfirm: (state, node) => {
-		state.gainProc(ResourceType.WildfireSelf);
+		state.gainStatus(ResourceType.WildfireSelf);
 		const wildFire = state.resources.get(ResourceType.Wildfire) as DoTBuff;
 
 		const wildFirePotency = new Potency({
@@ -892,7 +921,28 @@ makeWeaponskill_MCH(SkillName.AutoCrossbow, 52, {
 	highlightIf: (state) => state.hasResourceAvailable(ResourceType.Overheated),
 });
 
-// Flamethrower - Not adding unless a notable use-case for it is found. right now it's just end-of-downtime tic fishing
+makeWeaponskill_MCH(SkillName.Flamethrower, 70, {
+	applicationDelay: 0.89,
+	recastTime: (state) => state.config.adjustedSksGCD(),
+	onConfirm: (state, node) => {
+		state.addDoTPotencies({
+			node,
+			dotName: ResourceType.Flamethrower,
+			skillName: SkillName.Flamethrower,
+			tickPotency: 100,
+			tickFrequency: 1,
+			speedStat: "sks",
+		});
+	},
+	onApplication: (state, node) => {
+		state.applyDoT(ResourceType.Flamethrower, node);
+	},
+	secondaryCooldown: {
+		cdName: ResourceType.cd_Flamethrower,
+		cooldown: 60,
+		maxCharges: 1,
+	},
+});
 
 makeResourceAbility_MCH(SkillName.Tactician, 56, ResourceType.cd_Tactician, {
 	rscType: ResourceType.Tactician,

--- a/src/Game/Jobs/MCH.ts
+++ b/src/Game/Jobs/MCH.ts
@@ -168,6 +168,10 @@ export class MCHState extends GameState {
 		);
 	}
 
+	override cancelChanneledSkills(): void {
+		this.tryConsumeResource(ResourceType.Flamethrower);
+	}
+
 	processComboStatus(skill: SkillName) {
 		if (!COMBO_GCDS.includes(skill)) {
 			return;
@@ -347,7 +351,6 @@ const makeWeaponskill_MCH = (
 	const onApplication: EffectFn<MCHState> = params.onApplication ?? NO_EFFECT;
 	return makeWeaponskill(ShellJob.MCH, name, unlockLevel, {
 		...params,
-		onExecute: (state) => state.tryConsumeResource(ResourceType.Flamethrower),
 		onConfirm,
 		onApplication,
 		jobPotencyModifiers: (state) => {

--- a/src/Game/Jobs/RoleActions.ts
+++ b/src/Game/Jobs/RoleActions.ts
@@ -8,19 +8,10 @@ import {
 	TANK_JOBS,
 } from "../../Controller/Common";
 import { SkillName, ResourceType, TraitName, WarningType, TankLBResourceType } from "../Common";
-import {
-	combineEffects,
-	makeAbility,
-	makeLimitBreak,
-	makeResourceAbility,
-	makeSpell,
-} from "../Skills";
+import { makeAbility, makeLimitBreak, makeResourceAbility, makeSpell } from "../Skills";
 import { DoTBuff, EventTag, makeResource } from "../Resources";
 import type { GameState } from "../GameState";
 import { controller } from "../../Controller/Controller";
-import { SAMState } from "./SAM";
-import { DNCState } from "./DNC";
-import { MCHState } from "./MCH";
 
 //#region Helper functions
 
@@ -29,26 +20,6 @@ import { MCHState } from "./MCH";
 const cancelDualcast = (state: GameState) => {
 	if (state.job === ShellJob.RDM && state.tryConsumeResource(ResourceType.Dualcast)) {
 		controller.reportWarning(WarningType.DualcastEaten);
-	}
-};
-
-// Special case for SAM, since all actions should cancel meditate
-const cancelMeditate = (state: GameState) => {
-	if (state.job === ShellJob.SAM) {
-		(state as SAMState).cancelMeditate();
-	}
-};
-
-// All actions cancel Improvisation
-const cancelImprovisation = (state: GameState) => {
-	if (state.job === ShellJob.DNC) {
-		(state as DNCState).cancelImprovisation();
-	}
-};
-
-const cancelFlamethrower = (state: GameState) => {
-	if (state.job === ShellJob.MCH) {
-		(state as MCHState).tryConsumeResource(ResourceType.Flamethrower);
 	}
 };
 
@@ -66,7 +37,6 @@ makeAbility(PHYSICAL_RANGED_JOBS, SkillName.HeadGraze, 24, ResourceType.cd_HeadG
 	applicationDelay: 0,
 	cooldown: 30,
 	assetPath: "Role/Head Graze.png",
-	onExecute: cancelImprovisation,
 });
 
 //#endregion
@@ -93,7 +63,6 @@ makeResourceAbility(MELEE_JOBS, SkillName.Feint, 22, ResourceType.cd_Feint, {
 	cooldown: 90,
 	duration: (state) => (state.hasTraitUnlocked(TraitName.EnhancedFeint) && 15) || 10,
 	assetPath: "Role/Feint.png",
-	onExecute: cancelMeditate,
 });
 
 CASTER_JOBS.forEach((job) => {
@@ -130,7 +99,6 @@ makeResourceAbility(MELEE_JOBS, SkillName.TrueNorth, 50, ResourceType.cd_TrueNor
 	cooldown: 45,
 	maxCharges: 2,
 	assetPath: "Role/True North.png",
-	onExecute: cancelMeditate,
 });
 
 [...HEALER_JOBS, ...CASTER_JOBS].forEach((job) => {
@@ -191,7 +159,6 @@ makeResourceAbility(
 		applicationDelay: 0.62,
 		cooldown: 120,
 		assetPath: "Role/Arms Length.png",
-		onExecute: combineEffects(cancelMeditate, cancelImprovisation, cancelFlamethrower),
 	},
 );
 
@@ -223,7 +190,6 @@ makeResourceAbility(MELEE_JOBS, SkillName.Bloodbath, 8, ResourceType.cd_Bloodbat
 	applicationDelay: 0.625,
 	cooldown: 90,
 	assetPath: "Role/Bloodbath.png",
-	onExecute: cancelMeditate,
 });
 
 makeAbility(
@@ -235,7 +201,6 @@ makeAbility(
 		applicationDelay: 0.625,
 		cooldown: 120,
 		assetPath: "Role/Second Wind.png",
-		onExecute: combineEffects(cancelMeditate, cancelImprovisation, cancelFlamethrower),
 	},
 );
 
@@ -278,7 +243,6 @@ makeAbility(MELEE_JOBS, SkillName.LegSweep, 10, ResourceType.cd_LegSweep, {
 	applicationDelay: 0.625,
 	cooldown: 40,
 	assetPath: "Role/Leg Sweep.png",
-	onExecute: cancelMeditate,
 });
 
 //#endregion
@@ -290,7 +254,6 @@ makeResourceAbility(ALL_JOBS, SkillName.Tincture, 1, ResourceType.cd_Tincture, {
 	applicationDelay: 0.64, // delayed // somewhere in the midrange of what's seen in logs
 	cooldown: 270,
 	assetPath: "Role/Tincture.png",
-	onExecute: combineEffects(cancelMeditate, cancelImprovisation, cancelFlamethrower),
 	onConfirm: cancelDualcast,
 });
 
@@ -299,7 +262,6 @@ makeResourceAbility(ALL_JOBS, SkillName.Sprint, 1, ResourceType.cd_Sprint, {
 	applicationDelay: 0.133, // delayed
 	cooldown: 60,
 	assetPath: "General/Sprint.png",
-	onExecute: combineEffects(cancelMeditate, cancelImprovisation, cancelFlamethrower),
 	onConfirm: cancelDualcast,
 });
 
@@ -396,7 +358,6 @@ makeLimitBreak(MELEE_JOBS, SkillName.Braver, ResourceType.cd_MeleeLB1, {
 	castTime: 2,
 	applicationDelay: 2.23,
 	animationLock: 3.86,
-	onExecute: cancelMeditate,
 	potency: 1000,
 });
 makeLimitBreak(MELEE_JOBS, SkillName.Bladedance, ResourceType.cd_MeleeLB2, {
@@ -404,7 +365,6 @@ makeLimitBreak(MELEE_JOBS, SkillName.Bladedance, ResourceType.cd_MeleeLB2, {
 	castTime: 3,
 	applicationDelay: 3.28,
 	animationLock: 3.86,
-	onExecute: cancelMeditate,
 	potency: 2200,
 });
 const meleeLB3s = [
@@ -424,7 +384,6 @@ meleeLB3s.forEach((params) => {
 		castTime: 4.5,
 		applicationDelay: 2.26,
 		animationLock: 3.7,
-		onExecute: params.job === ShellJob.SAM ? cancelMeditate : undefined,
 		potency: 3500,
 	});
 });
@@ -435,7 +394,6 @@ makeLimitBreak(PHYSICAL_RANGED_JOBS, SkillName.BigShot, ResourceType.cd_RangedLB
 	castTime: 2,
 	applicationDelay: 2.23,
 	animationLock: 3.1,
-	onExecute: combineEffects(cancelImprovisation, cancelFlamethrower),
 	potency: 540,
 });
 makeLimitBreak(PHYSICAL_RANGED_JOBS, SkillName.Desperado, ResourceType.cd_RangedLB2, {
@@ -443,7 +401,6 @@ makeLimitBreak(PHYSICAL_RANGED_JOBS, SkillName.Desperado, ResourceType.cd_Ranged
 	castTime: 3,
 	applicationDelay: 2.49,
 	animationLock: 3.1,
-	onExecute: combineEffects(cancelImprovisation, cancelFlamethrower),
 	potency: 1170,
 });
 const rangedLB3s = [
@@ -460,7 +417,6 @@ rangedLB3s.forEach((params) => {
 		castTime: 4.5,
 		applicationDelay: 3.16,
 		animationLock: 3.7,
-		onExecute: combineEffects(cancelImprovisation, cancelFlamethrower),
 		potency: 1890,
 	});
 });

--- a/src/Game/Jobs/RoleActions.ts
+++ b/src/Game/Jobs/RoleActions.ts
@@ -20,6 +20,7 @@ import type { GameState } from "../GameState";
 import { controller } from "../../Controller/Controller";
 import { SAMState } from "./SAM";
 import { DNCState } from "./DNC";
+import { MCHState } from "./MCH";
 
 //#region Helper functions
 
@@ -42,6 +43,12 @@ const cancelMeditate = (state: GameState) => {
 const cancelImprovisation = (state: GameState) => {
 	if (state.job === ShellJob.DNC) {
 		(state as DNCState).cancelImprovisation();
+	}
+};
+
+const cancelFlamethrower = (state: GameState) => {
+	if (state.job === ShellJob.MCH) {
+		(state as MCHState).tryConsumeResource(ResourceType.Flamethrower);
 	}
 };
 
@@ -184,7 +191,7 @@ makeResourceAbility(
 		applicationDelay: 0.62,
 		cooldown: 120,
 		assetPath: "Role/Arms Length.png",
-		onExecute: combineEffects(cancelMeditate, cancelImprovisation),
+		onExecute: combineEffects(cancelMeditate, cancelImprovisation, cancelFlamethrower),
 	},
 );
 
@@ -228,7 +235,7 @@ makeAbility(
 		applicationDelay: 0.625,
 		cooldown: 120,
 		assetPath: "Role/Second Wind.png",
-		onExecute: combineEffects(cancelMeditate, cancelImprovisation),
+		onExecute: combineEffects(cancelMeditate, cancelImprovisation, cancelFlamethrower),
 	},
 );
 
@@ -283,7 +290,7 @@ makeResourceAbility(ALL_JOBS, SkillName.Tincture, 1, ResourceType.cd_Tincture, {
 	applicationDelay: 0.64, // delayed // somewhere in the midrange of what's seen in logs
 	cooldown: 270,
 	assetPath: "Role/Tincture.png",
-	onExecute: combineEffects(cancelMeditate, cancelImprovisation),
+	onExecute: combineEffects(cancelMeditate, cancelImprovisation, cancelFlamethrower),
 	onConfirm: cancelDualcast,
 });
 
@@ -292,7 +299,7 @@ makeResourceAbility(ALL_JOBS, SkillName.Sprint, 1, ResourceType.cd_Sprint, {
 	applicationDelay: 0.133, // delayed
 	cooldown: 60,
 	assetPath: "General/Sprint.png",
-	onExecute: combineEffects(cancelMeditate, cancelImprovisation),
+	onExecute: combineEffects(cancelMeditate, cancelImprovisation, cancelFlamethrower),
 	onConfirm: cancelDualcast,
 });
 
@@ -428,7 +435,7 @@ makeLimitBreak(PHYSICAL_RANGED_JOBS, SkillName.BigShot, ResourceType.cd_RangedLB
 	castTime: 2,
 	applicationDelay: 2.23,
 	animationLock: 3.1,
-	onExecute: cancelImprovisation,
+	onExecute: combineEffects(cancelImprovisation, cancelFlamethrower),
 	potency: 540,
 });
 makeLimitBreak(PHYSICAL_RANGED_JOBS, SkillName.Desperado, ResourceType.cd_RangedLB2, {
@@ -436,7 +443,7 @@ makeLimitBreak(PHYSICAL_RANGED_JOBS, SkillName.Desperado, ResourceType.cd_Ranged
 	castTime: 3,
 	applicationDelay: 2.49,
 	animationLock: 3.1,
-	onExecute: cancelImprovisation,
+	onExecute: combineEffects(cancelImprovisation, cancelFlamethrower),
 	potency: 1170,
 });
 const rangedLB3s = [
@@ -453,7 +460,7 @@ rangedLB3s.forEach((params) => {
 		castTime: 4.5,
 		applicationDelay: 3.16,
 		animationLock: 3.7,
-		onExecute: params.job === ShellJob.DNC ? cancelImprovisation : undefined,
+		onExecute: combineEffects(cancelImprovisation, cancelFlamethrower),
 		potency: 1890,
 	});
 });

--- a/src/Game/Skills.ts
+++ b/src/Game/Skills.ts
@@ -335,7 +335,10 @@ export function makeSpell<T extends PlayerState>(
 		(state, node) => (node.applicationTime = state.time),
 		params.onApplication ?? NO_EFFECT,
 	);
-
+	const onExecute: EffectFn<T> = combineEffects(
+		(state) => state.maybeCancelChanneledSkills(name),
+		params.onExecute ?? NO_EFFECT,
+	);
 	const info: Spell<T> = {
 		kind: "spell",
 		name: name,
@@ -359,7 +362,7 @@ export function makeSpell<T extends PlayerState>(
 		jobPotencyModifiers: params.jobPotencyModifiers ?? ((state) => []),
 		validateAttempt: params.validateAttempt ?? ((state) => true),
 		isInstantFn: params.isInstantFn ?? ((state) => false), // Spells should be assumed to have a cast time unless otherwise specified
-		onExecute: params.onExecute ?? NO_EFFECT,
+		onExecute,
 		onConfirm: params.onConfirm ?? NO_EFFECT,
 		onApplication,
 		applicationDelay: params.applicationDelay ?? 0,
@@ -406,6 +409,10 @@ export function makeWeaponskill<T extends PlayerState>(
 		(state, node) => (node.applicationTime = state.time),
 		params.onApplication ?? NO_EFFECT,
 	);
+	const onExecute: EffectFn<T> = combineEffects(
+		(state) => state.maybeCancelChanneledSkills(name),
+		params.onExecute ?? NO_EFFECT,
+	);
 	const info: Weaponskill<T> = {
 		kind: "weaponskill",
 		name: name,
@@ -429,7 +436,7 @@ export function makeWeaponskill<T extends PlayerState>(
 		jobPotencyModifiers: params.jobPotencyModifiers ?? ((state) => []),
 		validateAttempt: params.validateAttempt ?? ((state) => true),
 		isInstantFn: params.isInstantFn ?? ((state) => true), // Weaponskills should be assumed to be instant unless otherwise specified
-		onExecute: params.onExecute ?? NO_EFFECT,
+		onExecute,
 		onConfirm: params.onConfirm ?? NO_EFFECT,
 		onApplication,
 		applicationDelay: params.applicationDelay ?? 0,
@@ -493,6 +500,10 @@ export function makeAbility<T extends PlayerState>(
 		(state, node) => (node.applicationTime = state.time),
 		params.onApplication ?? NO_EFFECT,
 	);
+	const onExecute: EffectFn<T> = combineEffects(
+		(state) => state.maybeCancelChanneledSkills(name),
+		params.onExecute ?? NO_EFFECT,
+	);
 	// All abilities that require being in combat should check isInCombat
 	const validateAttempt: StatePredicate<T> = combinePredicatesAnd(
 		(state) => (params.requiresCombat ? state.isInCombat() : true),
@@ -520,7 +531,7 @@ export function makeAbility<T extends PlayerState>(
 		jobPotencyModifiers: params.jobPotencyModifiers ?? ((state) => []),
 		applicationDelay: params.applicationDelay ?? 0,
 		validateAttempt,
-		onExecute: params.onExecute ?? NO_EFFECT,
+		onExecute,
 		onConfirm: params.onConfirm ?? NO_EFFECT,
 		onApplication,
 	};
@@ -640,6 +651,10 @@ export function makeLimitBreak<T extends PlayerState>(
 		jobs = [jobs];
 	}
 	const assetName = "Limit Break " + params.tier;
+	const onExecute: EffectFn<T> = combineEffects(
+		(state) => state.maybeCancelChanneledSkills(name),
+		params.onExecute ?? NO_EFFECT,
+	);
 	const info: LimitBreak<T> = {
 		kind: "limitbreak",
 		name: name,
@@ -660,7 +675,7 @@ export function makeLimitBreak<T extends PlayerState>(
 		jobPotencyModifiers: (state) => [],
 		applicationDelay: params.applicationDelay ?? 0,
 		validateAttempt: (state) => true,
-		onExecute: params.onExecute ?? NO_EFFECT,
+		onExecute,
 		onConfirm: params.onConfirm ?? NO_EFFECT,
 		onApplication: params.onApplication ?? NO_EFFECT,
 	};

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,11 @@
 [
 	{
+		"date": "12/24/24",
+		"changes": [
+			"[MCH] Added support for Flamethrower"
+		]
+	},
+	{
 		"date": "12/22/24",
 		"changes": [
 			"[BRD] Added initial support for BRD",


### PR DESCRIPTION
Flamethrower has it's use-case now: FRU phase 4 optimization. It has the following behavior characteristics:
- Channeled skill like Meditate and Improvisation: all other actions cancel it
- Technically a ground-targeted DoT: It gets a special DoT tic on application
- Flamethrower tics once per second, rather than once every three

Core changes to support this:
- DoT registration with `registerRecurringEffects` can now specify that the core DoT tick handling will exclude that effect (Job code will be expected to deal with it)
- DoT registration can now specify that the DoT is a ground-targeted DoT
  - When addDotPotencies is called for a ground-targeted DoT, an extra potency will be added to the node for the special onApplication tick
  - When applyDot is called for a ground-targeted DoT, the first tick will be immediately handled
- DoT potency creation can now optionally specify the frequency at which the DoT ticks. The number of potencies added to the node will respect this frequency if provided.
- DoT tick tracking in the controller can now track ticks for specific DoTs in addition to the standard tick, to deal with the ground target initial ticks and specially-handled DoTs.
  - When retrieving the maximum number of potential ticks for a DoT, it will combine the specific ticks for that DoT with the total number of standard ticks, unless told to include only the DoT-specific ticks.

I also updated the damage statistics table to hide the total ticks denominator for DoTs that are not expected to be kept up full time, since there will always be many more potential ticks than actual ticks.