### PR TITLE
Misc RPR fixes

### DIFF
--- a/src/Game/Jobs/RPR.ts
+++ b/src/Game/Jobs/RPR.ts
@@ -332,6 +332,7 @@ export class RPRState extends GameState {
 		if (this.hasResourceAvailable("IDEAL_HOST")) this.resources.get("IDEAL_HOST").consume(1);
 		if (this.hasTraitUnlocked("ENHANCED_ENSHROUD")) this.setTimedResource("OBLATIO", 1);
 		this.setTimedResource("LEMURE_SHROUD", 5);
+		this.tryConsumeResource("PERFECTIO_PARATA", true);
 	}
 
 	exitEnshroud() {
@@ -362,6 +363,7 @@ const enshroudSkills = new Set<RPRActionKey | RoleActionKey | CommonActionKey>([
 	"ARCANE_CIRCLE",
 	"HELLS_EGRESS",
 	"HELLS_INGRESS",
+	"REGRESS",
 	"ARCANE_CREST",
 
 	"FEINT",
@@ -692,12 +694,12 @@ makeRPRWeaponskill("SOUL_SLICE", 60, {
 makeRPRWeaponskill("GIBBET", 70, {
 	replaceIf: [
 		{
-			newSkill: "EXECUTIONERS_GIBBET",
-			condition: (state) => state.hasResourceAvailable("EXECUTIONER"),
-		},
-		{
 			newSkill: "VOID_REAPING",
 			condition: (state) => state.hasResourceAvailable("ENSHROUDED"),
+		},
+		{
+			newSkill: "EXECUTIONERS_GIBBET",
+			condition: (state) => state.hasResourceAvailable("EXECUTIONER"),
 		},
 	],
 	potency: [
@@ -725,12 +727,12 @@ makeRPRWeaponskill("GIBBET", 70, {
 makeRPRWeaponskill("GALLOWS", 70, {
 	replaceIf: [
 		{
-			newSkill: "EXECUTIONERS_GALLOWS",
-			condition: (state) => state.resources.get("EXECUTIONER").available(1),
-		},
-		{
 			newSkill: "CROSS_REAPING",
 			condition: (state) => state.hasResourceAvailable("ENSHROUDED"),
+		},
+		{
+			newSkill: "EXECUTIONERS_GALLOWS",
+			condition: (state) => state.resources.get("EXECUTIONER").available(1),
 		},
 	],
 	potency: [
@@ -925,7 +927,7 @@ makeRPRAbility("GRIM_SWATHE", 55, "cd_BLOOD_STALK", {
 	replaceIf: [
 		{
 			condition: (state) => state.hasResourceAvailable("ENSHROUDED"),
-			newSkill: "LEMURES_SLICE",
+			newSkill: "LEMURES_SCYTHE",
 		},
 	],
 	isPhysical: true,
@@ -1242,12 +1244,12 @@ makeRPRAbility("LEMURES_SCYTHE", 86, "cd_LEMURES_SLICE", {
 makeRPRWeaponskill("GUILLOTINE", 70, {
 	replaceIf: [
 		{
-			newSkill: "EXECUTIONERS_GUILLOTINE",
-			condition: (state) => state.resources.get("EXECUTIONER").available(1),
-		},
-		{
 			newSkill: "GRIM_REAPING",
 			condition: (state) => state.hasResourceAvailable("ENSHROUDED"),
+		},
+		{
+			newSkill: "EXECUTIONERS_GUILLOTINE",
+			condition: (state) => state.resources.get("EXECUTIONER").available(1),
 		},
 	],
 	potency: 200,

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,14 @@
 [
 	{
+		"date": "5/9/25",
+		"changes": [
+			"[RPR] Fixed a bug where Regress wasn't usable in enshroud",
+			"[RPR] Fixed a bug where Grim Swathe was replaced with Lemure's Slice instead of Lemure's Scythe",
+			"[RPR] Fixed a bug where Perfectio was usable in enshroud",
+			"[RPR] Fixed a bug where Executioner's Gibbet/Gallows weren't replaced with Void/Cross Reaping while in enshroud"
+		]
+	}
+	{
 		"date": "5/2/25",
 		"changes": [
 			"Changed Ama's combat sim export to disable auto-attacks for healer/caster jobs."

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -7,7 +7,7 @@
 			"[RPR] Fixed a bug where Perfectio was usable in enshroud",
 			"[RPR] Fixed a bug where Executioner's Gibbet/Gallows weren't replaced with Void/Cross Reaping while in enshroud"
 		]
-	}
+	},
 	{
 		"date": "5/2/25",
 		"changes": [


### PR DESCRIPTION
- Fixed `Grim Swathe` incorrectly being replaced with `Lemure's Slice` instead of `Lemure's Scythe`
- `Regress` now usable in enshroud
- Changed order of replacement for `Gibbet`, `Gallows`, and `Guillotine` so that they are replaced by the enshroud versions when both `Enshrouded` and `Executioner` are available (confirmed ingame that this is correct)
- Removed `Perfectio Parata` upon entering enshroud (confirmed ingame that this is correct)