### PR TITLE
Use inherent speed modifiers in GCD display for MNK, NIN, SAM

### DIFF
--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -412,6 +412,11 @@ export class GameState {
 		}
 	}
 
+	// Inherent haste modifiers that are always active on the job. This is only used in GCD previews.
+	inherentSpeedModifier(): number | undefined {
+		return undefined;
+	}
+
 	// Job code may override to handle setting up any job-specific recurring events, such as BLM's Polyglot timer
 	jobSpecificRegisterRecurringEvents() {}
 

--- a/src/Game/Jobs/MNK.ts
+++ b/src/Game/Jobs/MNK.ts
@@ -207,6 +207,10 @@ export class MNKState extends GameState {
 		}
 	}
 
+	override inherentSpeedModifier(): number {
+		return this.hasTraitUnlocked("ENHANCED_GREASED_LIGHTNING_III") ? 20 : 15;
+	}
+
 	override get statusPropsGenerator(): StatusPropsGenerator<MNKState> {
 		return new MNKStatusPropsGenerator(this);
 	}
@@ -273,10 +277,7 @@ const makeMNKWeaponskill = (
 		validateAttempt: (state) =>
 			(formCondition?.(state) ?? true) && (params.validateAttempt?.(state) ?? true),
 		recastTime: (state) =>
-			state.config.adjustedSksGCD(
-				params.recastTime ?? 2.5,
-				state.hasTraitUnlocked("ENHANCED_GREASED_LIGHTNING_III") ? 20 : 15,
-			),
+			state.config.adjustedSksGCD(params.recastTime ?? 2.5, state.inherentSpeedModifier()),
 		onConfirm: combineEffects(
 			params.onConfirm ?? NO_EFFECT,
 			name !== "SIX_SIDED_STAR" && params.potency

--- a/src/Game/Jobs/NIN.ts
+++ b/src/Game/Jobs/NIN.ts
@@ -118,6 +118,10 @@ export class NINState extends GameState {
 		}
 	}
 
+	override inherentSpeedModifier(): number {
+		return 15;
+	}
+
 	override get statusPropsGenerator(): StatusPropsGenerator<NINState> {
 		return new NINStatusPropsGenerator(this);
 	}
@@ -301,7 +305,7 @@ const makeNINWeaponskill = (
 	return makeWeaponskill("NIN", name, unlockLevel, {
 		...params,
 		// NIN gets a 15% haste reduction
-		recastTime: (state) => state.config.adjustedSksGCD(2.5, 15),
+		recastTime: (state) => state.config.adjustedSksGCD(2.5, state.inherentSpeedModifier()),
 		validateAttempt: validateWithTCJ(params.validateAttempt),
 		onConfirm: combineEffects(
 			bunny,

--- a/src/Game/Jobs/SAM.ts
+++ b/src/Game/Jobs/SAM.ts
@@ -105,6 +105,10 @@ export class SAMState extends GameState {
 		return new SAMStatusPropsGenerator(this);
 	}
 
+	override inherentSpeedModifier(): number {
+		return this.hasTraitUnlocked("ENHANCED_FUGETSU_AND_FUKA") ? 13 : 10;
+	}
+
 	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<PlayerState>): void {
 		if (this.hasResourceAvailable("ENHANCED_ENPI") && skill.name === "ENPI") {
 			node.addBuff(BuffType.EnhancedEnpi);
@@ -140,7 +144,7 @@ export class SAMState extends GameState {
 			return 0;
 		}
 
-		return this.hasTraitUnlocked("ENHANCED_FUGETSU_AND_FUKA") ? 13 : 10;
+		return this.inherentSpeedModifier();
 	}
 
 	// Return true if the active combo buff is up, or meikyo is active.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1d4306b5-9224-4dff-8938-2c780373193a)

Fixes #98. User experience is still not perfect: the haste modification calculation is based on a method call to the active game state, so a dirty job change or level increase/decrease may use the incorrect value. This isn't too difficult to fix in principle, but requires some minor refactoring effort.