### PR TITLE
Fixes for crit + DH values

### DIFF
--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -1461,7 +1461,10 @@ class Controller {
 				buffName = "Radiant Finale";
 			}
 			const getBuffModifiers = () => {
-				if (buff.info.name === BuffType.Dokumori) {
+				if (
+					buff.info.name === BuffType.Dokumori ||
+					buff.info.name === BuffType.ChainStratagem
+				) {
 					return "Debuff Only";
 				} else if (buff.info.name === BuffType.RadiantFinale1) {
 					// need to put these in quotes so it stays as one column when parsed

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -1460,11 +1460,10 @@ class Controller {
 			) {
 				buffName = "Radiant Finale";
 			}
+			const isDebuff =
+				buff.info.name === BuffType.Dokumori || buff.info.name === BuffType.ChainStratagem;
 			const getBuffModifiers = () => {
-				if (
-					buff.info.name === BuffType.Dokumori ||
-					buff.info.name === BuffType.ChainStratagem
-				) {
+				if (isDebuff) {
 					return "Debuff Only";
 				} else if (buff.info.name === BuffType.RadiantFinale1) {
 					// need to put these in quotes so it stays as one column when parsed
@@ -1490,7 +1489,13 @@ class Controller {
 				}
 				return "";
 			};
-			return [marker.time, buffName, buff.info.job, getBuffModifiers(), ""];
+			return [
+				marker.time,
+				buffName,
+				buff.info.job,
+				getBuffModifiers(),
+				isDebuff ? "Boss0" : "",
+			];
 		});
 		// sim currently doesn't track mp ticks or mp costs, or any other manner of validation
 		// as such, many skills are unsupported: we set the use_strict_skill_naming metadata

--- a/src/Game/XIVMath.ts
+++ b/src/Game/XIVMath.ts
@@ -65,10 +65,16 @@ export class XIVMath {
 			return modifier;
 		}
 		const critDamageMult = XIVMath.#criticalHitStrength(level, crit);
+		const baseCritRate = XIVMath.#criticalHitRate(level, XIVMath.getSubstatBase(level));
 
 		const autoCDH = critRate >= 1 && dhRate >= 1;
-		const critMod = critRate > 1 ? 1 + (critRate - 1) * critDamageMult : 1;
-		const dhMod = dhRate > 1 ? 1 + (dhRate - 1) * 1.25 : 1;
+		console.error("autocdh? " + autoCDH);
+		console.error("critBonus " + critBonus)
+		console.error("critDamageMult " + critDamageMult)
+		const critMod = critRate > 1 ? 1 + (critDamageMult - 1) * (critBonus - 1) : 1;
+		console.error("critMod " + critMod)
+		const dhMod = dhRate > 1 ? 1 + (1.25 - 1) * dhBonus : 1;
+		console.error("dhMod " + dhMod)
 		const clampedCritRate = critRate > 1 ? 1 : critRate;
 		const clampedDHRate = dhRate > 1 ? 1 : dhRate;
 

--- a/src/__test__/math.test.ts
+++ b/src/__test__/math.test.ts
@@ -1,0 +1,89 @@
+
+import {
+	damageData,
+	rotationTestSetup,
+	rotationTestTeardown,
+	makeTestWithConfigFn,
+	applySkill,
+	compareDamageTables,
+} from "./utils";
+import { XIVMath } from "../Game/XIVMath";
+
+// Tests for the effect of crit buffs.
+// References for damage ratios are taken from simulations run with Ama's combat sim in patch 7.2.
+// https://colab.research.google.com/github/zqsz-xiv/xivintheshell-ama-sim-notebook/blob/main/in_the_shell_with_ama_sim.ipynb
+
+// === HAMMERS ===
+// No crit buffs:
+// - Average DPS: 53646.99
+// - Average damage: 305090.50
+// With Battle Litany: does 1.0601x more
+// - Average DPS: 56871.28
+// - Average damage: 323427.00
+// With Battle Litany + Devilment: 1.2305x
+// - Average DPS: 66012.74
+// - Average damage: 375348.50
+// With Battle Litany + Devilment + Technical Finish: 1.2729
+// - Average DPS: 68297.91
+// - Average damage: 388342.00
+// 
+/// === PAINT FILLER ===
+// No crit buffs:
+// - Average DPS: 37170.35
+// - Average damage: 189791.83
+// With Battle Litany: 1.0522x
+// - Average DPS: 39111.45
+// - Average damage: 199703.11
+// With Battle Litany + Devilment: 1.2103s
+// - Average DPS: 44988.71
+// - Average damage: 229712.42
+// With Battle Litany + Devilment + Technical Finish: 1.2521
+// - Average DPS: 46541.90
+// Average damage: 237642.98
+
+const commonStats = [100, 3214, 1990, 2033]; // level, crit, dh, det
+
+// just Battle Litany
+it("calculates hammer with litany", () => {
+	const baseDamage = XIVMath.calculateDamage(...commonStats, 1, 1, 1);
+	const withCritBuffs = XIVMath.calculateDamage(...commonStats, 1, 1.1, 1);
+	console.error(baseDamage);
+	console.error(withCritBuffs)
+	expect(withCritBuffs / baseDamage).toBeCloseTo(1.06, 2);
+});
+
+it("calculates paint with litany", () => {
+	const baseDamage = XIVMath.calculateDamage(...commonStats, 1, 0, 0);
+	const withCritBuffs = XIVMath.calculateDamage(...commonStats, 1, 0.1, 0);
+	expect(withCritBuffs / baseDamage).toBeCloseTo(1.05, 2);
+});
+
+// Battle Litany + Devilment
+it("calculates hammer with litany + devilment", () => {
+	const baseDamage = XIVMath.calculateDamage(...commonStats, 1, 1, 1);
+	const withCritBuffs = XIVMath.calculateDamage(...commonStats, 1, 1.3, 1.2);
+	console.error(baseDamage);
+	console.error(withCritBuffs)
+	expect(withCritBuffs / baseDamage).toBeCloseTo(1.23, 2);
+});
+
+it("calculates paint with litany + devilment", () => {
+	const baseDamage = XIVMath.calculateDamage(...commonStats, 1, 0, 0);
+	const withCritBuffs = XIVMath.calculateDamage(...commonStats, 1, 0.3, 0.2);
+	expect(withCritBuffs / baseDamage).toBeCloseTo(1.21, 2);
+});
+
+// Battle Litany + Devilment + Technical Finish
+it("calculates hammer with litany + devilment + tech", () => {
+	const baseDamage = XIVMath.calculateDamage(...commonStats, 1.05, 1, 1);
+	const withCritBuffs = XIVMath.calculateDamage(...commonStats, 1.05, 1.3, 1.2);
+	console.error(baseDamage);
+	console.error(withCritBuffs)
+	expect(withCritBuffs / baseDamage).toBeCloseTo(1.27, 2);
+});
+
+it("calculates paint with litany + devilment + tech", () => {
+	const baseDamage = XIVMath.calculateDamage(...commonStats, 1.05, 0, 0);
+	const withCritBuffs = XIVMath.calculateDamage(...commonStats, 1.05, 0.3, 0.2);
+	expect(withCritBuffs / baseDamage).toBeCloseTo(1.25, 2);
+});

--- a/src/__test__/math.test.ts
+++ b/src/__test__/math.test.ts
@@ -1,89 +1,143 @@
-
-import {
-	damageData,
-	rotationTestSetup,
-	rotationTestTeardown,
-	makeTestWithConfigFn,
-	applySkill,
-	compareDamageTables,
-} from "./utils";
 import { XIVMath } from "../Game/XIVMath";
 
 // Tests for the effect of crit buffs.
 // References for damage ratios are taken from simulations run with Ama's combat sim in patch 7.2.
 // https://colab.research.google.com/github/zqsz-xiv/xivintheshell-ama-sim-notebook/blob/main/in_the_shell_with_ama_sim.ipynb
 
+// NOTE 5/23: Some sim values for stacking buffs on top of Devilment (which buffs both crit + DH)
+// seem to be slightly off between Ama's combat sim and our internal math. It's unclear if this is
+// due to rounding issues or some other formula problem.
+// The corresponding tests are marked to fail.
+
 // === HAMMERS ===
-// No crit buffs:
+// No buffs:
 // - Average DPS: 53646.99
 // - Average damage: 305090.50
 // With Battle Litany: does 1.0601x more
 // - Average DPS: 56871.28
 // - Average damage: 323427.00
+// With Devilment: 1.1702x
+// - Average DPS: 62787.89
+// - Average damage: 357012.00
 // With Battle Litany + Devilment: 1.2305x
 // - Average DPS: 66012.74
 // - Average damage: 375348.50
-// With Battle Litany + Devilment + Technical Finish: 1.2729
+// * chain strat is probably bugged in combat sim?
+// With Battle Litany + Chain Stratagem: 1.0601x
+// - Average DPS: 56881.28
+// - Average damage: 323427.00
+// With Battle Litany + Wanderer's Minuet: 1.0721x
+// - Average DPS: 57525.58
+// - Average damage: 327090.50
+// With Battle Litany + Devilment + Technical Finish: 1.2729x
 // - Average DPS: 68297.91
 // - Average damage: 388342.00
-// 
+// With Technical Finish: 1.0500x
+// - Average DPS: 56339.07
+// - Average damage: 320344.00
+// With Army's Paeon + Technical Finish: 1.05786x
+// - Average DPS: 56761.16
+// - Average damage: 322744.00
+//
 /// === PAINT FILLER ===
-// No crit buffs:
+// No buffs:
 // - Average DPS: 37170.35
 // - Average damage: 189791.83
 // With Battle Litany: 1.0522x
 // - Average DPS: 39111.45
 // - Average damage: 199703.11
-// With Battle Litany + Devilment: 1.2103s
+// With Devilment: 1.1557x
+// - Average DPS: 42957.54
+// - Average damage: 219341.22
+// * chain strat is probably bugged in combat sim?
+// With Battle Litany + Chain Stratagem: 1.0522x
+// - Average DPS: 39111.45
+// - Average damage: 199703.11
+// With Battle Litany + Devilment: 1.2103x
 // - Average DPS: 44988.71
 // - Average damage: 229712.42
-// With Battle Litany + Devilment + Technical Finish: 1.2521
+// With Battle Litany + Devilment + Technical Finish: 1.2521x
 // - Average DPS: 46541.90
-// Average damage: 237642.98
+// - Average damage: 237642.98
+// With Technical Finish: 1.0500x
+// - Average DPS: 39028.60
+// - Average damage: 199280.09
+// With Army's Paeon + Technical Finish: 1.0573x
+// - Average DPS: 39300.27
+// - Average damage: 200667.22
 
-const commonStats = [100, 3214, 1990, 2033]; // level, crit, dh, det
+const commonStats: [number, number, number, number] = [100, 3214, 1990, 2033]; // level, crit, dh, det
+
+const hammerBaseDamage = XIVMath.calculateDamage(...commonStats, 1, 1, 1);
+const paintBaseDamage = XIVMath.calculateDamage(...commonStats, 1, 0, 0);
 
 // just Battle Litany
 it("calculates hammer with litany", () => {
-	const baseDamage = XIVMath.calculateDamage(...commonStats, 1, 1, 1);
-	const withCritBuffs = XIVMath.calculateDamage(...commonStats, 1, 1.1, 1);
-	console.error(baseDamage);
-	console.error(withCritBuffs)
-	expect(withCritBuffs / baseDamage).toBeCloseTo(1.06, 2);
+	const withBuffs = XIVMath.calculateDamage(...commonStats, 1, 1.1, 1);
+	expect(withBuffs / hammerBaseDamage).toBeCloseTo(1.06, 2);
 });
 
 it("calculates paint with litany", () => {
-	const baseDamage = XIVMath.calculateDamage(...commonStats, 1, 0, 0);
-	const withCritBuffs = XIVMath.calculateDamage(...commonStats, 1, 0.1, 0);
-	expect(withCritBuffs / baseDamage).toBeCloseTo(1.05, 2);
+	const withBuffs = XIVMath.calculateDamage(...commonStats, 1, 0.1, 0);
+	expect(withBuffs / paintBaseDamage).toBeCloseTo(1.05, 2);
+});
+
+// just Devilment
+it.fails("calculates hammer with devilment", () => {
+	const withBuffs = XIVMath.calculateDamage(...commonStats, 1, 1.2, 1.2);
+	expect(withBuffs / hammerBaseDamage).toBeCloseTo(1.17, 2);
+});
+
+it("calculates paint with devilment", () => {
+	const withBuffs = XIVMath.calculateDamage(...commonStats, 1, 0.2, 0.2);
+	expect(withBuffs / paintBaseDamage).toBeCloseTo(1.156, 2);
+});
+
+it("calculates hammer with litany + wm", () => {
+	const withBuffs = XIVMath.calculateDamage(...commonStats, 1, 1.12, 1);
+	expect(withBuffs / hammerBaseDamage).toBeCloseTo(1.072, 2);
 });
 
 // Battle Litany + Devilment
-it("calculates hammer with litany + devilment", () => {
-	const baseDamage = XIVMath.calculateDamage(...commonStats, 1, 1, 1);
-	const withCritBuffs = XIVMath.calculateDamage(...commonStats, 1, 1.3, 1.2);
-	console.error(baseDamage);
-	console.error(withCritBuffs)
-	expect(withCritBuffs / baseDamage).toBeCloseTo(1.23, 2);
+it.fails("calculates hammer with litany + devilment", () => {
+	const withBuffs = XIVMath.calculateDamage(...commonStats, 1, 1.3, 1.2);
+	expect(withBuffs / hammerBaseDamage).toBeCloseTo(1.23, 2);
 });
 
 it("calculates paint with litany + devilment", () => {
-	const baseDamage = XIVMath.calculateDamage(...commonStats, 1, 0, 0);
-	const withCritBuffs = XIVMath.calculateDamage(...commonStats, 1, 0.3, 0.2);
-	expect(withCritBuffs / baseDamage).toBeCloseTo(1.21, 2);
+	const withBuffs = XIVMath.calculateDamage(...commonStats, 1, 0.3, 0.2);
+	expect(withBuffs / paintBaseDamage).toBeCloseTo(1.21, 2);
 });
 
 // Battle Litany + Devilment + Technical Finish
-it("calculates hammer with litany + devilment + tech", () => {
-	const baseDamage = XIVMath.calculateDamage(...commonStats, 1.05, 1, 1);
-	const withCritBuffs = XIVMath.calculateDamage(...commonStats, 1.05, 1.3, 1.2);
-	console.error(baseDamage);
-	console.error(withCritBuffs)
-	expect(withCritBuffs / baseDamage).toBeCloseTo(1.27, 2);
+it.fails("calculates hammer with litany + devilment + tech", () => {
+	const withBuffs = XIVMath.calculateDamage(...commonStats, 1.05, 1.3, 1.2);
+	expect(withBuffs / hammerBaseDamage).toBeCloseTo(1.27, 2);
 });
 
-it("calculates paint with litany + devilment + tech", () => {
-	const baseDamage = XIVMath.calculateDamage(...commonStats, 1.05, 0, 0);
-	const withCritBuffs = XIVMath.calculateDamage(...commonStats, 1.05, 0.3, 0.2);
-	expect(withCritBuffs / baseDamage).toBeCloseTo(1.25, 2);
+it.fails("calculates paint with litany + devilment + tech", () => {
+	const withBuffs = XIVMath.calculateDamage(...commonStats, 1.05, 0.3, 0.2);
+	expect(withBuffs / paintBaseDamage).toBeCloseTo(1.25, 2);
+});
+
+// just Technical Finish
+it("calculates hammer with tech", () => {
+	const withBuffs = XIVMath.calculateDamage(...commonStats, 1.05, 1, 1);
+	expect(withBuffs / hammerBaseDamage).toBeCloseTo(1.05, 2);
+});
+
+it("calculates paint with tech", () => {
+	const withBuffs = XIVMath.calculateDamage(...commonStats, 1.05, 0, 0);
+	expect(withBuffs / paintBaseDamage).toBeCloseTo(1.05, 2);
+});
+
+// Army's Paeon + Technical Finish
+it("calculates hammer with AP + tech", () => {
+	const withBuffs = XIVMath.calculateDamage(...commonStats, 1.05, 1, 1.03);
+	expect(withBuffs / hammerBaseDamage).toBeCloseTo(1.058, 2);
+});
+
+it("calculates paint with AP + tech", () => {
+	const withBuffs = XIVMath.calculateDamage(...commonStats, 1.05, 0, 0.03);
+	expect(withBuffs / paintBaseDamage).toBeCloseTo(1.057, 2);
 });

--- a/src/__test__/math.test.ts
+++ b/src/__test__/math.test.ts
@@ -4,10 +4,10 @@ import { XIVMath } from "../Game/XIVMath";
 // References for damage ratios are taken from simulations run with Ama's combat sim in patch 7.2.
 // https://colab.research.google.com/github/zqsz-xiv/xivintheshell-ama-sim-notebook/blob/main/in_the_shell_with_ama_sim.ipynb
 
-// NOTE 5/23: Some sim values for stacking buffs on top of Devilment (which buffs both crit + DH)
-// seem to be slightly off between Ama's combat sim and our internal math. It's unclear if this is
-// due to rounding issues or some other formula problem.
-// The corresponding tests are marked to fail.
+// NOTE 5/23: Some sim values for stacking crit buffs on top of each other seem to be slightly off
+// between Ama's combat sim and our internal math. It's unclear if this is due to rounding issues,
+// configuration problems, formula errors, or the effect of additive constants like weapon damage
+// and base stats. The corresponding tests are marked to fail.
 
 // === HAMMERS ===
 // No buffs:
@@ -22,13 +22,12 @@ import { XIVMath } from "../Game/XIVMath";
 // With Battle Litany + Devilment: 1.2305x
 // - Average DPS: 66012.74
 // - Average damage: 375348.50
-// * chain strat is probably bugged in combat sim?
-// With Battle Litany + Chain Stratagem: 1.0601x
-// - Average DPS: 56881.28
-// - Average damage: 323427.00
 // With Battle Litany + Wanderer's Minuet: 1.0721x
 // - Average DPS: 57525.58
 // - Average damage: 327090.50
+// With Battle Litany + Chain Stratagem: 1.1017x
+// - Average DPS: 59113.69
+// - Average damage: 336120.50
 // With Battle Litany + Devilment + Technical Finish: 1.2729x
 // - Average DPS: 68297.91
 // - Average damage: 388342.00
@@ -49,10 +48,9 @@ import { XIVMath } from "../Game/XIVMath";
 // With Devilment: 1.1557x
 // - Average DPS: 42957.54
 // - Average damage: 219341.22
-// * chain strat is probably bugged in combat sim?
-// With Battle Litany + Chain Stratagem: 1.0522x
-// - Average DPS: 39111.45
-// - Average damage: 199703.11
+// With Battle Litany + Chain Stratagem: 1.0883x
+// - Average DPS: 40451.86
+// - Average damage: 206547.22
 // With Battle Litany + Devilment: 1.2103x
 // - Average DPS: 44988.71
 // - Average damage: 229712.42
@@ -93,9 +91,21 @@ it("calculates paint with devilment", () => {
 	expect(withBuffs / paintBaseDamage).toBeCloseTo(1.156, 2);
 });
 
+// Battle Litany + Wanderer's Minuet
 it("calculates hammer with litany + wm", () => {
 	const withBuffs = XIVMath.calculateDamage(...commonStats, 1, 1.12, 1);
 	expect(withBuffs / hammerBaseDamage).toBeCloseTo(1.072, 2);
+});
+
+// Battle Litany + Chain Stratagem
+it.fails("calculates hammer with litany + chain", () => {
+	const withBuffs = XIVMath.calculateDamage(...commonStats, 1, 1.2, 1);
+	expect(withBuffs / hammerBaseDamage).toBeCloseTo(1.102, 2);
+});
+
+it.fails("calculates paint with litany + chain", () => {
+	const withBuffs = XIVMath.calculateDamage(...commonStats, 1, 0.2, 0);
+	expect(withBuffs / paintBaseDamage).toBeCloseTo(1.088, 2);
 });
 
 // Battle Litany + Devilment


### PR DESCRIPTION
Yuyuka sent me a bug report via Discord DM that crit buff values were severely over-reporting their effects on auto-crit abilities, like hammers.

For a timeline of 3 hammers under a 10% crit buff (Battle Litany or Chain Stratagem), current main reports their effect as a ~16% buff:
![image](https://github.com/user-attachments/assets/79d3aaf7-8760-4814-b250-4a4dac9f7bde)

The same timeline + stats after this PR reports a more accurate 6%:
![image](https://github.com/user-attachments/assets/d865261e-41f9-4573-88ef-583b083f8411)

After scrounging around [xivgear's codebase](https://github.com/xiv-gear-planner/gear-planner/blob/master/packages/xivmath/src/xivmath.ts), I found some easily digestable formulas and found areas where our multipliers for auto-crit/DH buffs were incorrect. I tested these ratios with some short simulations using [our integration with Ama's combat sim](https://colab.research.google.com/github/zqsz-xiv/xivintheshell-ama-sim-notebook/blob/main/in_the_shell_with_ama_sim.ipynb), and encoded the results in a test.

Some results for stacking crit buffs are incorrect, I would guess due to some additive components in the damage formula that we don't account for. Our reported multipliers for these are within ~3% of simulated values, so the difference is not too large.

(FYI @TMTurtle in case you were using these formulas elsewhere)