### PR TITLE
More prominent changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # incremental build
 tsconfig.tsbuildinfo
 .react-router/
+.vite/
 
 # misc
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "xiv-in-the-shell",
       "version": "0.1.0",
       "dependencies": {
+        "@base-ui-components/react": "^1.0.0-alpha.8",
         "@types/jquery": "^3.5.14",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.3",
@@ -17,7 +18,6 @@
         "react-icons": "^5.3.0",
         "react-resizable-panels": "^2.1.9",
         "react-tabs": "^6.1.0",
-        "react-tooltip": "^5.28.1",
         "seedrandom": "^3.0.5",
         "typescript": "^5.8.3"
       },
@@ -98,9 +98,38 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
       "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui-components/react": {
+      "version": "1.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@base-ui-components/react/-/react-1.0.0-alpha.8.tgz",
+      "integrity": "sha512-tGSksjEjA9TPguCXzFZU2cpvvsE6lnkVWVI0qSk3Zl/jQiE9F6opPVBp1uzHcJou7hj7fr6pEgtNf7WzsiXh4Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.27.0",
+        "@floating-ui/react": "^0.27.7",
+        "@floating-ui/utils": "^0.2.9",
+        "@react-aria/overlays": "^3.27.0",
+        "prop-types": "^15.8.1",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -814,10 +843,82 @@
         "@floating-ui/utils": "^0.2.9"
       }
     },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.8.tgz",
+      "integrity": "sha512-EQJ4Th328y2wyHR3KzOUOoTW2UKjFk53fmyahfwExnFQ8vnsMYqKc+fFPOkeYtj5tcp1DUMiNJ7BFhed7e9ONw==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.9",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -882,6 +983,39 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
+      "integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/message": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.7.tgz",
+      "integrity": "sha512-gLQlhEW4iO7DEFPf/U7IrIdA3UyLGS0opeqouaFwlMObLUzwexRjbygONHDVbC9G9oFLXsLyGKYkJwqXw/QADg==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "intl-messageformat": "^10.1.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.1.tgz",
+      "integrity": "sha512-UVsb4bCwbL944E0SX50CHFtWEeZ2uB5VozZ5yDXJdq6iPZsZO5p+bjVMZh2GxHf4Bs/7xtDCcPwEa2NU9DaG/g==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.6.tgz",
+      "integrity": "sha512-LR2lnM4urJta5/wYJVV7m8qk5DrMZmLRTuFhbQO5b9/sKLHgty6unQy1Li4+Su2DWydmB4aZdS5uxBRXIq2aAw==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -965,6 +1099,187 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.20.2.tgz",
+      "integrity": "sha512-Q3rouk/rzoF/3TuH6FzoAIKrl+kzZi9LHmr8S5EqLAOyP9TXIKG34x2j42dZsAhrw7TbF9gA8tBKwnCNH4ZV+Q==",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.0",
+        "@react-aria/utils": "^3.28.2",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/i18n": {
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.8.tgz",
+      "integrity": "sha512-V/Nau9WuwTwxfFffQL4URyKyY2HhRlu9zmzkF2Hw/j5KmEQemD+9jfaLueG2CJu85lYL06JrZXUdnhZgKnqMkA==",
+      "dependencies": {
+        "@internationalized/date": "^3.8.0",
+        "@internationalized/message": "^3.1.7",
+        "@internationalized/number": "^3.6.1",
+        "@internationalized/string": "^3.2.6",
+        "@react-aria/ssr": "^3.9.8",
+        "@react-aria/utils": "^3.28.2",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.0.tgz",
+      "integrity": "sha512-GgIsDLlO8rDU/nFn6DfsbP9rfnzhm8QFjZkB9K9+r+MTSCn7bMntiWQgMM+5O6BiA8d7C7x4zuN4bZtc0RBdXQ==",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.8",
+        "@react-aria/utils": "^3.28.2",
+        "@react-stately/flags": "^3.1.1",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/overlays": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.27.0.tgz",
+      "integrity": "sha512-2vZVgL7FrloN5Rh8sAhadGADJbuWg69DdSJB3fd2/h5VvcEhnIfNPu9Ma5XmdkApDoTboIEsKZ4QLYwRl98w6w==",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/i18n": "^3.12.8",
+        "@react-aria/interactions": "^3.25.0",
+        "@react-aria/ssr": "^3.9.8",
+        "@react-aria/utils": "^3.28.2",
+        "@react-aria/visually-hidden": "^3.8.22",
+        "@react-stately/overlays": "^3.6.15",
+        "@react-types/button": "^3.12.0",
+        "@react-types/overlays": "^3.8.14",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.8.tgz",
+      "integrity": "sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.28.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.28.2.tgz",
+      "integrity": "sha512-J8CcLbvnQgiBn54eeEvQQbIOfBF3A1QizxMw9P4cl9MkeR03ug7RnjTIdJY/n2p7t59kLeAB3tqiczhcj+Oi5w==",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.8",
+        "@react-stately/flags": "^3.1.1",
+        "@react-stately/utils": "^3.10.6",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/visually-hidden": {
+      "version": "3.8.22",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.22.tgz",
+      "integrity": "sha512-EO3R8YTKZ7HkLl9k1Y2uBKYBgpJagth4/4W7mfpJZE24A3fQnCP8zx1sweXiAm0mirR4J6tNaK7Ia8ssP5TpOw==",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.0",
+        "@react-aria/utils": "^3.28.2",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.1.tgz",
+      "integrity": "sha512-XPR5gi5LfrPdhxZzdIlJDz/B5cBf63l4q6/AzNqVWFKgd0QqY5LvWJftXkklaIUpKSJkIKQb8dphuZXDtkWNqg==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/overlays": {
+      "version": "3.6.15",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.15.tgz",
+      "integrity": "sha512-LBaGpXuI+SSd5HSGzyGJA0Gy09V2tl2G/r0lllTYqwt0RDZR6p7IrhdGVXZm6vI0oWEnih7yLC32krkVQrffgQ==",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.6",
+        "@react-types/overlays": "^3.8.14",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.10.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.6.tgz",
+      "integrity": "sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/button": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.12.0.tgz",
+      "integrity": "sha512-YrASNa+RqGQpzJcxNAahzNuTYVID1OE6HCorrEOXIyGS3EGogHsQmFs9OyThXnGHq6q4rLlA806/jWbP9uZdxA==",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/overlays": {
+      "version": "3.8.14",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.14.tgz",
+      "integrity": "sha512-XJS67KHYhdMvPNHXNGdmc85gE+29QT5TwC58V4kxxHVtQh9fYzEEPzIV8K84XWSz04rRGe3fjDgRNbcqBektWQ==",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.40.2",
@@ -1454,9 +1769,6 @@
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
       "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -2552,11 +2864,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2790,7 +3097,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -4351,6 +4657,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -6078,20 +6395,6 @@
         "react": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/react-tooltip": {
-      "version": "5.28.1",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.28.1.tgz",
-      "integrity": "sha512-ZA4oHwoIIK09TS7PvSLFcRlje1wGZaxw6xHvfrzn6T82UcMEfEmHVCad16Gnr4NDNDh93HyN037VK4HDi5odfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.6.1",
-        "classnames": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.14.0",
-        "react-dom": ">=16.14.0"
-      }
-    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -6801,6 +7104,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -7040,10 +7348,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7269,6 +7574,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -7902,8 +8215,20 @@
     "@babel/runtime": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
-      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
-      "dev": true
+      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog=="
+    },
+    "@base-ui-components/react": {
+      "version": "1.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@base-ui-components/react/-/react-1.0.0-alpha.8.tgz",
+      "integrity": "sha512-tGSksjEjA9TPguCXzFZU2cpvvsE6lnkVWVI0qSk3Zl/jQiE9F6opPVBp1uzHcJou7hj7fr6pEgtNf7WzsiXh4Q==",
+      "requires": {
+        "@babel/runtime": "^7.27.0",
+        "@floating-ui/react": "^0.27.7",
+        "@floating-ui/utils": "^0.2.9",
+        "@react-aria/overlays": "^3.27.0",
+        "prop-types": "^15.8.1",
+        "use-sync-external-store": "^1.5.0"
+      }
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -8242,10 +8567,74 @@
         "@floating-ui/utils": "^0.2.9"
       }
     },
+    "@floating-ui/react": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.8.tgz",
+      "integrity": "sha512-EQJ4Th328y2wyHR3KzOUOoTW2UKjFk53fmyahfwExnFQ8vnsMYqKc+fFPOkeYtj5tcp1DUMiNJ7BFhed7e9ONw==",
+      "requires": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.9",
+        "tabbable": "^6.0.0"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "requires": {
+        "@floating-ui/dom": "^1.0.0"
+      }
+    },
     "@floating-ui/utils": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+    },
+    "@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "requires": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "requires": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "requires": {
+        "tslib": "^2.8.0"
+      }
     },
     "@humanfs/core": {
       "version": "0.19.1",
@@ -8282,6 +8671,39 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
       "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
       "dev": true
+    },
+    "@internationalized/date": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
+      "integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
+      "requires": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "@internationalized/message": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.7.tgz",
+      "integrity": "sha512-gLQlhEW4iO7DEFPf/U7IrIdA3UyLGS0opeqouaFwlMObLUzwexRjbygONHDVbC9G9oFLXsLyGKYkJwqXw/QADg==",
+      "requires": {
+        "@swc/helpers": "^0.5.0",
+        "intl-messageformat": "^10.1.0"
+      }
+    },
+    "@internationalized/number": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.1.tgz",
+      "integrity": "sha512-UVsb4bCwbL944E0SX50CHFtWEeZ2uB5VozZ5yDXJdq6iPZsZO5p+bjVMZh2GxHf4Bs/7xtDCcPwEa2NU9DaG/g==",
+      "requires": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "@internationalized/string": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.6.tgz",
+      "integrity": "sha512-LR2lnM4urJta5/wYJVV7m8qk5DrMZmLRTuFhbQO5b9/sKLHgty6unQy1Li4+Su2DWydmB4aZdS5uxBRXIq2aAw==",
+      "requires": {
+        "@swc/helpers": "^0.5.0"
+      }
     },
     "@jridgewell/resolve-uri": {
       "version": "3.1.2",
@@ -8344,6 +8766,143 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true
+    },
+    "@react-aria/focus": {
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.20.2.tgz",
+      "integrity": "sha512-Q3rouk/rzoF/3TuH6FzoAIKrl+kzZi9LHmr8S5EqLAOyP9TXIKG34x2j42dZsAhrw7TbF9gA8tBKwnCNH4ZV+Q==",
+      "requires": {
+        "@react-aria/interactions": "^3.25.0",
+        "@react-aria/utils": "^3.28.2",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      }
+    },
+    "@react-aria/i18n": {
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.8.tgz",
+      "integrity": "sha512-V/Nau9WuwTwxfFffQL4URyKyY2HhRlu9zmzkF2Hw/j5KmEQemD+9jfaLueG2CJu85lYL06JrZXUdnhZgKnqMkA==",
+      "requires": {
+        "@internationalized/date": "^3.8.0",
+        "@internationalized/message": "^3.1.7",
+        "@internationalized/number": "^3.6.1",
+        "@internationalized/string": "^3.2.6",
+        "@react-aria/ssr": "^3.9.8",
+        "@react-aria/utils": "^3.28.2",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "@react-aria/interactions": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.0.tgz",
+      "integrity": "sha512-GgIsDLlO8rDU/nFn6DfsbP9rfnzhm8QFjZkB9K9+r+MTSCn7bMntiWQgMM+5O6BiA8d7C7x4zuN4bZtc0RBdXQ==",
+      "requires": {
+        "@react-aria/ssr": "^3.9.8",
+        "@react-aria/utils": "^3.28.2",
+        "@react-stately/flags": "^3.1.1",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "@react-aria/overlays": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.27.0.tgz",
+      "integrity": "sha512-2vZVgL7FrloN5Rh8sAhadGADJbuWg69DdSJB3fd2/h5VvcEhnIfNPu9Ma5XmdkApDoTboIEsKZ4QLYwRl98w6w==",
+      "requires": {
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/i18n": "^3.12.8",
+        "@react-aria/interactions": "^3.25.0",
+        "@react-aria/ssr": "^3.9.8",
+        "@react-aria/utils": "^3.28.2",
+        "@react-aria/visually-hidden": "^3.8.22",
+        "@react-stately/overlays": "^3.6.15",
+        "@react-types/button": "^3.12.0",
+        "@react-types/overlays": "^3.8.14",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "@react-aria/ssr": {
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.8.tgz",
+      "integrity": "sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==",
+      "requires": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "@react-aria/utils": {
+      "version": "3.28.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.28.2.tgz",
+      "integrity": "sha512-J8CcLbvnQgiBn54eeEvQQbIOfBF3A1QizxMw9P4cl9MkeR03ug7RnjTIdJY/n2p7t59kLeAB3tqiczhcj+Oi5w==",
+      "requires": {
+        "@react-aria/ssr": "^3.9.8",
+        "@react-stately/flags": "^3.1.1",
+        "@react-stately/utils": "^3.10.6",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      }
+    },
+    "@react-aria/visually-hidden": {
+      "version": "3.8.22",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.22.tgz",
+      "integrity": "sha512-EO3R8YTKZ7HkLl9k1Y2uBKYBgpJagth4/4W7mfpJZE24A3fQnCP8zx1sweXiAm0mirR4J6tNaK7Ia8ssP5TpOw==",
+      "requires": {
+        "@react-aria/interactions": "^3.25.0",
+        "@react-aria/utils": "^3.28.2",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "@react-stately/flags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.1.tgz",
+      "integrity": "sha512-XPR5gi5LfrPdhxZzdIlJDz/B5cBf63l4q6/AzNqVWFKgd0QqY5LvWJftXkklaIUpKSJkIKQb8dphuZXDtkWNqg==",
+      "requires": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "@react-stately/overlays": {
+      "version": "3.6.15",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.15.tgz",
+      "integrity": "sha512-LBaGpXuI+SSd5HSGzyGJA0Gy09V2tl2G/r0lllTYqwt0RDZR6p7IrhdGVXZm6vI0oWEnih7yLC32krkVQrffgQ==",
+      "requires": {
+        "@react-stately/utils": "^3.10.6",
+        "@react-types/overlays": "^3.8.14",
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "@react-stately/utils": {
+      "version": "3.10.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.6.tgz",
+      "integrity": "sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==",
+      "requires": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "@react-types/button": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.12.0.tgz",
+      "integrity": "sha512-YrASNa+RqGQpzJcxNAahzNuTYVID1OE6HCorrEOXIyGS3EGogHsQmFs9OyThXnGHq6q4rLlA806/jWbP9uZdxA==",
+      "requires": {
+        "@react-types/shared": "^3.29.0"
+      }
+    },
+    "@react-types/overlays": {
+      "version": "3.8.14",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.14.tgz",
+      "integrity": "sha512-XJS67KHYhdMvPNHXNGdmc85gE+29QT5TwC58V4kxxHVtQh9fYzEEPzIV8K84XWSz04rRGe3fjDgRNbcqBektWQ==",
+      "requires": {
+        "@react-types/shared": "^3.29.0"
+      }
+    },
+    "@react-types/shared": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+      "requires": {}
     },
     "@rollup/rollup-android-arm-eabi": {
       "version": "4.40.2",
@@ -8585,9 +9144,6 @@
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
       "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
       "requires": {
         "tslib": "^2.8.0"
       }
@@ -9345,11 +9901,6 @@
       "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "dev": true
     },
-    "classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
-    },
     "clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -9518,8 +10069,7 @@
     "decimal.js": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-      "dev": true
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="
     },
     "deep-eql": {
       "version": "5.0.2",
@@ -10622,6 +11172,17 @@
         "side-channel": "^1.1.0"
       }
     },
+    "intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
+      }
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -11715,15 +12276,6 @@
         "prop-types": "^15.5.0"
       }
     },
-    "react-tooltip": {
-      "version": "5.28.1",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.28.1.tgz",
-      "integrity": "sha512-ZA4oHwoIIK09TS7PvSLFcRlje1wGZaxw6xHvfrzn6T82UcMEfEmHVCad16Gnr4NDNDh93HyN037VK4HDi5odfQ==",
-      "requires": {
-        "@floating-ui/dom": "^1.6.1",
-        "classnames": "^2.3.0"
-      }
-    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -12214,6 +12766,11 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+    },
     "tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -12363,10 +12920,7 @@
     "tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "type-check": {
       "version": "0.4.0",
@@ -12519,6 +13073,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "requires": {}
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "homepage": "https://xivintheshell.com",
   "private": true,
   "dependencies": {
+    "@base-ui-components/react": "^1.0.0-alpha.8",
     "@types/jquery": "^3.5.14",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.3",
@@ -13,7 +14,6 @@
     "react-icons": "^5.3.0",
     "react-resizable-panels": "^2.1.9",
     "react-tabs": "^6.1.0",
-    "react-tooltip": "^5.28.1",
     "seedrandom": "^3.0.5",
     "typescript": "^5.8.3"
   },

--- a/src/Components/Changelog.tsx
+++ b/src/Components/Changelog.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useContext } from "react";
 import { Dialog } from "@base-ui-components/react/dialog";
+import { FaXmark } from "react-icons/fa6";
 import changelog from "../changelog.json";
 import { getCurrentThemeColors, ColorThemeContext } from "./ColorTheme";
 import { Clickable, Expandable, Help, ButtonIndicator, ContentNode } from "./Common";
@@ -122,7 +123,7 @@ export function Changelog() {
 		// use the most recent changelog entry (5/10/25) as the last read.
 		// If someone last visited the site at an earlier date... there's not really
 		// anything we can do about that.
-		if (!isFirstVisit) {
+		if (!isFirstVisit && (lastReadDate === null || lastReadChangeCountStr === null)) {
 			lastReadDate = "5/10/25";
 			lastReadChangeCountStr = "1";
 		}
@@ -199,6 +200,13 @@ export function Changelog() {
 		</span>
 	</div>;
 
+	const exitTrigger = <FaXmark
+		className="dialogExit"
+		style={{
+			color: colors.bgHighContrast,
+		}}
+	/>;
+
 	return <>
 		<style>{changelogDialogStyles}</style>
 		<Dialog.Root onOpenChange={onOpenChange}>
@@ -220,6 +228,7 @@ export function Changelog() {
 					}}
 				>
 					<Dialog.Title render={<h3>{titleNode}</h3>} />
+					<Dialog.Close render={exitTrigger} />
 					<Dialog.Description
 						className="Description"
 						render={

--- a/src/Components/Changelog.tsx
+++ b/src/Components/Changelog.tsx
@@ -204,14 +204,21 @@ export function Changelog() {
 		<Dialog.Root onOpenChange={onOpenChange}>
 			<Dialog.Trigger render={dialogTrigger} />
 			<Dialog.Portal>
-				<Dialog.Backdrop className="Backdrop" style={{
-					opacity: lightMode ? 0.2 : 0.7,
-				}}/>
-				<Dialog.Popup className="Popup visibleScrollbar" id="changelogPopup" style={{
-					"backgroundColor": colors.background,
-					"border": "1px solid " + colors.bgMediumContrast,
-					"color": colors.text,
-				}}>
+				<Dialog.Backdrop
+					className="Backdrop"
+					style={{
+						opacity: lightMode ? 0.2 : 0.7,
+					}}
+				/>
+				<Dialog.Popup
+					className="Popup visibleScrollbar"
+					id="changelogPopup"
+					style={{
+						backgroundColor: colors.background,
+						border: "1px solid " + colors.bgMediumContrast,
+						color: colors.text,
+					}}
+				>
 					<Dialog.Title render={<h3>{titleNode}</h3>} />
 					<Dialog.Description
 						className="Description"

--- a/src/Components/Changelog.tsx
+++ b/src/Components/Changelog.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useContext } from "react";
 import { Dialog } from "@base-ui-components/react/dialog";
 import changelog from "../changelog.json";
-import { getCurrentThemeColors } from "./ColorTheme";
+import { getCurrentThemeColors, ColorThemeContext } from "./ColorTheme";
 import { Clickable, Expandable, Help, ButtonIndicator, ContentNode } from "./Common";
 import { localize, LocalizedContent } from "./Localization";
 import { getCachedValue, setCachedValue } from "../Controller/Common";
@@ -52,13 +52,13 @@ function getRenderedEntry(entry: ChangelogEntry) {
 	</div>;
 }
 
-// TODO set background, border, backdrop according to theme
+// Partially copied from BaseUI's Dialog example
+// https://base-ui.com/react/components/dialog
 const changelogDialogStyles = `
 .Backdrop {
   position: fixed;
   inset: 0;
   background-color: black;
-  opacity: 0.2;
   transition: opacity 50ms cubic-bezier(0.45, 1.005, 0, 1.005);
 
   &[data-starting-style],
@@ -74,16 +74,13 @@ const changelogDialogStyles = `
   left: 50%;
   transform: translate(-50%, -50%);
   width: 50vw;
-  height: 60vw;
-  max-height: 60vw;
-  overflow: scroll;
+  height: 70vh;
+  max-height: 70vh;
+  overflow-y: scroll;
   margin-top: -2rem;
   padding-left: 1.5rem;
   padding-right: 1.5rem;
-  background-color: white;
   transition: all 50ms cubic-bezier(0.45, 1.005, 0, 1.005);
-
-  border: 1px solid black;
 
   font-family: monospace;
   font-size: 13px;
@@ -113,6 +110,10 @@ export function Changelog() {
 	let handleStyle: React.CSSProperties = {};
 	const hiddenStartIndex = useRef(5);
 	const [upToDate, setUpToDate] = useState(false);
+
+	const lightMode = useContext(ColorThemeContext) === "Light";
+	const colors = getCurrentThemeColors();
+
 	// Check whether CL is up to date on page load
 	useEffect(() => {
 		const lastReadDate = getCachedValue("changelogLastRead");
@@ -182,16 +183,23 @@ export function Changelog() {
 	const dialogTrigger = <div className="clickable">
 		<span style={handleStyle}>
 			<span>{dialogHandle} </span>
-			{titleNode}
+			<span className="clickableLinkLike">{titleNode}</span>
 		</span>
 	</div>;
+
 	return <>
 		<style>{changelogDialogStyles}</style>
 		<Dialog.Root onOpenChange={onOpenChange}>
 			<Dialog.Trigger render={dialogTrigger} />
 			<Dialog.Portal>
-				<Dialog.Backdrop className="Backdrop" />
-				<Dialog.Popup className="Popup visibleScrollbar" id="changelogPopup">
+				<Dialog.Backdrop className="Backdrop" style={{
+					opacity: lightMode ? 0.2 : 0.7,
+				}}/>
+				<Dialog.Popup className="Popup visibleScrollbar" id="changelogPopup" style={{
+					"backgroundColor": colors.background,
+					"border": "1px solid " + colors.bgMediumContrast,
+					"color": colors.text,
+				}}>
 					<Dialog.Title render={<h3>{titleNode}</h3>} />
 					<Dialog.Description
 						className="Description"

--- a/src/Components/Changelog.tsx
+++ b/src/Components/Changelog.tsx
@@ -1,0 +1,200 @@
+import React, { useState, useEffect, useRef } from "react";
+import { Dialog } from "@base-ui-components/react/dialog";
+import changelog from "../changelog.json";
+import { Clickable, Expandable, Help, ButtonIndicator, ContentNode } from "./Common";
+import { localize, LocalizedContent } from "./Localization";
+import { getCachedValue, setCachedValue } from "../Controller/Common";
+
+export function getLastChangeDate(): string {
+	return changelog[0].date;
+}
+
+// changelog.json contains a non-empty array of entries with the following schema:
+// - date: the date a change was made
+// - changes: a string array describing the changes
+// - [optional] changes_zh: chinese localized version of `changes`
+// the array of entries is assumed to have unique dates, and be sorted in descending order by date
+type ChangelogEntry = {
+	date: string;
+	changes: string[];
+	changes_zh?: string[];
+};
+
+type OldChangelogParams = {
+	entryStartIndex: number;
+};
+
+function getRenderedEntry(entry: ChangelogEntry) {
+	return <div>
+		{entry.date}
+		<ul>
+			{localize({
+				en: <>{entry.changes.map((change, i) => <li key={i}>{change}</li>)}</>,
+				zh:
+					entry.changes_zh !== undefined ? (
+						<>{entry.changes_zh.map((change, i) => <li key={i}>{change}</li>)}</>
+					) : undefined,
+			})}
+		</ul>
+	</div>;
+}
+
+// TODO swap for dark theme
+const changelogDialogStyles = `
+.Backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: black;
+  opacity: 0.2;
+  transition: opacity 50ms cubic-bezier(0.45, 1.005, 0, 1.005);
+
+  &[data-starting-style],
+  &[data-ending-style] {
+	opacity: 0;
+  }
+}
+
+.Popup {
+  box-sizing: border-box;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 50vw;
+  height: 60vw;
+  max-height: 60vw;
+  overflow: auto;
+  margin-top: -2rem;
+  padding: 1.5rem;
+  border-radius: 0.5rem;
+  background-color: white;
+  transition: all 50ms cubic-bezier(0.45, 1.005, 0, 1.005);
+
+  font-family: monospace;
+  font-size: 13px;
+
+  &[data-starting-style],
+  &[data-ending-style] {
+	opacity: 0;
+	transform: translate(-50%, -50%) scale(0.9);
+  }
+}
+
+.Title {
+  margin-top: -0.375rem;
+  margin-bottom: 0.25rem;
+  font-family: monospace;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  letter-spacing: -0.0025em;
+  font-weight: 500;
+}
+`;
+
+export function Changelog() {
+	let entryStartIndex: number = 0;
+	let titleNode: ContentNode;
+	let dialogHandle: ContentNode;
+	const [upToDate, setUpToDate] = useState(false);
+	// Check whether CL is up to date on page load
+	useEffect(() => {
+		const lastReadDate = getCachedValue("changelogLastRead");
+		const lastReadChangeCountStr = getCachedValue("changelogLastReadChangeCount");
+		setUpToDate(
+			lastReadDate === undefined ||
+				!lastReadChangeCountStr ||
+				(lastReadDate === changelog[0].date &&
+					parseInt(lastReadChangeCountStr) === changelog[0].changes.length),
+		);
+	}, []);
+
+	if (upToDate) {
+		// If this is the user's first visit, or they have already seen all relevant entries, don't do anything special.
+		titleNode = localize({ en: "Changelog", zh: "更新日志", ja: "更新履歴" });
+		dialogHandle = "•"; // U+2022 "bullet"
+	} else {
+		// If something has changed, then stylize the changelog label.
+		titleNode = localize({
+			en: "Changelog (new updates!!)",
+			zh: "更新日志（有变！！）",
+		});
+		dialogHandle = "!";
+	}
+	// Don't use a bespoke Clickable component for the expand button, since it suppresses Dialog.Trigger's
+	// built-in dismiss behavior.
+	const dialogTrigger = <div className="clickable">
+		<span>
+			<span>{dialogHandle} </span>
+			{titleNode}
+		</span>
+	</div>;
+	return <>
+		<style>{changelogDialogStyles}</style>
+		<Dialog.Root>
+			<Dialog.Trigger render={dialogTrigger} />
+			<Dialog.Portal>
+				<Dialog.Backdrop className="Backdrop" />
+				<Dialog.Popup className="Popup visibleScrollbar" id="changelogPopup">
+					<Dialog.Title className="Title">{titleNode}</Dialog.Title>
+					<Dialog.Description
+						className="Description"
+						render={<OldChangelog entryStartIndex={entryStartIndex} />}
+					/>
+				</Dialog.Popup>
+			</Dialog.Portal>
+		</Dialog.Root>
+	</>;
+}
+
+/**
+ * XIV in the Shell tracks the date of the user's last seen changelog entry, as well as the number of
+ * changes that were listed in that entry when the user opened it.
+ *
+ * If the user loads the page and the first changelog entry is newer or has a different number of entries,
+ * then the changelog label will be stylized, and older entries are collapsed.
+ *
+ * If the user opens the changelog and there are no new entries, the most recent 5 dates are displayed,
+ * with older entries placed in an expandable below.
+ */
+function OldChangelog(props: OldChangelogParams) {
+	const entriesToShow = [];
+	for (let i = props.entryStartIndex; i < changelog.length; i++) {
+		entriesToShow.push(getRenderedEntry(changelog[i]));
+	}
+	// Use a custom Expandable that's always closed to start, and ignores localStorage.
+	// This ensures the changelog dialog is always scrolled to the top, as I couldn't find any
+	// elegant ways to save the scroll state of the pane without slight layout shifts.
+	const [show, setShow] = useState(false);
+	const titleNode = localize({ en: "Older Changes", zh: "之前的更新" });
+	return <div style={{ marginTop: 10, marginBottom: 10 }}>
+		<Clickable
+			content={
+				<span>
+					<span>{show ? "- " : "+ "}</span>
+					{titleNode}
+				</span>
+			}
+			onClickFn={() => setShow(!show)}
+		/>
+		<div style={{ position: "relative", display: show ? "block" : "none" }}>
+			<div style={{ margin: 10, paddingLeft: 6, marginBottom: 20 }}>
+				<div>{entriesToShow.map((entry, i) => <div key={i}>{entry}</div>)}</div>
+				<div>
+					For older changelog entries before the BLM/PCT in the Shell rejoining, see&nbsp;
+					<b>About this site/Changelog</b> on the old sites:&nbsp;
+					<a
+						target={"_blank"}
+						rel={"noreferrer"}
+						href={"https://miyehn.me/ffxiv-blm-rotation/"}
+					>
+						BLM in the Shell
+					</a>
+					,&nbsp;
+					<a target={"_blank"} rel={"noreferrer"} href={"https://picto.zqsz.me/"}>
+						PCT in the Shell
+					</a>
+				</div>
+			</div>
+		</div>
+	</div>;
+}

--- a/src/Components/IntroSection.tsx
+++ b/src/Components/IntroSection.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties } from "react";
 import { clearCachedValues } from "../Controller/Common";
 import { Expandable, Help, ButtonIndicator } from "./Common";
 import { localize } from "./Localization";
-import changelog from "../changelog.json";
+import { Changelog } from "./Changelog";
 import { getCurrentThemeColors } from "./ColorTheme";
 import { ShellJob } from "../Game/Data/Jobs";
 
@@ -14,48 +14,6 @@ const GITHUB_URL = "https://github.com/xivintheshell/xivintheshell";
 const HELP_CHANNEL_URL = "https://discord.com/channels/277897135515762698/1307922201726685236";
 
 const BALANCE_URL = "https://discord.gg/thebalanceffxiv";
-
-function Changelog() {
-	return <div className={"paragraph"}>
-		<Expandable
-			title={"Changelog"}
-			titleNode={localize({ en: "Changelog", zh: "更新日志", ja: "更新履歴" })}
-			defaultShow={false}
-			content={
-				<>
-					<div>
-						{changelog.map((entry) => {
-							let changes: React.JSX.Element[] = [];
-							for (let i = 0; i < entry.changes.length; i++) {
-								changes.push(<div key={i}>{entry.changes[i]}</div>);
-							}
-							return <div className={"paragraph"} key={entry.date}>
-								{entry.date}
-								<br />
-								{changes}
-							</div>;
-						})}
-					</div>
-					<div>
-						For older changelog entries before the BLM/PCT in the Shell rejoining, see
-						the old sites:&nbsp;
-						<a
-							target={"_blank"}
-							rel={"noreferrer"}
-							href={"https://miyehn.me/ffxiv-blm-rotation/"}
-						>
-							BLM in the Shell
-						</a>
-						,&nbsp;
-						<a target={"_blank"} rel={"noreferrer"} href={"https://picto.zqsz.me/"}>
-							PCT in the Shell
-						</a>
-					</div>
-				</>
-			}
-		/>
-	</div>;
-}
 
 // needs to be a function to evaluate localization
 const getAcknowledgements = () => <>
@@ -191,6 +149,7 @@ export function IntroSection(props: { job: ShellJob }) {
 	let colors = getCurrentThemeColors();
 	const job = props.job;
 	return <div>
+		<Changelog />
 		<Expandable
 			defaultShow={true}
 			title={"instructions"}
@@ -603,7 +562,6 @@ export function IntroSection(props: { job: ShellJob }) {
 							}
 						</ul>,
 					})}
-					<Changelog />
 				</div>
 			}
 		/>

--- a/src/Components/Main.tsx
+++ b/src/Components/Main.tsx
@@ -9,7 +9,7 @@ import { SkillSequencePresets } from "./SkillSequencePresets";
 import { IntroSection } from "./IntroSection";
 import changelog from "../changelog.json";
 import { localize, localizeDate, SelectLanguage } from "./Localization";
-import { Expandable, GlobalHelpTooltip, Tabs } from "./Common";
+import { Expandable, Tabs } from "./Common";
 import {
 	getCachedColorTheme,
 	getThemeColors,
@@ -342,9 +342,19 @@ export default class Main extends React.Component<{ command?: string }> {
 					height: 0.8em;
 					border-radius: 0.4em;
 				}
+				.help-tooltip {
+				    color: ${colors.text};
+				    background-color: ${colors.tipBackground};
+				    opacity: 0.98;
+				    max-width: 300px;
+				    outline: 1px solid ${colors.bgHighContrast};
+				    transition: none;
+				    font-size: 100%;
+				    z-index: 10;
+				}
 			`}</style>
 			<ColorThemeContext.Provider value={this.state.colorTheme}>
-				<div style={containerStyle}>
+				<div style={containerStyle} id={"globalHelpTooltipAnchor"}>
 					<div
 						style={{
 							flex: 1,
@@ -512,7 +522,6 @@ export default class Main extends React.Component<{ command?: string }> {
 						</div>
 					</div>
 					<Timeline />
-					<GlobalHelpTooltip content={"initial content"} />
 				</div>
 			</ColorThemeContext.Provider>
 		</div>;

--- a/src/Components/Main.tsx
+++ b/src/Components/Main.tsx
@@ -7,7 +7,7 @@ import { controller } from "../Controller/Controller";
 import "react-tabs/style/react-tabs.css";
 import { SkillSequencePresets } from "./SkillSequencePresets";
 import { IntroSection } from "./IntroSection";
-import changelog from "../changelog.json";
+import { getLastChangeDate } from "./Changelog";
 import { localize, localizeDate, SelectLanguage } from "./Localization";
 import { Expandable, Tabs } from "./Common";
 import {
@@ -376,16 +376,15 @@ export default class Main extends React.Component<{ command?: string }> {
 								<h3 style={{ marginTop: 20, marginBottom: 6 }}>XIV in the Shell</h3>
 								{localize({
 									en: <div style={{ marginBottom: 16 }}>
-										Last updated: {changelog[0].date} (see{" "}
-										<b>About this tool/Changelog</b>)
+										Last updated: {getLastChangeDate()} (see <b>Changelog</b>)
 									</div>,
 									zh: <div style={{ marginBottom: 16 }}>
-										最近更新（月日年）：{changelog[0].date}（详见
-										<b>关于/更新日志</b>）
+										最近更新（月日年）：{getLastChangeDate()}（详见
+										<b>更新日志</b>）
 									</div>,
 									ja: <div style={{ marginBottom: 16 }}>
-										最終更新日：{localizeDate(changelog[0].date, "ja")}（
-										<b>このツールについて/更新履歴</b>を参照）（
+										最終更新日：{localizeDate(getLastChangeDate(), "ja")}（
+										<b>更新履歴</b>を参照）（
 										<a
 											href={
 												"https://coda.io/d/_d-N3WFoMZ8e/Black-Mage-in-the-Shell_suRLF"

--- a/src/Components/Skills.tsx
+++ b/src/Components/Skills.tsx
@@ -1,9 +1,9 @@
 import React, { useState, FormEvent, FormEventHandler } from "react";
+import { Tooltip } from "@base-ui-components/react/tooltip";
 import { Clickable, ContentNode, Help, parseTime, ValueChangeEvent } from "./Common";
 import { Debug, SkillReadyStatus, SkillUnavailableReason } from "../Game/Common";
 import { controller } from "../Controller/Controller";
 import { MAX_ABILITY_TARGETS } from "../Controller/Common";
-import { Tooltip as ReactTooltip } from "react-tooltip";
 import { localize, localizeSkillName } from "./Localization";
 import { updateTimelineView } from "./Timeline";
 import * as ReactDOMServer from "react-dom/server";
@@ -460,12 +460,9 @@ class SkillButton extends React.Component {
 			{proc}
 			{stacksOverlay}
 		</div>;
-		return <span
+		const tooltipTrigger = <span
 			title={ACTIONS[this.props.skillName].name}
-			className={"skillButton"}
-			data-tooltip-offset={3}
-			data-tooltip-html={ReactDOMServer.renderToStaticMarkup(this.state.skillDescription)}
-			data-tooltip-id={"skillButton-" + this.props.skillName}
+			className="skillButton"
 		>
 			<Clickable
 				onClickFn={
@@ -483,6 +480,16 @@ class SkillButton extends React.Component {
 				style={controller.displayingUpToDateGameState ? {} : { cursor: "not-allowed" }}
 			/>
 		</span>;
+		return <Tooltip.Root delay={0}>
+			<Tooltip.Trigger render={tooltipTrigger} />
+			<Tooltip.Portal container={document.getElementById("skillsWindowAnchor")}>
+				<Tooltip.Positioner sideOffset={3} side="top" className="tooltip-positioner">
+					<Tooltip.Popup className="info-tooltip tooltip">
+						{this.state.skillDescription}
+					</Tooltip.Popup>
+				</Tooltip.Positioner>
+			</Tooltip.Portal>
+		</Tooltip.Root>;
 	}
 }
 
@@ -709,7 +716,7 @@ export class SkillsWindow extends React.Component {
 				</div>,
 			})}
 		/>;
-		return <div className={"skillsWindow"}>
+		return <div className={"skillsWindow"} id={"skillsWindowAnchor"}>
 			<div className={"skillIcons"}>
 				<style>{`
 					.info-tooltip {
@@ -722,14 +729,8 @@ export class SkillsWindow extends React.Component {
 						font-size: 100%;
 						z-index: 10;
 					}
-					.info-tooltip-arrow { display: none; }
 				`}</style>
 				{skillButtons}
-				<ReactTooltip
-					anchorSelect={".skillButton"}
-					className={"info-tooltip"}
-					classNameArrow={"info-tooltip-arrow"}
-				/>
 				<div style={{ margin: "10px 0" }}>
 					{localize({
 						en: "# of targets hit",

--- a/src/Controller/Common.ts
+++ b/src/Controller/Common.ts
@@ -51,6 +51,10 @@ export function containsEwCacheContent(): boolean {
 
 const thisExpansion: Expansion = Expansion.DT; // change here in ew archive
 
+// Assume that if there are no localStorage entries, this is the user's first visit to the site.
+// A timeline record is always created on page load, so this assumption should be valid.
+export const isFirstVisit = localStorage.length === 0;
+
 export function getCachedValue(key: string): string | null {
 	// 2x reads from localStorage but should be fine...?
 	let current = localStorage.getItem(thisExpansion + "." + key);

--- a/src/Style/style.css
+++ b/src/Style/style.css
@@ -78,6 +78,15 @@
     cursor: pointer;
 }
 
+.clickableLinkLike {
+    display: inline-block;
+}
+
+.clickableLinkLike:hover {
+    cursor: pointer;
+    text-decoration: underline;
+}
+
 .paragraph {
     margin: 10px 0;
 }

--- a/src/Style/style.css
+++ b/src/Style/style.css
@@ -1,4 +1,4 @@
-#baseUiAnchor {
+.root {
     /*
     Needed for BaseUI dialogs to always appear on top
     https://base-ui.com/react/overview/quick-start
@@ -104,4 +104,12 @@ https://github.com/ReactTooltip/react-tooltip/blob/master/src/components/Tooltip
 
 .tooltip-positioner {
     z-index: 10;
+}
+
+.dialogExit {
+    position: absolute;
+    top: 0.5em;
+    right: 0.5em;
+    cursor: pointer;
+    font-size: 1.5rem;
 }

--- a/src/Style/style.css
+++ b/src/Style/style.css
@@ -1,4 +1,4 @@
-.root {
+#baseUiAnchor {
     /*
     Needed for BaseUI dialogs to always appear on top
     https://base-ui.com/react/overview/quick-start

--- a/src/Style/style.css
+++ b/src/Style/style.css
@@ -1,3 +1,11 @@
+.root {
+    /*
+    Needed for BaseUI dialogs to always appear on top
+    https://base-ui.com/react/overview/quick-start
+    */
+    isolation: isolate;
+}
+
 @font-face {
     font-family: "Goldman Regular";
     src: url("https://xivintheshell.github.io/resources/fonts/Goldman/Goldman-Regular.ttf");
@@ -72,4 +80,19 @@
 
 .paragraph {
     margin: 10px 0;
+}
+
+/*
+copied when migrating from react-tooltip to baseui
+https://github.com/ReactTooltip/react-tooltip/blob/master/src/components/Tooltip/styles.module.css
+*/
+.tooltip {
+    padding: 8px 16px;
+    border-radius: 3px;
+    font-size: 90%;
+    width: max-content;
+}
+
+.tooltip-positioner {
+    z-index: 10;
 }

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,8 +1,22 @@
 [
 	{
+		"date": "5/14/25",
+		"changes": [
+			"We've made some big updates to the tools we use to build XIV in the Shell. The site should work the same as before, but if you notice anything broken or slow, please let us know posthaste.",
+			"We're planning on adding some large features in the near feature, so we've also made the changelog more prominent in anticipation. Please look forward to it."
+		],
+		"changes_zh": [
+			"我们对制造XIV in the Shell的软件工具做了大更新。网站的操作应该和以前一样、但如果您发现有任何功能有破坏或变慢了，请尽快通知我们。",
+			"因为我们准备在不久的将来内对排轴器增加大功能，所以我们先把更新日志变得更加引人注意。更大的公告也会有像这样的中文翻译。敬请期待。"
+		]
+	},
+	{
 		"date": "5/10/25",
 		"changes": [
 			"[PLD] Added initial support for PLD"
+		],
+		"changes_zh": [
+			"【骑士】 加了初步的骑士支持。"
 		]
 	},
 	{

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,12 +1,12 @@
 [
 	{
-		"date": "5/14/25",
+		"date": "5/17/25",
 		"changes": [
 			"We've made some big updates to the tools we use to build XIV in the Shell. The site should work the same as before, but if you notice anything broken or slow, please let us know posthaste.",
 			"We're planning on adding some large features in the near feature, so we've also made the changelog more prominent in anticipation. Please look forward to it."
 		],
 		"changes_zh": [
-			"我们对制造XIV in the Shell的软件工具做了大更新。网站的操作应该和以前一样、但如果您发现有任何功能有破坏或变慢了，请尽快通知我们。",
+			"我们对制造XIV in the Shell的软件工具做了大更新。网站的操作应该和以前一样、如果您发现有任何功能有破坏或变慢了，请尽快通知我们。",
 			"因为我们准备在不久的将来内对排轴器增加大功能，所以我们先把更新日志变得更加引人注意。更大的公告也会有像这样的中文翻译。敬请期待。"
 		]
 	},


### PR DESCRIPTION
(branched off #140)

This PR moves the changelog tab out of the intro section, and makes it more prominent. The new changelog opens in a dialog box displaying the 5 most recent entries, or all entries since the user's last view of the changelog, with older entries in an expandable. Additionally, this PR adds boilerplate for localized changelog entries.

Example gif (shows basic behavior, page refresh, and localizable entries):
![full_changelog_demo](https://github.com/user-attachments/assets/27748278-2362-4530-99d9-d674db8b4989)

Internal changes:
- Replaced `react-tooltip` by `@base-ui-components`'s tooltip component. This reduces the overall bundle size, and the JS bundle with both `@base-ui-components/react/tooltip` and `@base-ui-components/react/dialog` is about 100 kB smaller before gzip. Some additional boilerplate is necessary, but component arrangement is mostly easier to reason about.
- Added some additional CSS classes.
- Added the `isFirstVisit` variable, determined by whether localstorage is empty on module load. I assume the declaration of the variable always runs before any `setCachedValue` operations, unless there's some weird hoisting shenanigans going on.

Behavior flowchart (can test "first time visitor" flow by opening in private/incognito):
- If user has `changelogLastRead` in localstorage
  - If `changelogLastRead` matches the date in the most recent entry:
    - If `changelogLastReadChangeCount` matches the number of elements in the most recent entry's `changes` field, then the Changelog is not highlighted.
    - Otherwise, the Changelog button is stylized bold + warning color + exclamation points.
  - If `changelogLastRead` does NOT match the date in the most recent entry, the Changelog is not highlighted.
- If user does NOT have `changelogLastRead`:
  - If user has visited site before: treat 5/10/25 as the most-recently read entry.
  - If user is visiting site for the first time: treat all entries as already read.

`changelogLastRead` and `changelogLastReadChangeCount` are updated to match the most recent entry when the dialog is closed. The code implicitly relies on the invariant that the changelog remains sorted in chronological order, and that entries cannot be removed from the changelog, but will not break catastrophically if these invariants are violated.