### PR TITLE
New script setup to help coordinate localization effort

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-tabs": "^4.0.1",
         "react-tooltip": "^5.8.3",
         "seedrandom": "^3.0.5",
+        "ts-node": "^10.9.2",
         "typescript": "^4.6.3",
         "web-vitals": "^2.1.4",
         "ws": "^8.17.1"
@@ -37,8 +38,7 @@
         "jest-canvas-mock": "^2.5.2",
         "prettier-no-jsx-parens": "^3.4.0",
         "react-app-rewired": "^2.2.1",
-        "react-scripts": "^5.0.1",
-        "ts-node": "^10.9.2"
+        "react-scripts": "^5.0.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2216,7 +2216,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -2228,7 +2227,6 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -3062,7 +3060,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -3103,8 +3100,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -3752,26 +3748,22 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "dev": true
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw=="
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/@types/aria-query": {
       "version": "4.2.2",
@@ -4656,7 +4648,6 @@
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6322,8 +6313,7 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -7054,7 +7044,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -11794,8 +11783,7 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -17010,7 +16998,6 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -17053,7 +17040,6 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -17064,8 +17050,7 @@
     "node_modules/ts-node/node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -17471,8 +17456,7 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
@@ -18414,7 +18398,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -19925,7 +19908,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -19934,7 +19916,6 @@
           "version": "0.3.9",
           "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
           "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-          "dev": true,
           "requires": {
             "@jridgewell/resolve-uri": "^3.0.3",
             "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -20489,8 +20470,7 @@
     "@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="
     },
     "@jridgewell/set-array": {
       "version": "1.2.1",
@@ -20524,8 +20504,7 @@
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -20966,26 +20945,22 @@
     "@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "dev": true
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw=="
     },
     "@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
     },
     "@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "@types/aria-query": {
       "version": "4.2.2",
@@ -21739,8 +21714,7 @@
     "acorn": {
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-      "dev": true
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg=="
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -22977,8 +22951,7 @@
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -23486,8 +23459,7 @@
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "diff-sequences": {
       "version": "27.5.1",
@@ -26997,8 +26969,7 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "makeerror": {
       "version": "1.0.12",
@@ -30707,7 +30678,6 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -30728,7 +30698,6 @@
           "version": "8.3.4",
           "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
           "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-          "dev": true,
           "requires": {
             "acorn": "^8.11.0"
           }
@@ -30736,8 +30705,7 @@
         "arg": {
           "version": "4.1.3",
           "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-          "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-          "dev": true
+          "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
         }
       }
     },
@@ -31037,8 +31005,7 @@
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "v8-to-istanbul": {
       "version": "8.1.1",
@@ -31793,8 +31760,7 @@
     "yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-tabs": "^4.0.1",
     "react-tooltip": "^5.8.3",
     "seedrandom": "^3.0.5",
+    "ts-node": "^10.9.2",
     "typescript": "^4.6.3",
     "web-vitals": "^2.1.4",
     "ws": "^8.17.1"

--- a/scripts/localization/template.ts
+++ b/scripts/localization/template.ts
@@ -1,0 +1,23 @@
+// npx ts-node template.ts
+
+//import fs from "node:fs"
+import {BRD_RESOURCES, BRD_ACTIONS, BRD_COOLDOWNS, BRDCooldownKey} from "../../src/Game/Data/Jobs/BRD";
+
+Object.values(BRD_ACTIONS).forEach(action => {
+	console.log(action.name);
+});
+
+console.log("----");
+
+Object.values(BRD_RESOURCES).forEach(rsc => {
+	console.log(rsc.name);
+});
+
+console.log("----");
+
+let actionKeys = Object.keys(BRD_ACTIONS);
+Object.keys(BRD_COOLDOWNS).forEach(cdKey => {
+	if (!(cdKey.startsWith("cd_") && actionKeys.includes(cdKey.slice(3)))) {
+		console.log(BRD_COOLDOWNS[cdKey as BRDCooldownKey].name);
+	}
+});

--- a/src/Components/Jobs/WAR.tsx
+++ b/src/Components/Jobs/WAR.tsx
@@ -5,8 +5,8 @@ import {
 	StatusPropsGenerator,
 } from "../StatusDisplay";
 import { WARState } from "../../Game/Jobs/WAR";
-import { getCurrentThemeColors } from "../../Components/ColorTheme";
-import { localize } from "../../Components/Localization";
+import { getCurrentThemeColors } from "../ColorTheme";
+import { localize } from "../Localization";
 import { ResourceKey, RESOURCES } from "../../Game/Data";
 import { WAR_STATUSES } from "../../Game/Data/Jobs/WAR";
 

--- a/src/Components/Localization.tsx
+++ b/src/Components/Localization.tsx
@@ -16,6 +16,17 @@ export type LocalizedContent = {
 	ja?: ContentNode;
 };
 
+export function makeLocalizableLabel(resource: {
+	name: string;
+	label: { zh?: string; ja?: string };
+}) {
+	return {
+		en: resource.name,
+		zh: resource.label.zh,
+		ja: resource.label.ja,
+	};
+}
+
 export function localize(content: LocalizedContent) {
 	let currentLang = getCurrentLanguage();
 	if (currentLang === "zh" && content.zh) {

--- a/src/Game/Data/Jobs/BRD.ts
+++ b/src/Game/Data/Jobs/BRD.ts
@@ -13,7 +13,7 @@ export const BRD_ACTIONS = ensureRecord<ActionData>()({
 	ARMYS_PAEON: { name: "Army's Paeon" },
 	RAIN_OF_DEATH: { name: "Rain Of Death" },
 	BATTLE_VOICE: { name: "Battle Voice" },
-	EMYPREAL_ARROW: { name: "Empyreal Arrow" },
+	EMPYREAL_ARROW: { name: "Empyreal Arrow" },
 	WANDERERS_MINUET: { name: "Wanderer's Minuet" },
 	IRON_JAWS: { name: "Iron Jaws" },
 	WARDENS_PAEAN: { name: "Warden's Paean" },

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -40,8 +40,7 @@ import { SkillButtonViewInfo } from "../Components/Skills";
 import { ReactNode } from "react";
 import { localizeResourceType } from "../Components/Localization";
 import { ShellJob, HEALER_JOBS, CASTER_JOBS, JOBS, HEALERS } from "./Data/Jobs";
-import { ActionKey, CooldownKey, ResourceKey, RESOURCES, TraitKey } from "./Data";
-import { hasUnlockedTrait } from "../utilities";
+import { ActionKey, CooldownKey, ResourceKey, RESOURCES, TraitKey, TRAITS } from "./Data";
 import { StatusPropsGenerator } from "../Components/StatusDisplay";
 import { XIVMath } from "./XIVMath";
 
@@ -1516,7 +1515,8 @@ export class GameState {
 	}
 
 	hasTraitUnlocked(traitName: TraitKey) {
-		return hasUnlockedTrait(traitName, this.config.level);
+		let trait = traitName in TRAITS ? TRAITS[traitName] : TRAITS["NEVER"];
+		return this.config.level >= trait.level;
 	}
 
 	isInCombat() {

--- a/src/Game/Jobs/BRD.ts
+++ b/src/Game/Jobs/BRD.ts
@@ -582,7 +582,7 @@ makeWeaponskill_BRD("BLAST_ARROW", 86, {
 	onConfirm: (state) => state.tryConsumeResource("BLAST_ARROW_READY"),
 });
 
-makeAbility_BRD("EMYPREAL_ARROW", 54, "cd_EMPYREAL_ARROW", {
+makeAbility_BRD("EMPYREAL_ARROW", 54, "cd_EMPYREAL_ARROW", {
 	potency: [
 		["NEVER", 240], // TODO - Confirm
 		["RANGED_MASTERY", 260],

--- a/src/Game/Skills.ts
+++ b/src/Game/Skills.ts
@@ -4,9 +4,8 @@ import { PlayerState, GameState } from "./GameState";
 import { makeCooldown, getResourceInfo, ResourceInfo } from "./Resources";
 import { PotencyModifier } from "./Potency";
 import { ShellJob, ALL_JOBS } from "./Data/Jobs";
-import { ActionKey, ACTIONS, CooldownKey, ResourceKey, RESOURCES, TraitKey } from "./Data";
+import { ActionKey, ACTIONS, CooldownKey, ResourceKey, RESOURCES, TraitKey, TRAITS } from "./Data";
 import { LimitBreakActionKey } from "./Data/Shared/LimitBreak";
-import { hasUnlockedTrait } from "../utilities";
 import { Data } from "./Data/Data";
 
 // all gapclosers have the same animation lock
@@ -713,6 +712,10 @@ export function getAutoReplacedSkillName(
 	level: LevelSync,
 ): ActionKey {
 	let skill = getSkill(job, skillName);
+	let hasUnlockedTrait = (traitKey: TraitKey, level: LevelSync) => {
+		let trait = traitKey in TRAITS ? TRAITS[traitKey] : TRAITS["NEVER"];
+		return level >= trait.level;
+	};
 	// upgrade: if level >= upgrade options
 	while (skill.autoUpgrade && hasUnlockedTrait(skill.autoUpgrade.trait, level)) {
 		skill = getSkill(job, getAutoReplacedSkillName(job, skill.autoUpgrade.otherSkill, level));

--- a/src/__test__/BrdRotations.test.ts
+++ b/src/__test__/BrdRotations.test.ts
@@ -32,7 +32,7 @@ it(
 				[
 					"STORMBITE",
 					"WANDERERS_MINUET",
-					"EMYPREAL_ARROW",
+					"EMPYREAL_ARROW",
 					"CAUSTIC_BITE",
 					"BATTLE_VOICE",
 					"BURST_SHOT",
@@ -45,7 +45,7 @@ it(
 					"REFULGENT_ARROW",
 					"SIDEWINDER",
 					"RESONANT_ARROW",
-					"EMYPREAL_ARROW",
+					"EMPYREAL_ARROW",
 					"BURST_SHOT",
 					"HEARTBREAK_SHOT",
 					"BURST_SHOT",
@@ -71,7 +71,7 @@ it(
 					hitCount: 1,
 				},
 				{
-					skillName: "EMYPREAL_ARROW",
+					skillName: "EMPYREAL_ARROW",
 					displayedModifiers: [PotencyModifierType.WANDERERS_MINUET],
 					hitCount: 1,
 				},
@@ -171,7 +171,7 @@ it(
 					hitCount: 1,
 				},
 				{
-					skillName: "EMYPREAL_ARROW",
+					skillName: "EMPYREAL_ARROW",
 					displayedModifiers: [
 						PotencyModifierType.WANDERERS_MINUET,
 						PotencyModifierType.RAGING_STRIKES,

--- a/src/__test__/traits.test.js
+++ b/src/__test__/traits.test.js
@@ -1,8 +1,12 @@
 import { TRAITS } from "../Game/Data";
-import { hasUnlockedTrait } from "../utilities";
 
 function GetTraits() {
 	return Object.keys(TRAITS);
+}
+
+function hasUnlockedTrait(traitName, level) {
+	let trait = traitName in TRAITS ? TRAITS[traitName] : TRAITS["NEVER"];
+	return level >= trait.level;
 }
 
 // for helpful error messages

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,11 +1,3 @@
-import { LevelSync } from "./Game/Common";
-import { TraitKey, TRAITS } from "./Game/Data";
-
-export function hasUnlockedTrait(traitKey: TraitKey, level: LevelSync): boolean {
-	let trait = traitKey in TRAITS ? TRAITS[traitKey] : TRAITS["NEVER"];
-	return level >= trait.level;
-}
-
 /**
  * Ensure that the values in the provided record match at _least_ the requested data shape.
  *


### PR DESCRIPTION
This PR is just for the script's setup which is a bunch of miscellaneous changes. The actual script is not important here
- put back `ts-node` dependency so we can have scripts with ts code
- inlined `hasTraitUnlocked` utility function, to get rid of a circular dependency. Seems like it hasn't been an issue because webpack is pretty smart at resolving dependencies but `ts-node` just blindly imports everything listed at each file's top
- fixed a typo in BRD's skill name