### PR TITLE
Post keyed data fixes

### DIFF
--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -56,6 +56,7 @@ import { MELEE_JOBS, ShellJob } from "../Game/Data/Jobs";
 import { ActionKey, ACTIONS, ResourceKey, RESOURCES } from "../Game/Data";
 import { LIMIT_BREAK_ACTIONS } from "../Game/Data/Shared/LimitBreak";
 import { getGameState } from "../Game/Jobs";
+import { localizeSkillName } from "../Components/Localization";
 
 // Ensure role actions are imported after job-specific ones to protect hotbar ordering
 require("../Game/Jobs/RoleActions");
@@ -425,10 +426,10 @@ class Controller {
 		if (!replayResult.success) {
 			let msg = "Failed to load the entire record- \n";
 			if (replayResult.firstInvalidNode) {
-				msg +=
-					"Stopped here because the next action " +
-					(replayResult.firstInvalidNode.skillName ?? "(unknown)") +
-					" can't be added: ";
+				const actionName = replayResult.firstInvalidNode.skillName
+					? localizeSkillName(replayResult.firstInvalidNode.skillName)
+					: "(unknown)";
+				msg += "Stopped here because the next action " + actionName + " can't be added: ";
 			}
 			msg += replayResult.invalidReason;
 			window.alert(msg);

--- a/src/Game/GameConfig.ts
+++ b/src/Game/GameConfig.ts
@@ -3,7 +3,7 @@ import { ResourceOverride, ResourceOverrideData } from "./Resources";
 import { ShellInfo, ShellVersion } from "../Controller/Common";
 import { XIVMath } from "./XIVMath";
 import { ShellJob } from "./Data/Jobs";
-import { ResourceKey, RESOURCES } from "./Data";
+import { CooldownKey, COOLDOWNS, ResourceKey, RESOURCES } from "./Data";
 
 export type ConfigData = {
 	job: ShellJob;
@@ -134,7 +134,7 @@ export class GameConfig {
 				else obj.effectOrTimerEnabled = obj.enabled;
 			}
 			// Backwards compatibility re: change to keyed data
-			if (!(obj.type in RESOURCES)) {
+			if (!(obj.type in RESOURCES || obj.type in COOLDOWNS)) {
 				// Special case a few spelling changes made during the transition
 				if (obj.type.toString() === "AstralFire") {
 					obj.type = "ASTRAL_FIRE";
@@ -143,9 +143,17 @@ export class GameConfig {
 				} else if (obj.type.toString() === "UmbralHeart") {
 					obj.type = "UMBRAL_HEART";
 				} else {
-					const key = Object.keys(RESOURCES).find(
+					// Try to find the key in RESOURCES
+					let key: ResourceKey | CooldownKey | undefined = Object.keys(RESOURCES).find(
 						(key) => RESOURCES[key as ResourceKey].name === obj.type,
 					) as ResourceKey;
+					// If not found, check COOLDOWNS next
+					if (!key) {
+						key = Object.keys(COOLDOWNS).find(
+							(key) => COOLDOWNS[key as CooldownKey].name === obj.type,
+						) as CooldownKey;
+					}
+					// If we found it in either data set, assign the key as the type
 					if (key) {
 						obj.type = key;
 					}

--- a/src/Game/Jobs/PCT.ts
+++ b/src/Game/Jobs/PCT.ts
@@ -79,6 +79,10 @@ const HYPERPHANTASIA_SKILLS: PCTActionKey[] = [
 	"STAR_PRISM",
 ];
 
+const MOTIFS: ActionKey[] = ["POM_MOTIF", "WING_MOTIF", "CLAW_MOTIF", "MAW_MOTIF"];
+
+const HAMMER_COMBO: ActionKey[] = ["HAMMER_BRUSH", "HAMMER_STAMP", "POLISHING_HAMMER"];
+
 // === JOB GAUGE AND STATE ===
 export class PCTState extends GameState {
 	constructor(config: GameConfig) {
@@ -116,7 +120,7 @@ export class PCTState extends GameState {
 
 	// apply hyperphantasia + sps adjustment without consuming any resources
 	captureSpellCastTime(name: ActionKey, baseCastTime: number): number {
-		if (name.includes("MOTIF")) {
+		if (MOTIFS.includes(name)) {
 			// motifs are not affected by sps
 			return baseCastTime;
 		}
@@ -133,7 +137,7 @@ export class PCTState extends GameState {
 	}
 
 	captureSpellRecastTime(name: ActionKey, baseRecastTime: number): number {
-		if (name.includes("Motif")) {
+		if (MOTIFS.includes(name)) {
 			// motifs are unaffected by sps
 			return baseRecastTime;
 		}
@@ -145,7 +149,7 @@ export class PCTState extends GameState {
 			return this.hasResourceAvailable("RAINBOW_BRIGHT") ? recast - 3.5 : recast;
 		}
 		// hammers are not affected by inspiration
-		if (name.includes("Hammer")) {
+		if (HAMMER_COMBO.includes(name)) {
 			return this.config.adjustedGCD(baseRecastTime);
 		}
 		return this.config.adjustedGCD(


### PR DESCRIPTION
Two issues were reported to us after the initial deployment of the keyed data update:
- Timelines with initial cooldown overrides weren't loading
- Spell speed and speed buffs were applying to the recast of motifs and the hammer combo skills inappropriately

This stemmed from two problems:
- The backwards compatibility change to handle mapping the old override string enum names to the keys was only done for resources, despite the `ResourceOverride` class being used for both.
  - Now we'll secondarily check the COOLDOWNS object for a matching key if we don't find one in the RESOURCES object
- There were a couple places in PCT's `captureSpellCastTime` and `captureSpellRecastTime` functions that were doing partial string matches on the name of the action, which missed getting updated to compare against the ALL CAPS key, since they didn't cause type check errors
  - These are now updates to check if the action name key is included in the appropriate const array that defines the set of action keys that fit the criteria (motif or hammer combo action)