### PR TITLE
Resource and CoolDown refactors

### DIFF
--- a/src/Components/DamageStatistics.tsx
+++ b/src/Components/DamageStatistics.tsx
@@ -393,7 +393,10 @@ export class DamageStatistics extends React.Component {
 		const dotUptime = controller.game.overTimeEffectGroups
 			.filter((group) => group.reportName && !group.isHealing)
 			.map((dotGroup) => {
-				let dotStr = dotGroup.reportName + " " + localize({ en: "uptime" }) + colon;
+				let dotStr =
+					dotGroup.reportName +
+					(localize({ en: " uptime", zh: "覆盖率" }) as string) +
+					colon;
 
 				let uptime = 0;
 				let totalTicks = 0;

--- a/src/Components/PlaybackControl.tsx
+++ b/src/Components/PlaybackControl.tsx
@@ -1623,7 +1623,7 @@ export class Config extends React.Component {
 			<Input
 				style={{ color: fieldColor("piety") }}
 				defaultValue={this.state.piety}
-				description={localize({ en: "piety: " })}
+				description={localize({ en: "piety: ", zh: "信仰：" })}
 				onChange={this.setPiety}
 			/>
 			<Input

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -590,19 +590,6 @@ export class GameState {
 		return 200;
 	}
 
-	// BLM uses this for LL GCD scaling, but PCT and SAM do not.
-	gcdRecastTimeScale(): number {
-		// TODO move this to child class methods
-		if (this.job === "BLM" && this.hasResourceAvailable("LEY_LINES")) {
-			// should be approximately 0.85
-			const num = this.config.getAfterTaxGCD(this.config.adjustedGCD(2.5, 15));
-			const denom = this.config.getAfterTaxGCD(this.config.adjustedGCD(2.5));
-			return num / denom;
-		} else {
-			return 1;
-		}
-	}
-
 	requestToggleBuff(buffName: ResourceKey) {
 		let rsc = this.resources.get(buffName);
 		// Ley lines, paint lines, and positionals can be toggled.
@@ -836,9 +823,9 @@ export class GameState {
 			);
 		}
 		// recast
-		cd.useStackWithRecast(this, this.config.getAfterTaxGCD(recastTime));
+		cd.useStackWithRecast(this.config.getAfterTaxGCD(recastTime));
 		if (secondaryCd) {
-			secondaryCd.useStack(this);
+			secondaryCd.useStack();
 		}
 	}
 
@@ -958,7 +945,7 @@ export class GameState {
 		}
 
 		// recast
-		cd.useStack(this);
+		cd.useStack();
 
 		// animation lock
 		this.resources.takeResourceLock("NOT_ANIMATION_LOCKED", skill.animationLockFn(this));
@@ -1079,7 +1066,7 @@ export class GameState {
 			);
 		}
 		// recast
-		cd.useStack(this);
+		cd.useStack();
 	}
 
 	#timeTillSkillAvailable(skillName: ActionKey) {
@@ -1376,7 +1363,7 @@ export class GameState {
 		const secondaryCd = skill.secondaryCd
 			? this.cooldowns.get(skill.secondaryCd.cdName)
 			: undefined;
-		let timeTillNextStackReady = this.cooldowns.timeTillNextStackAvailable(skill.cdName);
+		let timeTillNextStackReady = cd.timeTillNextStackAvailable() % cd.currentStackCd();
 		const timeTillSecondaryReady = skill.secondaryCd
 			? this.cooldowns.timeTillNextStackAvailable(skill.secondaryCd.cdName)
 			: undefined;

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -388,7 +388,8 @@ const makeSpell_BLM = (
 		...params,
 		aspect: aspect,
 		castTime: (state) => state.captureSpellCastTimeAFUI(params.baseCastTime, aspect),
-		recastTime: (state) => state.config.adjustedGCD(2.5),
+		recastTime: (state) =>
+			state.config.adjustedGCD(2.5, state.hasResourceAvailable("LEY_LINES") ? 15 : 0),
 		manaCost: (state) => state.captureManaCost(name, aspect, params.baseManaCost),
 		// TODO apply AFUI modifiers?
 		potency: (state) => params.basePotency,

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -91,7 +91,7 @@ export class BLMState extends GameState {
 
 		this.registerRecurringEvents([
 			{
-				reportName: localize({ en: "Thunder DoT" }),
+				reportName: localize({ en: "Thunder DoT", zh: "雷DoT" }),
 				groupedEffects: [
 					{
 						effectName: "HIGH_THUNDER",

--- a/src/Game/Jobs/BRD.ts
+++ b/src/Game/Jobs/BRD.ts
@@ -189,7 +189,7 @@ export class BRDState extends GameState {
 				this.resources.get("PITCH_PERFECT").gain(1);
 				break;
 			case "MAGES_BALLAD":
-				this.cooldowns.get("cd_HEARTBREAK_SHOT").restore(this, 7.5);
+				this.cooldowns.get("cd_HEARTBREAK_SHOT").restore(7.5);
 				break;
 			case "ARMYS_PAEON":
 				this.resources.get("REPERTOIRE").gain(1);

--- a/src/Game/Jobs/MCH.ts
+++ b/src/Game/Jobs/MCH.ts
@@ -681,8 +681,8 @@ makeWeaponskill_MCH("BLAZING_SHOT", 68, {
 	applicationDelay: 0.85,
 	recastTime: 1.5,
 	onConfirm: (state) => {
-		(state.cooldowns.get("cd_DOUBLE_CHECK") as CoolDown).restore(state, 15);
-		(state.cooldowns.get("cd_CHECKMATE") as CoolDown).restore(state, 15);
+		(state.cooldowns.get("cd_DOUBLE_CHECK") as CoolDown).restore(15);
+		(state.cooldowns.get("cd_CHECKMATE") as CoolDown).restore(15);
 	},
 	validateAttempt: (state) => state.hasResourceAvailable("OVERHEATED"),
 	highlightIf: (state) => state.hasResourceAvailable("OVERHEATED"),

--- a/src/Game/Jobs/PCT.ts
+++ b/src/Game/Jobs/PCT.ts
@@ -1170,7 +1170,9 @@ makeAbility_PCT("TEMPERA_COAT_POP", 10, "cd_TEMPERA_POP", {
 			coatElapsed > 0,
 			"attempted to pop Tempera Coat when no timer for Tempera Coat CD was active",
 		);
-		state.cooldowns.get("cd_TEMPERA_COAT").overrideCurrentValue(180 - coatElapsed);
+		state.cooldowns
+			.get("cd_TEMPERA_COAT")
+			.overrideTimeTillNextStack(Math.max(0, coatElapsed - 60));
 	},
 	highlightIf: (state) => state.hasResourceAvailable("TEMPERA_COAT"),
 });
@@ -1196,7 +1198,9 @@ makeAbility_PCT("TEMPERA_GRASSA_POP", 10, "cd_TEMPERA_POP", {
 			coatElapsed > 0,
 			"attempted to pop Tempera Grassa when no timer for Tempera Coat CD was active",
 		);
-		state.cooldowns.get("cd_TEMPERA_COAT").overrideCurrentValue(150 - coatElapsed);
+		state.cooldowns
+			.get("cd_TEMPERA_COAT")
+			.overrideTimeTillNextStack(Math.max(0, coatElapsed - 30));
 	},
 	highlightIf: (state) => state.hasResourceAvailable("TEMPERA_GRASSA"),
 });

--- a/src/Game/Jobs/SAM.ts
+++ b/src/Game/Jobs/SAM.ts
@@ -1098,9 +1098,7 @@ makeResourceAbility("SAM", "MEDITATE", 60, "cd_MEDITATE", {
 	// roll the GCD
 	onConfirm: (state) => {
 		const recastTime = state.config.adjustedSksGCD(2.5, state.getFukaModifier());
-		state.cooldowns
-			.get("cd_GCD")
-			.useStackWithRecast(state, state.config.getAfterTaxGCD(recastTime));
+		state.cooldowns.get("cd_GCD").useStackWithRecast(state.config.getAfterTaxGCD(recastTime));
 	},
 	// start the meditate timer
 	onApplication: (state: SAMState) => state.startMeditateTimer(),

--- a/src/Game/Jobs/SMN.ts
+++ b/src/Game/Jobs/SMN.ts
@@ -350,7 +350,7 @@ export class SMNState extends GameState {
 		);
 		// prevent radiant aegis and other pet summons
 		const summonLockout = PET_LOCK_DURATIONS.get(sourceSkill)!;
-		this.cooldowns.get("cd_SUMMON_LOCKOUT").useStackWithRecast(this, summonLockout);
+		this.cooldowns.get("cd_SUMMON_LOCKOUT").useStackWithRecast(summonLockout);
 	}
 }
 

--- a/src/Game/Jobs/WAR.ts
+++ b/src/Game/Jobs/WAR.ts
@@ -412,7 +412,7 @@ makeWeaponskill_WAR("MYTHRIL_TEMPEST", 40, {
 
 function reduceInfuriateCooldown(state: WARState) {
 	const cooldown = state.cooldowns.get("cd_INFURIATE") as CoolDown;
-	cooldown.restore(state, 5);
+	cooldown.restore(5);
 }
 
 makeWeaponskill_WAR("FELL_CLEAVE", 54, {

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -186,8 +186,10 @@ export class CoolDown extends ResourceOrCooldown {
 			if (this.#timeTillNextStackAvailable < Debug.epsilon) {
 				super.gain(1);
 				this.#currentRecast = this.#defaultRecast;
-				if (this.stacksAvailable() <= this.maxStacks()) {
+				if (this.stacksAvailable() < this.maxStacks()) {
 					this.#timeTillNextStackAvailable = this.#defaultRecast;
+				} else {
+					this.#timeTillNextStackAvailable = 0;
 				}
 			}
 			deltaTime -= forThisStack;

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -45,16 +45,60 @@ export class Event {
 
 abstract class ResourceOrCooldown {
 	abstract type: ResourceKey | CooldownKey;
-	maxValue: number;
-	#currentValue: number;
+	readonly maxValue: number;
+
+	protected currentValue: number;
+
+	protected constructor(maxValue: number, initialValue: number) {
+		this.maxValue = maxValue;
+		this.currentValue = initialValue;
+	}
+	availableAmount() {
+		return this.currentValue;
+	}
+	consume(amount: number) {
+		if (this.currentValue < amount - Debug.epsilon) {
+			console.warn(
+				`invalid resource consumption: ${this.type}, ${this.currentValue} - ${amount}`,
+			);
+		}
+		this.currentValue = Math.max(this.currentValue - amount, 0);
+	}
+	gain(amount: number) {
+		this.currentValue = Math.min(this.currentValue + amount, this.maxValue);
+	}
+	overrideCurrentValue(amount: number) {
+		this.currentValue = amount;
+	}
+}
+
+// can never be negative
+export class Resource extends ResourceOrCooldown {
+	type: ResourceKey;
 	enabled: boolean;
 	pendingChange?: Event;
+
 	#lastExpirationTime?: number;
 
-	constructor(maxValue: number, initialValue: number) {
-		this.maxValue = maxValue;
-		this.#currentValue = initialValue;
+	constructor(type: ResourceKey, maxValue: number, initialValue: number) {
+		super(maxValue, initialValue);
+		this.type = type;
 		this.enabled = true;
+	}
+
+	available(amount: number) {
+		return this.availableAmount() + Debug.epsilon >= amount;
+	}
+	availableAmountIncludingDisabled(): number {
+		// used for checking LL existence: if Retrace should replace its button
+		// also used for checking if a ground dot has been toggled but is still active
+		return this.currentValue;
+	}
+	availableAmount() {
+		return this.enabled ? super.availableAmount() : 0;
+	}
+	gainWrapping(amount: number) {
+		this.currentValue = (this.currentValue + amount) % (this.maxValue + 1);
 	}
 	overrideTimer(game: GameState, newTime: number) {
 		if (this.pendingChange) {
@@ -77,49 +121,15 @@ abstract class ResourceOrCooldown {
 			this.pendingChange = undefined;
 		}
 	}
-	available(amount: number) {
-		return this.availableAmount() + Debug.epsilon >= amount;
-	}
-	availableAmount() {
-		return this.enabled ? this.#currentValue : 0;
-	}
-	availableAmountIncludingDisabled(): number {
-		// used for checking LL existence: if Retrace should replace its button
-		// also used for checking if a ground dot has been toggled but is still active
-		return this.#currentValue;
-	}
-	consume(amount: number) {
-		if (this.#currentValue < amount - Debug.epsilon) {
-			console.warn("invalid resource consumption: " + this.type);
-			console.log(amount);
-			console.log(this);
-		}
-		this.#currentValue = Math.max(this.#currentValue - amount, 0);
-		if (this.#currentValue === 0) {
-			this.#lastExpirationTime = controller.game.getDisplayTime();
-		}
-	}
 	getLastExpirationTime(): number | undefined {
 		return this.#lastExpirationTime;
 	}
-	gain(amount: number) {
-		this.#currentValue = Math.min(this.#currentValue + amount, this.maxValue);
-	}
-	gainWrapping(amount: number) {
-		this.#currentValue = (this.#currentValue + amount) % (this.maxValue + 1);
-	}
-	overrideCurrentValue(amount: number) {
-		this.#currentValue = amount;
-	}
-}
-
-// can never be negative
-export class Resource extends ResourceOrCooldown {
-	type: ResourceKey;
-
-	constructor(type: ResourceKey, maxValue: number, initialValue: number) {
-		super(maxValue, initialValue);
-		this.type = type;
+	consume(amount: number) {
+		super.consume(amount);
+		if (this.currentValue === 0) {
+			// note: might not want to access controller here
+			this.#lastExpirationTime = controller.game.getDisplayTime();
+		}
 	}
 }
 
@@ -131,75 +141,61 @@ export class OverTimeBuff extends Resource {
 export class CoolDown extends ResourceOrCooldown {
 	type: CooldownKey;
 
-	readonly #defaultBaseRecast: number;
-	#recastTimeScale: number;
-	#currentBaseRecast: number;
+	readonly #defaultRecast: number;
+	#currentRecast: number;
+	#timeTillNextStackAvailable: number;
 
-	constructor(
-		type: CooldownKey,
-		cdPerStack: number,
-		maxStacks: number,
-		initialNumStacks: number,
-	) {
-		super(maxStacks * cdPerStack, initialNumStacks * cdPerStack);
+	constructor(type: CooldownKey, cdPerStack: number, maxStacks: number, initialStacks: number) {
+		super(maxStacks, initialStacks);
 		this.type = type;
 
-		this.#defaultBaseRecast = cdPerStack;
-		this.#currentBaseRecast = cdPerStack; // special case for mixed-recast spells
-		this.#recastTimeScale = 1; // effective for the next stack (i.e. 0.85 if captured LL)
+		this.#defaultRecast = cdPerStack;
+		this.#currentRecast = cdPerStack; // special case for mixed-recast spells
+		this.#timeTillNextStackAvailable = 0;
 	}
 	currentStackCd() {
-		return this.#currentBaseRecast * this.#recastTimeScale;
-	}
-	stacksAvailable() {
-		return Math.floor((this.availableAmount() + Debug.epsilon) / this.#currentBaseRecast);
+		return this.#currentRecast;
 	}
 	maxStacks() {
-		return this.maxValue / this.#currentBaseRecast;
+		return this.maxValue;
 	}
-	useStack(game: GameState) {
-		this.consume(this.#defaultBaseRecast);
-		this.#reCaptureRecastTimeScale(game);
+	useStack() {
+		if (this.stacksAvailable() === this.maxStacks()) {
+			this.#timeTillNextStackAvailable = this.#currentRecast;
+		}
+		super.consume(1);
 	}
-	useStackWithRecast(game: GameState, recast: number) {
+	useStackWithRecast(recast: number) {
+		console.assert(
+			this.maxStacks() === 1,
+			"class CoolDown assumes special recasts are only available for skills with at most 1 stack",
+		);
 		// roll the GCD with a special recast value
-		this.consume(this.#currentBaseRecast);
-		this.maxValue = recast;
-		// LL modifier
-		// (PCT handles hyperphantasia logic separately)
-		this.#reCaptureRecastTimeScale(game);
-		// scale for spells with longer cast/recast
-		this.#currentBaseRecast = recast;
+		this.#currentRecast = recast;
+		this.useStack();
 	}
-	setRecastTimeScale(timeScale: number) {
-		this.#recastTimeScale = timeScale;
-	}
-	#reCaptureRecastTimeScale(game: GameState) {
-		this.#recastTimeScale = this.type === "cd_GCD" ? game.gcdRecastTimeScale() : 1;
-	}
-	restore(game: GameState, deltaTime: number) {
-		let stacksBefore = this.stacksAvailable();
-		let unscaledTimeTillNextStack =
-			(stacksBefore + 1) * this.#currentBaseRecast - this.availableAmount();
-		let scaledTimeTillNextStack = unscaledTimeTillNextStack * this.#recastTimeScale;
-		if (deltaTime >= scaledTimeTillNextStack) {
-			// upon return, will have gained another stack
-			// part before stack gain
-			this.gain(unscaledTimeTillNextStack);
-			// re-capture
-			this.#reCaptureRecastTimeScale(game);
-			// and part after stack gain
-			this.gain((deltaTime - scaledTimeTillNextStack) / this.#recastTimeScale);
-		} else {
-			this.gain(deltaTime / this.#recastTimeScale);
+	restore(deltaTime: number) {
+		while (deltaTime > 0 && super.availableAmount() < this.maxStacks()) {
+			let forThisStack = Math.min(this.#timeTillNextStackAvailable, deltaTime);
+			this.#timeTillNextStackAvailable -= forThisStack;
+			if (this.#timeTillNextStackAvailable < Debug.epsilon) {
+				super.gain(1);
+				this.#currentRecast = this.#defaultRecast;
+				if (this.stacksAvailable() <= this.maxStacks()) {
+					this.#timeTillNextStackAvailable = this.#defaultRecast;
+				}
+			}
+			deltaTime -= forThisStack;
 		}
 	}
 	timeTillNextStackAvailable() {
-		if (this.availableAmount() === this.maxValue) return 0;
-		return (
-			(this.#currentBaseRecast - (this.availableAmount() % this.#currentBaseRecast)) *
-			this.#recastTimeScale
-		);
+		return this.#timeTillNextStackAvailable;
+	}
+	overrideTimeTillNextStack(newTime: number) {
+		this.#timeTillNextStackAvailable = newTime;
+	}
+	stacksAvailable(): number {
+		return super.availableAmount();
 	}
 }
 
@@ -229,14 +225,7 @@ export class CoolDownState {
 	}
 
 	tick(deltaTime: number) {
-		for (const cd of this.#map.values()) cd.restore(this.game, deltaTime);
-	}
-	stacksAvailable(rscType: CooldownKey): number {
-		return this.get(rscType).stacksAvailable();
-	}
-	setRecastTimeScale(cdName: CooldownKey, timeScale: number) {
-		let cd = this.get(cdName);
-		cd.setRecastTimeScale(timeScale);
+		for (const cd of this.#map.values()) cd.restore(deltaTime);
 	}
 	timeTillNextStackAvailable(cdName: CooldownKey) {
 		let cd = this.get(cdName);

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -188,8 +188,6 @@ export class CoolDown extends ResourceOrCooldown {
 				this.#currentRecast = this.#defaultRecast;
 				if (this.stacksAvailable() < this.maxStacks()) {
 					this.#timeTillNextStackAvailable += this.#defaultRecast;
-				} else {
-					this.#timeTillNextStackAvailable = 0;
 				}
 			}
 			deltaTime -= forThisStack;

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -187,7 +187,7 @@ export class CoolDown extends ResourceOrCooldown {
 				super.gain(1);
 				this.#currentRecast = this.#defaultRecast;
 				if (this.stacksAvailable() < this.maxStacks()) {
-					this.#timeTillNextStackAvailable = this.#defaultRecast;
+					this.#timeTillNextStackAvailable += this.#defaultRecast;
 				} else {
 					this.#timeTillNextStackAvailable = 0;
 				}

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,12 @@
 [
 	{
+		"date": "4/28/25",
+		"changes": [
+			"Refactored cooldown logic. Changes should not affect end users, but let us know if anything is off.",
+			"Added a few missing translations"
+		]
+	},
+	{
 		"date": "4/21/25",
 		"changes": [
 			"Updated compatibility with Ama's combat sim for newly-supported jobs."


### PR DESCRIPTION
Made Resource and CoolDown classes more separate by pulling some some functions out of the base abstract class
Got rid of recast time scaling for CDs, and switch to just store number of stacks available + time till next stack

As a result, there are slight changes to some jobs' implementations
* BLM: Ley Lines is now handled in `Game/Jobs/BLM.ts`
* PCT: Tempera Coat and Tempera Grassa - hopefully I changed them right?
* Others: remove redundant function call parameter(s)

Site behavior is the same as before according to some basic manual testing and shanzhe's test corpus. Resource overrides for CDs also still work.

And I slipped in a few translations