### PR TITLE
Move TESTING/OUTDATED warning copy into Support Interface

### DIFF
--- a/src/Components/PlaybackControl.tsx
+++ b/src/Components/PlaybackControl.tsx
@@ -222,28 +222,17 @@ export function ConfigSummary(props: { job: ShellJob; dirty: boolean }) {
 	});
 	let warningColor = getCurrentThemeColors().warning;
 	let tryGetImplementationWarning = (impl: ImplementationKey, warningColor: string) => {
-		if (impl === "TESTING") {
-			return <p
-				style={{
-					color: warningColor,
-				}}
-			>
-				{localize({
-					en: "WARNING: This job was recently added to XIV in the Shell and is still being tested. There may be bugs or changes in the near future, so make sure to frequently export and save timelines for this job to make sure you don't lose your work.",
-					zh: "警告：此职业刚被实现没多久，可能还不是很稳定，目前暂时不要太依赖txt文件，记得勤在别处保存进度。",
-				})}
-			</p>;
-		} else if (impl === "OUTDATED") {
-			return <p
-				style={{
-					color: warningColor,
-				}}
-			>
-				{localize({
-					en: "WARNING: This job recently had significant changes, and may not have been fully updated to reflect them. There may be bugs or changes in the near future, so make sure to frequently export and save timelines for this job to make sure you don't lose your work.",
-				})}
-			</p>;
+		const details = IMPLEMENTATION_LEVELS[impl];
+		if (!details.warningContent) {
+			return;
 		}
+		return <p
+			style={{
+				color: warningColor,
+			}}
+		>
+			{details.warningContent}
+		</p>;
 	};
 
 	let legacyCasterTaxBlurbContent = localize({

--- a/src/Components/PlaybackControl.tsx
+++ b/src/Components/PlaybackControl.tsx
@@ -1552,7 +1552,7 @@ export class Config extends React.Component {
 			>
 				{ALL_JOBS.filter((job) => JOBS[job].implementationLevel !== "UNIMPLEMENTED").map(
 					(job) => {
-						const impl = JOBS[job].implementationLevel;
+						const impl = JOBS[job].implementationLevel as ImplementationKey;
 						if (impl !== "LIVE") {
 							return <option key={job} value={job}>
 								{job + ` (${IMPLEMENTATION_LEVELS[impl].label})`}

--- a/src/Game/Data/Jobs.ts
+++ b/src/Game/Data/Jobs.ts
@@ -14,14 +14,22 @@ import { LimitBreak3ActionKey, TankLimitBreak3ResourceKey } from "./Shared/Limit
  */
 export interface ImplementationDetails {
 	label?: ReactNode;
+	warningContent?: ReactNode;
 }
 export const IMPLEMENTATION_LEVELS = ensureRecord<ImplementationDetails>()({
 	UNIMPLEMENTED: {},
 	OUTDATED: {
 		label: localize({ en: "Outdated" }),
+		warningContent: localize({
+			en: "WARNING: This job recently had significant changes, and may not have been fully updated to reflect them. There may be bugs or changes in the near future, so make sure to frequently export and save timelines for this job to make sure you don't lose your work.",
+		}),
 	},
 	TESTING: {
 		label: localize({ en: "Testing", zh: "测试中" }),
+		warningContent: localize({
+			en: "WARNING: This job was recently added to XIV in the Shell and is still being tested. There may be bugs or changes in the near future, so make sure to frequently export and save timelines for this job to make sure you don't lose your work.",
+			zh: "警告：此职业刚被实现没多久，可能还不是很稳定，目前暂时不要太依赖txt文件，记得勤在别处保存进度。",
+		}),
 	},
 	LIVE: {},
 });

--- a/src/Game/Data/Jobs.ts
+++ b/src/Game/Data/Jobs.ts
@@ -21,7 +21,8 @@ export const IMPLEMENTATION_LEVELS = ensureRecord<ImplementationDetails>()({
 	OUTDATED: {
 		label: localize({ en: "Outdated" }),
 		warningContent: localize({
-			en: "WARNING: This job recently had significant changes, and may not have been fully updated to reflect them. There may be bugs or changes in the near future, so make sure to frequently export and save timelines for this job to make sure you don't lose your work.",
+			en: "WARNING: This job recently had significant changes, and may not have been fully updated to reflect them. Exported plans may not load correctly following these changes, so be cautious about relying on them until the job has been fully updated.",
+			zh: "警告：此职业最近经历的技改还未被完整实现到排轴器中。当前排轴器的此职业可能有bug，或在近期经历更新，所以暂时不要太依赖txt，记得勤在别处保存排轴进度。",
 		}),
 	},
 	TESTING: {


### PR DESCRIPTION
Mark fully-supported jobs as outdated due to patch 7.2 changes to warn users about instability until we can update them all.

Notes: 
- We probably want a CN translation for the OUTDATED warning content before we push this out.
- We probably don't want to push this out before the servers go down for the patch.
- Submitting as a draft for right now because of these.

I also have no idea what we're going to do about the CN/KR regions lagging behind Global given the scope of at least the BLM changes...