### PR TITLE
Fix timeline editor scroll

### DIFF
--- a/src/Components/Common.tsx
+++ b/src/Components/Common.tsx
@@ -704,8 +704,7 @@ type LoadJsonFromFileOrUrlProps = {
 };
 
 export function LoadJsonFromFileOrUrl(props: LoadJsonFromFileOrUrlProps) {
-	// @ts-expect-error for some reason, newer versions allow the type to be RefObject<elem | null>
-	const fileSelectorRef: React.RefObject<HTMLInputElement> = React.createRef();
+	const fileSelectorRef: React.RefObject<HTMLInputElement | null> = useRef(null);
 	let loadUrl = props.defaultLoadUrl ?? "";
 
 	const onLoadUrlChange = (evt: ChangeEvent<{ value: string }>) => {

--- a/src/Components/Timeline.tsx
+++ b/src/Components/Timeline.tsx
@@ -24,7 +24,7 @@ export let scrollTimelineTo = (positionX: number) => {};
 
 // the actual timeline canvas
 class TimelineMain extends React.Component {
-	myRef: React.RefObject<HTMLDivElement>;
+	myRef: React.RefObject<HTMLDivElement | null>;
 	updateVisibleRange: () => void;
 	state: {
 		timelineWidth: number;
@@ -45,7 +45,6 @@ class TimelineMain extends React.Component {
 			visibleWidth: 66,
 			version: 0,
 		};
-		// @ts-expect-error for some reason, newer versions allow the type to be RefObject<elem | null>
 		this.myRef = React.createRef();
 
 		this.updateVisibleRange = () => {

--- a/src/Components/TimelineEditor.tsx
+++ b/src/Components/TimelineEditor.tsx
@@ -75,7 +75,7 @@ function TimelineActionElement(props: {
 	isInvalid: boolean;
 	includeDetails: boolean;
 	usedAt: number;
-	refObj?: React.RefObject<HTMLTableRowElement>;
+	refObj?: React.RefObject<HTMLTableRowElement | null>;
 }) {
 	const colors = getCurrentThemeColors();
 	// Every other row should be highlighted slightly to provide contrast.
@@ -171,8 +171,7 @@ export let scrollEditorToFirstSelected = () => {};
 
 export function TimelineEditor() {
 	const colors = getCurrentThemeColors();
-	// @ts-expect-error for some reason, newer versions allow the type to be RefObject<elem | null>
-	const firstSelected: React.RefObject<HTMLTableRowElement> = React.createRef();
+	const firstSelected: React.RefObject<HTMLTableRowElement | null> = useRef(null);
 
 	const [isDirty, setDirty] = useState<boolean>(false);
 	const [recordValidStatus, setRecordValidStatus] = useState<RecordValidStatus | undefined>(

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,13 @@
 [
 	{
+		"date": "6/25/25",
+		"changes": [
+			"Fixed a bug where timestamps would not appear for wait events in the timeline editor.",
+			"Fixed a bug where selecting a skill in the visual canvas did not cause the editor table to scroll to its location."
+		],
+		"level": "minor"
+	},
+	{
 		"date": "6/24/25",
 		"changes": [
 			"[NIN] Added initial support for NIN."


### PR DESCRIPTION
resolves #182

lesson learned: don't ignore type warnings

this does not fully fix the issue, as due to styling hacks for the editor table row, scrolling to an older skill will have the skill be hidden under the header