### PR TITLE
Corrected gcd formula

### DIFF
--- a/scripts/sps-LL/test.js
+++ b/scripts/sps-LL/test.js
@@ -7,25 +7,23 @@
 let levelParam0 = 420;
 let levelParam1 = 2780;
 
-// GCD formula, 2 decimals
+// GCD formula, 2 decimals, outdated (can be off by 0.01s under LL)
 // from: https://bbs.nga.cn/read.php?tid=29774994&rand=903
-function computeGCD(spellSpeed, baseTime, LL) {
-	let subtractLL = LL ? 15 : 0;
-	return Math.floor(Math.floor(Math.floor((100-subtractLL)*100/100)*Math.floor((2000-Math.floor(130*(spellSpeed-levelParam0)/levelParam1+1000))*(1000*baseTime)/10000)/100)*100/100)/100;
+function computeGCD(spellSpeed, baseTime, speedModifier) {
+	return Math.floor(Math.floor(Math.floor((100-speedModifier)*100/100)*Math.floor((2000-Math.floor(130*(spellSpeed-levelParam0)/levelParam1+1000))*(1000*baseTime)/10000)/100)*100/100)/100;
 }
 
 // cast time formula, 3 decimals
-function computeCastTime(spellSpeed, baseTime, LL) {
+function computeCastTime(spellSpeed, baseTime, speedModifier) {
 	let subtractLL = LL ? 15 : 0;
 	return Math.floor(Math.floor(Math.floor((100-subtractLL)*100/100)*Math.floor((2000-Math.floor(130*(spellSpeed-levelParam0)/levelParam1+1000))*(1000*baseTime)/1000)/100)*100/100)/1000;
 }
 
-// old formula, from EW implementation
-function adjustedCastTime(spellSpeed, baseRecastTime, LL) {
+// old formula, from EW implementation but turns out is more accurate..
+function allaganGcd(spellSpeed, baseTime, speedModifier) {
 	let ceil = Math.ceil((levelParam0 - spellSpeed) * 130 / levelParam1);
-	let pts = Math.floor(baseRecastTime * (1000 + ceil));
-	let llFactor = LL ? 0.85 : 1;
-	return Math.floor(llFactor * pts / 10) / 100;
+	let pts = Math.floor(baseTime * (1000 + ceil));
+	return Math.floor((100 - speedModifier) * pts / 1000) / 100;
 }
 
 let baseRecastTimes = [1.5, 2.0, 2.5, 2.8, 3.0, 3.5, 4.0];
@@ -34,19 +32,11 @@ let LL = false;
 let allTestsPassed = true;
 baseRecastTimes.forEach(baseCastTime => {
 	for (let sps = 400; sps < 3000; sps++) {
-		let s1 = computeGCD(sps, baseCastTime, LL);
-		/*
-		// the old formula is the same as new when there's no LL, but LL makes it fail.
-		let s2 = adjustedCastTime(sps, baseCastTime, LL);
-		if (s1 !== s2) {
-			console.log(`${sps} (${baseCastTime}): ${s1} != ${s2}`);
-			allTestsPassed = false;
-		}
-		 */
-		let s3 = computeCastTime(sps, baseCastTime, LL);
-		let diff = s3 - s1;
-		if (diff < 0 || diff >= 0.01) {
-			console.log("!");
+		let s1 = computeGCD(sps, baseCastTime, LL ? 15 : 0);
+		let s2 = allaganGcd(sps, baseCastTime, LL ? 15 : 0);
+		let diff = s2 - s1;
+		if (Math.abs(diff) >= 0.001) {
+			console.log(`sps: ${sps}, baseCastTime: ${baseCastTime}, old: ${s1}, allagan: ${s2}`);
 			allTestsPassed = false;
 		}
 	}

--- a/src/Controller/Common.ts
+++ b/src/Controller/Common.ts
@@ -27,6 +27,7 @@ export const enum TickMode {
 export const enum ShellVersion {
 	Initial = 0,
 	FpsTax = 1, // extra FPS field added to GameConfig
+	AllaganGcdFormula = 2, // files >= this version uses Allagan's gcd formula which behaves correctly with haste buff
 }
 
 export const enum Expansion {
@@ -35,7 +36,7 @@ export const enum Expansion {
 }
 
 export const ShellInfo = {
-	version: ShellVersion.FpsTax,
+	version: ShellVersion.AllaganGcdFormula,
 	// thisExpansion is not exported so it stays local outside
 };
 

--- a/src/Game/GameConfig.ts
+++ b/src/Game/GameConfig.ts
@@ -182,11 +182,19 @@ export class GameConfig {
 
 	// returns GCD before FPS tax
 	adjustedGCD(baseGCD: number = 2.5, speedModifier?: number) {
-		return XIVMath.preTaxGcd(this.level, this.spellSpeed, baseGCD, speedModifier);
+		if (this.shellVersion >= ShellVersion.AllaganGcdFormula) {
+			return XIVMath.preTaxGcd(this.level, this.spellSpeed, baseGCD, speedModifier);
+		} else {
+			return XIVMath.preTaxGcdLegacy(this.level, this.spellSpeed, baseGCD, speedModifier);
+		}
 	}
 
 	adjustedSksGCD(baseGCD: number = 2.5, speedModifier?: number) {
-		return XIVMath.preTaxGcd(this.level, this.skillSpeed, baseGCD, speedModifier);
+		if (this.shellVersion >= ShellVersion.AllaganGcdFormula) {
+			return XIVMath.preTaxGcd(this.level, this.skillSpeed, baseGCD, speedModifier);
+		} else {
+			return XIVMath.preTaxGcdLegacy(this.level, this.skillSpeed, baseGCD, speedModifier);
+		}
 	}
 
 	// returns cast time before FPS and caster tax

--- a/src/Game/XIVMath.ts
+++ b/src/Game/XIVMath.ts
@@ -147,6 +147,22 @@ export class XIVMath {
 	static preTaxGcd(level: LevelSync, speed: number, baseGCD: number, speedModifier?: number) {
 		const subStat = this.getSubstatBase(level);
 		const div = this.getStatDiv(level);
+		let ceil = Math.ceil(((subStat - speed) * 130) / div);
+		let pts = Math.floor(baseGCD * (1000 + ceil));
+		return Math.floor(((100 - (speedModifier ?? 0)) * pts) / 1000) / 100;
+	}
+
+	// DO NOT USE except to support legacy timelines. Arguments are the same as for preTaxGcd
+	// this formula is rounded incorrectly, as a result when there is haste buff the resulting GCD
+	// may be inaccurate by up to 0.01s
+	static preTaxGcdLegacy(
+		level: LevelSync,
+		speed: number,
+		baseGCD: number,
+		speedModifier?: number,
+	) {
+		const subStat = this.getSubstatBase(level);
+		const div = this.getStatDiv(level);
 
 		return (
 			Math.floor(

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,11 @@
 [
 	{
+		"date": "2/26/25",
+		"changes": [
+			"Updated the GCD formula because the old formula may be off by 0.01s when there is haste buff. Thank you Yuyuka for spotting the error. Note: old timelines (including timelines in browser localStorage) aren't affected; only newly created timelines use the new formula."
+		]
+	},
+	{
 		"date": "2/22/25",
 		"changes": [
 			"Added Queen Eternal markers by 小盐"


### PR DESCRIPTION
Yuyuka found that at spell speed 1047, with ley lines the GCD should be 2.06 as shown in game, not 2.05. So we dug into the formula and found an error.

Both formulas give the same result when there is no haste buff. The old formula could be off by up to 0.01s when there is haste buff (tested with LL so speedModifier=15). The new formula is a slight modification from what's on Allagan Studies, to account for haste buff correctly. And reused my old script to do some sanity checks

To make sure existing files still load, I also bumped `shellVersion` so existing files still use the old formula <-- confirmed by locally loading all files from shanzhe's test corpus.