### PR TITLE
GameState cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# secret test corpus
+src/__test__/secret*
+
 # temporary files
 scripts/*_xivapi_cache.csv
 # dependencies

--- a/scripts/generate_job_data.py
+++ b/scripts/generate_job_data.py
@@ -622,7 +622,6 @@ import {{
     MakeAbilityParams,
     MakeGCDParams,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	PotencyModifierFn,
 	Skill,
 	SkillAutoReplace,

--- a/scripts/generate_job_data.py
+++ b/scripts/generate_job_data.py
@@ -601,7 +601,7 @@ import {{ {JOB}StatusPropsGenerator }} from "../../Components/Jobs/{JOB}";
 import {{ StatusPropsGenerator }} from "../../Components/StatusDisplay";
 import {{ ActionNode }} from "../../Controller/Record";
 import {{ controller }} from "../../Controller/Controller";
-import {{ BuffType, WarningType }} from "../Common";
+import {{ BuffType }} from "../Common";
 import {{ ActionKey, TraitKey }} from "../Data";
 import {{ {JOB}ActionKey, {JOB}CooldownKey, {JOB}ResourceKey }} from "../Data/Jobs/{JOB}";
 import {{ GameConfig }} from "../GameConfig";
@@ -633,7 +633,7 @@ import {{
 const make{JOB}Resource = (
 	rsc: {JOB}ResourceKey,
 	maxValue: number,
-	params?: {{ timeout?: number; default?: number }},
+	params?: {{ timeout?: number; default?: number, warnOnOvercap?: boolean, warnOnTimeout?: boolean }},
 ) => {{
 	makeResource("{JOB}", rsc, maxValue, params ?? {'{}'});
 }};

--- a/src/Components/Jobs/PCT.tsx
+++ b/src/Components/Jobs/PCT.tsx
@@ -26,7 +26,7 @@ export class PCTStatusPropsGenerator extends StatusPropsGenerator<PCTState> {
 					return this.makeCommonTimerless(key);
 				}
 				if (key === "INSPIRATION") {
-					return this.makeToggleableTimer(key);
+					return this.makeToggleableTimerless(key);
 				}
 				return this.makeCommonTimer(key);
 			}),

--- a/src/Components/StatusDisplay.tsx
+++ b/src/Components/StatusDisplay.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties } from "react";
 import { Clickable, ContentNode, Help, ProgressBar, StaticFn } from "./Common";
-import type { PlayerState } from "../Game/GameState";
+import type { GameState } from "../Game/GameState";
 import { controller } from "../Controller/Controller";
 import { localize, localizeResourceType } from "./Localization";
 import {
@@ -890,7 +890,7 @@ export class StatusDisplay extends React.Component {
 	}
 }
 
-export class StatusPropsGenerator<T extends PlayerState> {
+export class StatusPropsGenerator<T extends GameState> {
 	state: T;
 
 	constructor(state: T) {

--- a/src/Components/StatusDisplay.tsx
+++ b/src/Components/StatusDisplay.tsx
@@ -935,6 +935,18 @@ export class StatusPropsGenerator<T extends GameState> {
 		};
 	}
 
+	makeToggleableTimerless(rscType: ResourceKey, onSelf: boolean = true): BuffProps {
+		const resource = this.state.resources.get(rscType);
+
+		return {
+			rscType,
+			onSelf,
+			enabled: resource.enabled,
+			stacks: resource.availableAmount(),
+			className: resource.availableAmountIncludingDisabled() > 0 ? "" : "hidden",
+		};
+	}
+
 	// Jobs should override this to display their enemy-targeted buffs
 	public jobSpecificOtherTargetedBuffViewProps(): BuffProps[] {
 		return [];

--- a/src/Components/TimelineCanvas.tsx
+++ b/src/Components/TimelineCanvas.tsx
@@ -24,12 +24,13 @@ import {
 	TimelineDimensions,
 	TimelineDrawOptions,
 } from "./Common";
-import { BuffType, WarningType } from "../Game/Common";
+import { BuffType } from "../Game/Common";
 import { getSkillIconImage } from "./Skills";
 import { buffIconImages } from "./Buffs";
 import { controller } from "../Controller/Controller";
 import {
 	localize,
+	localizeResourceType,
 	localizeBuffType,
 	localizeSkillName,
 	localizeSkillUnavailableReason,
@@ -418,24 +419,44 @@ function drawWarningMarks(
 		g_ctx.fillText("!", x, bottomY - 1);
 
 		let message: string = "[" + mark.displayTime.toFixed(3) + "] ";
-		if (mark.warningType === WarningType.PolyglotOvercap) {
-			message += localize({ en: "polyglot overcap!", zh: "通晓溢出！" });
-		} else if (mark.warningType === WarningType.CometOverwrite) {
-			message += localize({ en: "comet overwrite!", zh: "彗星之黑被覆盖！" });
-		} else if (mark.warningType === WarningType.PaletteOvercap) {
-			message += localize({ en: "palette gauge overcap!", zh: "调色量值溢出！" });
-		} else if (mark.warningType === WarningType.ImbalancedMana) {
-			message += localize({ en: mark.warningType + "!", zh: "魔元失衡！" });
-		} else if (mark.warningType === WarningType.KenkiOvercap) {
-			message += localize({ en: "kenki overcap!" });
-		} else if (mark.warningType === WarningType.MeditationOvercap) {
-			message += localize({ en: "meditation stack overcap!" });
-		} else if (mark.warningType === WarningType.SenOvercap) {
-			message += localize({ en: "sen overcap!" });
-		} else {
-			message += localize({ en: mark.warningType + "!" });
+		switch (mark.warningType.kind) {
+			case "combobreak":
+				message += localize({
+					en: "broken combo!",
+					zh: "连击被断！",
+				}).toString();
+				break;
+			case "overcap":
+				message +=
+					localizeResourceType(mark.warningType.rsc).toString() +
+					localize({
+						en: "overcap!",
+						zh: "溢出！",
+					}).toString();
+				break;
+			case "overwrite":
+				message +=
+					localizeResourceType(mark.warningType.rsc).toString() +
+					localize({
+						en: "overwrite!",
+						zh: "被覆盖！",
+					}).toString();
+				break;
+			case "timeout":
+				message +=
+					localizeResourceType(mark.warningType.rsc).toString() +
+					localize({
+						en: "expired!",
+						zh: "已过期！",
+					});
+				break;
+			default:
+				message += localize({
+					en: mark.warningType.en,
+					zh: mark.warningType.zh,
+				});
+				break;
 		}
-
 		testInteraction(
 			{ x: x - sideLength / 2, y: bottomY - sideLength, w: sideLength, h: sideLength },
 			[message],

--- a/src/Components/TimelineCanvas.tsx
+++ b/src/Components/TimelineCanvas.tsx
@@ -430,7 +430,7 @@ function drawWarningMarks(
 				message +=
 					localizeResourceType(mark.warningType.rsc).toString() +
 					localize({
-						en: "overcap!",
+						en: " overcap!",
 						zh: "溢出！",
 					}).toString();
 				break;
@@ -438,7 +438,7 @@ function drawWarningMarks(
 				message +=
 					localizeResourceType(mark.warningType.rsc).toString() +
 					localize({
-						en: "overwrite!",
+						en: " overwrite!",
 						zh: "被覆盖！",
 					}).toString();
 				break;
@@ -446,7 +446,7 @@ function drawWarningMarks(
 				message +=
 					localizeResourceType(mark.warningType.rsc).toString() +
 					localize({
-						en: "expired!",
+						en: " expired!",
 						zh: "已过期！",
 					});
 				break;

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -23,7 +23,7 @@ import {
 	ProcMode,
 	SkillReadyStatus,
 	SkillUnavailableReason,
-	WarningType,
+	Warning,
 } from "../Game/Common";
 import { DEFAULT_CONFIG, GameConfig } from "../Game/GameConfig";
 import { updateStatusDisplay } from "../Components/StatusDisplay";
@@ -653,7 +653,7 @@ class Controller {
 		};
 	}
 
-	reportWarning(type: WarningType) {
+	reportWarning(type: Warning) {
 		if (!this.#bInSandbox) {
 			this.timeline.addElement({
 				type: ElemType.WarningMark,
@@ -662,6 +662,10 @@ class Controller {
 				displayTime: this.game.getDisplayTime(),
 			});
 		}
+	}
+
+	reportComboBreak() {
+		this.reportWarning({ kind: "combobreak" });
 	}
 
 	resolvePotency(p: Potency) {

--- a/src/Controller/Timeline.ts
+++ b/src/Controller/Timeline.ts
@@ -1,6 +1,6 @@
 import { updateTimelineView } from "../Components/Timeline";
 import { controller } from "./Controller";
-import { BuffType, Debug, SkillUnavailableReason, WarningType } from "../Game/Common";
+import { BuffType, Debug, SkillUnavailableReason, Warning } from "../Game/Common";
 import { ActionNode } from "./Record";
 import { FileType, getCachedValue, removeCachedValue, setCachedValue } from "./Common";
 import { updateMarkers_TimelineMarkerPresets } from "../Components/TimelineMarkers";
@@ -86,7 +86,7 @@ export type AutoTickMarkElem = TimelineElemBase & {
 };
 export type WarningMarkElem = TimelineElemBase & {
 	type: ElemType.WarningMark;
-	warningType: WarningType;
+	warningType: Warning;
 	displayTime: number;
 };
 export type SkillElem = TimelineElemBase & {

--- a/src/Game/Common.ts
+++ b/src/Game/Common.ts
@@ -1,3 +1,5 @@
+import type { ResourceKey } from "./Data";
+
 export const Debug = {
 	epsilon: 1e-6,
 	disableManaTicks: false,
@@ -147,55 +149,24 @@ export enum BuffType {
 	Temperance = "Temperance",
 }
 
-export const enum WarningType {
-	PolyglotOvercap = "polyglot overcap",
-
-	CometOverwrite = "comet overwrite",
-	PaletteOvercap = "palette gauge overcap",
-
-	DualcastEaten = "dualcast dropped",
-	ImbalancedMana = "mana difference became more than 30",
-	ComboBreak = "broken combo",
-	// TODO make buff overwrite warning generic
-	GIOverwrite = "Grand Impact Ready overwrite",
-	GIDrop = "Grand Impact expired",
-	ViceOfThornsDrop = "Vice of Thorns expired",
-	PrefulgenceDrop = "Prefulgence expired",
-	ManaficDrop = "Manafication stacks expired",
-	MagickedSwordplayDrop = "Magicked Swordplay stacks expired",
-
-	EspritOvercap = "esprit gauge overcap",
-	FeatherOvercap = "feather gauge overcap",
-	FanThreeOverwrite = "overwrote fan dance 3",
-
-	HeatOvercap = "heat gauge overcap",
-	BatteryOvercap = "battery gauge overcap",
-
-	KenkiOvercap = "kenki overcap",
-	MeditationOvercap = "meditation stack overcap",
-	SenOvercap = "sen overcap",
-
-	BeastGaugeOvercap = "Beast Gauge overcap",
-	InnerReleaseDrop = "Inner Release expired",
-	NascentChaosDrop = "Nascent Chaos expired",
-
-	SoulVoiceOvercap = "soul voice overcap",
-	CodaOvercap = "coda overcap",
-
-	CartridgeOvercap = "cartridge overcap",
-
-	ScaleOvercap = "firstminds' focus overcap",
-
-	LateEnkindle = "enkindle used near end of demi window may ghost",
-	RubysGlimmerDrop = "Ruby's Glimmer expired",
-	AetherflowOvercap = "aetherflow overcap",
-
-	BloodGaugeOvercap = "blood gauge overcap",
-	DarkArtsOvercap = "dark arts overcap",
-
-	NinkiOvercap = "ninki gauge overcap",
-	KazematoiOvercap = "kazematoi gauge overcap",
-	RaijuOverwrite = "raiju ready overwritten",
-
-	CardOverwrite = "damage card overwritten",
-}
+export type Warning =
+	| {
+			kind: "combobreak";
+	  }
+	| {
+			kind: "overcap";
+			rsc: ResourceKey;
+	  }
+	| {
+			kind: "overwrite";
+			rsc: ResourceKey;
+	  }
+	| {
+			kind: "timeout";
+			rsc: ResourceKey;
+	  }
+	| {
+			kind: "custom";
+			en: string;
+			zh?: string;
+	  };

--- a/src/Game/Data/Jobs/AST.ts
+++ b/src/Game/Data/Jobs/AST.ts
@@ -383,6 +383,7 @@ export const AST_COOLDOWNS = ensureRecord<CooldownData>()({
 	cd_HOROSCOPE_RECAST: { name: "cd_HoroscopeRecast" },
 	cd_NEUTRAL_SECT: { name: "cd_NeutralSect" },
 	cd_EXALTATION: { name: "cd_Exaltation" },
+	cd_MACROCOSMOS: { name: "cd_Macrocosmos" },
 	cd_MICROCOSMOS: { name: "cd_Microcosmos" },
 	cd_ORACLE: { name: "cd_Oracle" },
 	cd_SUN_SIGN: { name: "cd_SunSign" },

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -35,7 +35,6 @@ import { ActionNode } from "../Controller/Record";
 import { Modifiers, Potency, PotencyKind, PotencyModifier, PotencyModifierType } from "./Potency";
 import { Buff } from "./Buffs";
 
-import type { BLMState } from "./Jobs/BLM";
 import { SkillButtonViewInfo } from "../Components/Skills";
 import { ReactNode } from "react";
 import { localizeResourceType } from "../Components/Localization";

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -240,7 +240,7 @@ export class GameState {
 			const lucid = this.resources.get("LUCID_DREAMING") as OverTimeBuff;
 			if (lucid.available(1)) {
 				lucid.tickCount++;
-				if (!(this.isBLMState() && this.getFireStacks() > 0)) {
+				if (!(this.job === "BLM" && this.hasResourceAvailable("ASTRAL_FIRE"))) {
 					// Block lucid ticks for BLM in fire
 					const mana = this.resources.get("MANA");
 					mana.gain(550);
@@ -1893,10 +1893,5 @@ export class GameState {
 
 	isInCombat() {
 		return this.hasResourceAvailable("IN_COMBAT");
-	}
-
-	// These methods enforce type specialization so we can avoid some casts on the frontend
-	isBLMState(): this is BLMState {
-		return this.job === "BLM";
 	}
 }

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -480,6 +480,9 @@ export class GameState {
 		const resource = this.resources.get(rscType);
 		const resourceInfo = getResourceInfo(this.job, rscType) as ResourceInfo;
 		if (this.hasResourceAvailable(rscType)) {
+			if (resourceInfo.warnOnOvercap && stacks >= resource.availableAmount()) {
+				controller.reportWarning({ kind: "overcap", rsc: rscType });
+			}
 			if (resourceInfo.maxTimeout > 0) {
 				resource.overrideTimer(this, resourceInfo.maxTimeout);
 			}

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -140,7 +140,12 @@ export class GameState {
 				);
 			} else {
 				this.resources.set(
-					new Resource(rsc as ResourceKey, info.maxValue, info.defaultValue),
+					new Resource(
+						rsc as ResourceKey,
+						info.maxValue,
+						info.defaultValue,
+						info.warnOnOvercap,
+					),
 				);
 			}
 		});
@@ -1481,8 +1486,8 @@ export class GameState {
 				rsc.consume(toConsume ?? rsc.availableAmountIncludingDisabled());
 				// Make sure the timer is canceled to avoid this warning
 				const rscInfo = getResourceInfo(this.job, rsc.type) as ResourceInfo;
-				if (rscInfo.warningOnTimeout) {
-					controller.reportWarning(rscInfo.warningOnTimeout);
+				if (rscInfo.warnOnTimeout) {
+					controller.reportWarning({ kind: "timeout", rsc: rsc.type });
 				}
 			},
 		});

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -175,7 +175,7 @@ export class GameState {
 		this.autoAttackDelay = 2.5; // defaults to 2.5
 	}
 
-	get statusPropsGenerator(): StatusPropsGenerator<PlayerState> {
+	get statusPropsGenerator(): StatusPropsGenerator<GameState> {
 		return new StatusPropsGenerator(this);
 	}
 
@@ -425,9 +425,9 @@ export class GameState {
 	jobSpecificOnResolveHotTick(_hotResource: ResourceKey) {}
 
 	// Job code may override to handle adding buff covers for the timeline
-	jobSpecificAddDamageBuffCovers(_node: ActionNode, _skill: Skill<PlayerState>) {}
-	jobSpecificAddSpeedBuffCovers(_node: ActionNode, _skill: Skill<PlayerState>) {}
-	jobSpecificAddHealingBuffCovers(_node: ActionNode, _skill: Skill<PlayerState>) {}
+	jobSpecificAddDamageBuffCovers(_node: ActionNode, _skill: Skill<GameState>) {}
+	jobSpecificAddSpeedBuffCovers(_node: ActionNode, _skill: Skill<GameState>) {}
+	jobSpecificAddHealingBuffCovers(_node: ActionNode, _skill: Skill<GameState>) {}
 
 	maybeCancelChanneledSkills(nextSkillName: ActionKey) {
 		const nextSkill = this.skillsList.get(nextSkillName);
@@ -791,7 +791,7 @@ export class GameState {
 	 *
 	 */
 	refreshAutoBasedOnSkill(
-		skill: Spell<PlayerState> | Weaponskill<PlayerState>,
+		skill: Spell<GameState> | Weaponskill<GameState>,
 		capturedCastTime: number,
 		doesDamage: boolean,
 	) {
@@ -891,7 +891,7 @@ export class GameState {
 	 * it performs the confirmation immediately.
 	 */
 	useSpellOrWeaponskill(
-		skill: Spell<PlayerState> | Weaponskill<PlayerState>,
+		skill: Spell<GameState> | Weaponskill<GameState>,
 		node: ActionNode,
 		actionIndex: number,
 	) {
@@ -1103,7 +1103,7 @@ export class GameState {
 	 * Because abilities have no cast time, this function snapshots potencies and enqueues the
 	 * application event immediately.
 	 */
-	useAbility(skill: Ability<PlayerState>, node: ActionNode) {
+	useAbility(skill: Ability<GameState>, node: ActionNode) {
 		console.assert(node);
 		const cd = this.cooldowns.get(skill.cdName);
 		// potency
@@ -1253,7 +1253,7 @@ export class GameState {
 	 * If the spell is a hardcast, this enqueues the cast confirm event. If it is instant, then
 	 * it performs the confirmation immediately.
 	 */
-	useLimitBreak(skill: LimitBreak<PlayerState>, node: ActionNode, actionIndex: number) {
+	useLimitBreak(skill: LimitBreak<GameState>, node: ActionNode, actionIndex: number) {
 		const cd = this.cooldowns.get(skill.cdName);
 
 		const capturedCastTime = skill.castTimeFn(this);
@@ -1893,8 +1893,3 @@ export class GameState {
 		return this.job === "BLM";
 	}
 }
-
-// TODO if we ever support multiple jobs running in parallel, then we will need to move a lot of
-// elements out onto per-player state.
-// This type alias is placed here for now to make this possible future refactor easier.
-export type PlayerState = GameState;

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -1023,7 +1023,7 @@ export class GameState {
 			}
 
 			// Perform additional side effects
-			skill.onConfirm(this, node);
+			skill.onConfirm?.(this, node);
 
 			// Enqueue effect application
 			this.addEvent(
@@ -1037,7 +1037,7 @@ export class GameState {
 					if (healingPotency) {
 						controller.resolveHealingPotency(healingPotency);
 					}
-					skill.onApplication(this, node);
+					skill.onApplication?.(this, node);
 				}),
 			);
 
@@ -1202,7 +1202,7 @@ export class GameState {
 			this.resources.get("MANA").consume(manaCost);
 		}
 
-		skill.onConfirm(this, node);
+		skill.onConfirm?.(this, node);
 
 		if (potency && !this.hasResourceAvailable("IN_COMBAT")) {
 			const combatStart = this.resources.timeTillReady("IN_COMBAT");
@@ -1227,7 +1227,7 @@ export class GameState {
 					if (healingPotency) {
 						controller.resolveHealingPotency(healingPotency);
 					}
-					skill.onApplication(this, node);
+					skill.onApplication?.(this, node);
 				}),
 			);
 		} else {
@@ -1237,7 +1237,7 @@ export class GameState {
 			if (healingPotency) {
 				controller.resolveHealingPotency(healingPotency);
 			}
-			skill.onApplication(this, node);
+			skill.onApplication?.(this, node);
 		}
 
 		// recast
@@ -1304,7 +1304,7 @@ export class GameState {
 		 */
 		const onLimitBreakConfirm = () => {
 			// Perform additional side effects
-			skill.onConfirm(this, node);
+			skill.onConfirm?.(this, node);
 
 			// potency
 			if (potency) {
@@ -1323,7 +1323,7 @@ export class GameState {
 					if (healingPotency) {
 						controller.resolveHealingPotency(healingPotency);
 					}
-					skill.onApplication(this, node);
+					skill.onApplication?.(this, node);
 				}),
 			);
 

--- a/src/Game/Jobs/AST.ts
+++ b/src/Game/Jobs/AST.ts
@@ -8,7 +8,7 @@ import { Aspect, BuffType, WarningType } from "../Common";
 import { TraitKey } from "../Data";
 import { ASTActionKey, ASTCooldownKey, ASTResourceKey } from "../Data/Jobs/AST";
 import { GameConfig } from "../GameConfig";
-import { GameState, PlayerState } from "../GameState";
+import { GameState } from "../GameState";
 import { Modifiers, Potency, PotencyModifier } from "../Potency";
 import { makeResource, CoolDown } from "../Resources";
 import {
@@ -162,7 +162,7 @@ export class ASTState extends GameState {
 		this.tryConsumeResource("COLLECTIVE_UNCONSCIOUS");
 	}
 
-	override jobSpecificAddHealingBuffCovers(node: ActionNode, skill: Skill<PlayerState>): void {
+	override jobSpecificAddHealingBuffCovers(node: ActionNode, skill: Skill<GameState>): void {
 		if (skill.cdName === "cd_GCD" && this.hasResourceAvailable("NEUTRAL_SECT")) {
 			node.addBuff(BuffType.NeutralSect);
 		}
@@ -174,7 +174,7 @@ export class ASTState extends GameState {
 		}
 	}
 
-	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<PlayerState>): void {
+	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<GameState>): void {
 		if (this.hasResourceAvailable("DIVINATION")) {
 			node.addBuff(BuffType.Divination);
 		}

--- a/src/Game/Jobs/AST.ts
+++ b/src/Game/Jobs/AST.ts
@@ -21,7 +21,6 @@ import {
 	MakeResourceAbilityParams,
 	makeSpell,
 	MakeAbilityParams,
-	NO_EFFECT,
 	PotencyModifierFn,
 	Skill,
 	SkillAutoReplace,
@@ -244,8 +243,8 @@ const makeASTSpell = (
 		isInstantFn: (state) => !params.baseCastTime || state.hasResourceAvailable("SWIFTCAST"),
 		// swiftcast is used if lightspeed is active
 		onConfirm: combineEffects(
-			baseCastTime ? (state) => state.tryConsumeResource("SWIFTCAST") : NO_EFFECT,
-			params.onConfirm ?? NO_EFFECT,
+			baseCastTime ? (state) => state.tryConsumeResource("SWIFTCAST") : undefined,
+			params.onConfirm,
 		),
 	});
 };

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -19,7 +19,7 @@ import {
 	Spell,
 	StatePredicate,
 } from "../Skills";
-import { GameState, PlayerState } from "../GameState";
+import { GameState } from "../GameState";
 import { makeResource, CoolDown, Event, Resource } from "../Resources";
 import { GameConfig } from "../GameConfig";
 import { localize } from "../../Components/Localization";
@@ -137,7 +137,7 @@ export class BLMState extends GameState {
 		recurringPolyglotGain(this.resources.get("POLYGLOT"));
 	}
 
-	override jobSpecificAddSpeedBuffCovers(node: ActionNode, skill: Skill<PlayerState>): void {
+	override jobSpecificAddSpeedBuffCovers(node: ActionNode, skill: Skill<GameState>): void {
 		if (this.hasResourceAvailable("LEY_LINES") && skill.cdName === "cd_GCD") {
 			node.addBuff(BuffType.LeyLines);
 		}
@@ -560,11 +560,11 @@ makeSpell_BLM("BLIZZARD", 1, {
 	],
 });
 
-const gainFirestarterProc = (state: PlayerState) => {
+const gainFirestarterProc = (state: GameState) => {
 	state.resources.get("FIRESTARTER").gain(1);
 };
 
-const potentiallyGainFirestarter = (game: PlayerState) => {
+const potentiallyGainFirestarter = (game: GameState) => {
 	const rand = game.rng();
 	if (
 		game.config.procMode === ProcMode.Always ||

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -81,7 +81,7 @@ export class BLMState extends GameState {
 			(this.hasTraitUnlocked("ENHANCED_POLYGLOT_II") && 3) ||
 			(this.hasTraitUnlocked("ENHANCED_POLYGLOT") && 2) ||
 			1;
-		this.resources.set(new Resource("POLYGLOT", polyglotStacks, 0));
+		this.resources.set(new Resource("POLYGLOT", polyglotStacks, 0, true));
 
 		// skill CDs (also a form of resource)
 		const manafontCooldown = (this.hasTraitUnlocked("ENHANCED_MANAFONT") && 100) || 120;

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -13,7 +13,6 @@ import {
 	makeResourceAbility,
 	makeSpell,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	Skill,
 	SkillAutoReplace,
 	Spell,
@@ -381,12 +380,11 @@ const makeSpell_BLM = (
 				state.gainUmbralMana(params.applicationDelay);
 			}
 		},
-		params.onConfirm ?? NO_EFFECT,
+		params.onConfirm,
 	);
-	const onApplication: EffectFn<BLMState> = params.onApplication ?? NO_EFFECT;
 	return makeSpell("BLM", name, unlockLevel, {
 		...params,
-		aspect: aspect,
+		aspect,
 		castTime: (state) => state.captureSpellCastTimeAFUI(params.baseCastTime, aspect),
 		recastTime: (state) =>
 			state.config.adjustedGCD(2.5, state.hasResourceAvailable("LEY_LINES") ? 15 : 0),
@@ -404,8 +402,8 @@ const makeSpell_BLM = (
 			state.hasResourceAvailable("SWIFTCAST") ||
 			// Triple
 			state.hasResourceAvailable("TRIPLECAST"),
-		onConfirm: onConfirm,
-		onApplication: onApplication,
+		onConfirm,
+		onApplication: params.onApplication,
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyMultiplier[] = [];
 			if (state.hasResourceAvailable("ENOCHIAN")) {

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -1,8 +1,7 @@
 // Skill and state declarations for BLM.
 
-import { controller } from "../../Controller/Controller";
 import { ActionNode } from "../../Controller/Record";
-import { Aspect, BuffType, Debug, WarningType } from "../Common";
+import { Aspect, BuffType, Debug } from "../Common";
 import { PotencyModifierType, PotencyMultiplier } from "../Potency";
 import {
 	Ability,
@@ -28,11 +27,15 @@ import { BLMResourceKey, BLMActionKey, BLMCooldownKey } from "../Data/Jobs/BLM";
 
 // === JOB GAUGE ELEMENTS AND STATUS EFFECTS ===
 // TODO values changed by traits are handled in the class constructor, should be moved here
-const makeBLMResource = (rsc: BLMResourceKey, maxValue: number, params?: { timeout: number }) => {
+const makeBLMResource = (
+	rsc: BLMResourceKey,
+	maxValue: number,
+	params?: { timeout: number; warnOnOvercap?: boolean },
+) => {
 	makeResource("BLM", rsc, maxValue, params ?? {});
 };
 
-makeBLMResource("POLYGLOT", 3, { timeout: 30 });
+makeBLMResource("POLYGLOT", 3, { timeout: 30, warnOnOvercap: true });
 makeBLMResource("ASTRAL_FIRE", 3);
 makeBLMResource("UMBRAL_ICE", 3);
 makeBLMResource("UMBRAL_HEART", 3);
@@ -121,9 +124,6 @@ export class BLMState extends GameState {
 		// also polyglot
 		const recurringPolyglotGain = (rsc: Resource) => {
 			if (this.hasEnochian()) {
-				if (rsc.availableAmount() === rsc.maxValue) {
-					controller.reportWarning(WarningType.PolyglotOvercap);
-				}
 				rsc.gain(1);
 			}
 			this.resources.addResourceEvent({
@@ -919,9 +919,6 @@ makeAbility_BLM("AMPLIFIER", 86, "cd_AMPLIFIER", {
 	validateAttempt: (state) => state.getFireStacks() > 0 || state.getIceStacks() > 0,
 	onApplication: (state, node) => {
 		const polyglot = state.resources.get("POLYGLOT");
-		if (polyglot.available(polyglot.maxValue)) {
-			controller.reportWarning(WarningType.PolyglotOvercap);
-		}
 		polyglot.gain(1);
 	},
 });

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -2,7 +2,7 @@
 
 import { controller } from "../../Controller/Controller";
 import { ActionNode } from "../../Controller/Record";
-import { Aspect, BuffType, Debug, ProcMode, WarningType } from "../Common";
+import { Aspect, BuffType, Debug, WarningType } from "../Common";
 import { PotencyModifierType, PotencyMultiplier } from "../Potency";
 import {
 	Ability,
@@ -558,20 +558,6 @@ makeSpell_BLM("BLIZZARD", 1, {
 	],
 });
 
-const gainFirestarterProc = (state: GameState) => {
-	state.resources.get("FIRESTARTER").gain(1);
-};
-
-const potentiallyGainFirestarter = (game: GameState) => {
-	const rand = game.rng();
-	if (
-		game.config.procMode === ProcMode.Always ||
-		(game.config.procMode === ProcMode.RNG && rand < 0.4)
-	) {
-		gainFirestarterProc(game);
-	}
-};
-
 makeSpell_BLM("FIRE", 2, {
 	aspect: Aspect.Fire,
 	baseCastTime: 2,
@@ -580,7 +566,9 @@ makeSpell_BLM("FIRE", 2, {
 	applicationDelay: 1.871,
 	onConfirm: (state, node) => {
 		// Refresh Enochian and gain a UI stack at the cast confirm window, not the damage application.
-		potentiallyGainFirestarter(state);
+		if (state.triggersEffect(0.4, true)) {
+			state.gainStatus("FIRESTARTER");
+		}
 		if (state.getIceStacks() === 0) {
 			// in fire or no enochian
 			state.switchToAForUI("ASTRAL_FIRE", 1);
@@ -962,7 +950,7 @@ makeSpell_BLM("PARADOX", 90, {
 	onConfirm: (state, node) => {
 		state.resources.get("PARADOX").consume(1);
 		if (state.getFireStacks() > 0) {
-			gainFirestarterProc(state);
+			state.gainStatus("FIRESTARTER");
 		} else if (state.getIceStacks() === 0) {
 			console.error("cannot cast Paradox outside of AF/UI");
 		}

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -800,10 +800,7 @@ makeAbility_BLM("TRIPLECAST", 66, "cd_TRIPLECAST", {
 	applicationDelay: 0, // instant
 	cooldown: 60,
 	maxCharges: 2,
-	onApplication: (state, node) => {
-		const triple = state.resources.get("TRIPLECAST");
-		state.gainStatus("TRIPLECAST", 3);
-	},
+	onApplication: (state, node) => state.gainStatus("TRIPLECAST", 3),
 });
 
 makeSpell_BLM("FOUL", 70, {

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -395,7 +395,6 @@ const makeSpell_BLM = (
 			// Triple
 			state.hasResourceAvailable("TRIPLECAST"),
 		onConfirm,
-		onApplication: params.onApplication,
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyMultiplier[] = [];
 			if (state.hasResourceAvailable("ENOCHIAN")) {

--- a/src/Game/Jobs/BLM.ts
+++ b/src/Game/Jobs/BLM.ts
@@ -295,7 +295,6 @@ export class BLMState extends GameState {
 			"ASTRAL_SOUL",
 		];
 		rscToLose.forEach((rsc) => this.tryConsumeResource(rsc, true));
-		this.resources.get("ENOCHIAN").consume(1);
 	}
 }
 
@@ -853,7 +852,8 @@ makeSpell_BLM("XENOGLOSSY", 80, {
 	basePotency: 890,
 	applicationDelay: 0.63,
 	validateAttempt: (state) => state.hasResourceAvailable("POLYGLOT"),
-	onConfirm: (state, node) => state.tryConsumeResource("POLYGLOT"),
+	// Don't call tryConsumeResource so we ensure the timer keeps ticking.
+	onConfirm: (state, node) => state.resources.get("POLYGLOT").consume(1),
 	highlightIf: (state) => state.hasResourceAvailable("POLYGLOT"),
 });
 

--- a/src/Game/Jobs/BLU.ts
+++ b/src/Game/Jobs/BLU.ts
@@ -11,7 +11,6 @@ import {
 	makeAbility,
 	makeSpell,
 	CooldownGroupProperties,
-	NO_EFFECT,
 	ResourceCalculationFn,
 	PotencyModifierFn,
 	Spell,
@@ -211,10 +210,7 @@ const makeBLUSpell = (
 	const baseCastTime = params.baseCastTime ?? 0;
 	const onConfirm: EffectFn<BLUState> | undefined =
 		baseCastTime > 0
-			? combineEffects(
-					(state) => state.tryConsumeResource("SWIFTCAST"),
-					params.onConfirm ?? NO_EFFECT,
-				)
+			? combineEffects((state) => state.tryConsumeResource("SWIFTCAST"), params.onConfirm)
 			: params.onConfirm;
 	const jobPotencyMod: PotencyModifierFn<BLUState> =
 		params.jobPotencyModifiers ?? ((state) => []);

--- a/src/Game/Jobs/BRD.ts
+++ b/src/Game/Jobs/BRD.ts
@@ -7,7 +7,7 @@ import { Debug, BuffType, WarningType } from "../Common";
 import { TraitKey } from "../Data";
 import { BRDResourceKey, BRDActionKey, BRDCooldownKey } from "../Data/Jobs/BRD";
 import { GameConfig } from "../GameConfig";
-import { GameState, PlayerState } from "../GameState";
+import { GameState } from "../GameState";
 import { Modifiers, PotencyModifier } from "../Potency";
 import { CoolDown, makeResource, Event } from "../Resources";
 import {
@@ -106,7 +106,7 @@ export class BRDState extends GameState {
 		return new BRDStatusPropsGenerator(this);
 	}
 
-	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<PlayerState>): void {
+	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<GameState>): void {
 		if (this.hasResourceAvailable("RAGING_STRIKES")) {
 			node.addBuff(BuffType.RagingStrikes);
 		}

--- a/src/Game/Jobs/BRD.ts
+++ b/src/Game/Jobs/BRD.ts
@@ -1,9 +1,8 @@
 import { BRDStatusPropsGenerator } from "../../Components/Jobs/BRD";
 import { localizeResourceType } from "../../Components/Localization";
 import { StatusPropsGenerator } from "../../Components/StatusDisplay";
-import { controller } from "../../Controller/Controller";
 import { ActionNode } from "../../Controller/Record";
-import { Debug, BuffType, WarningType } from "../Common";
+import { Debug, BuffType } from "../Common";
 import { TraitKey } from "../Data";
 import { BRDResourceKey, BRDActionKey, BRDCooldownKey } from "../Data/Jobs/BRD";
 import { GameConfig } from "../GameConfig";
@@ -29,17 +28,17 @@ import {
 const makeBRDResource = (
 	rsc: BRDResourceKey,
 	maxValue: number,
-	params?: { timeout?: number; default?: number },
+	params?: { timeout?: number; default?: number; warnOnOvercap?: boolean },
 ) => {
 	makeResource("BRD", rsc, maxValue, params ?? {});
 };
 
-makeBRDResource("SOUL_VOICE", 100);
+makeBRDResource("SOUL_VOICE", 100, { warnOnOvercap: true });
 makeBRDResource("PITCH_PERFECT", 3);
 makeBRDResource("REPERTOIRE", 4);
-makeBRDResource("WANDERERS_CODA", 1);
-makeBRDResource("MAGES_CODA", 1);
-makeBRDResource("ARMYS_CODA", 1);
+makeBRDResource("WANDERERS_CODA", 1, { warnOnOvercap: true });
+makeBRDResource("MAGES_CODA", 1, { warnOnOvercap: true });
+makeBRDResource("ARMYS_CODA", 1, { warnOnOvercap: true });
 makeBRDResource("ETHOS_REPERTOIRE", 4);
 makeBRDResource("MUSE_REPERTOIRE", 4);
 
@@ -197,9 +196,6 @@ export class BRDState extends GameState {
 		}
 
 		if (this.hasTraitUnlocked("SOUL_VOICE")) {
-			if (this.hasResourceAvailable("SOUL_VOICE", 100)) {
-				controller.reportWarning(WarningType.SoulVoiceOvercap);
-			}
 			this.resources.get("SOUL_VOICE").gain(5);
 		}
 	}
@@ -233,9 +229,6 @@ export class BRDState extends GameState {
 					: newSong === "MAGES_BALLAD"
 						? "MAGES_CODA"
 						: "ARMYS_CODA";
-			if (this.hasResourceAvailable(coda)) {
-				controller.reportWarning(WarningType.CodaOvercap);
-			}
 			this.resources.get(coda).gain(1);
 		}
 

--- a/src/Game/Jobs/BRD.ts
+++ b/src/Game/Jobs/BRD.ts
@@ -435,9 +435,7 @@ const makeResourceAbility_BRD = (
 		secondaryCooldown?: CooldownGroupProperties;
 	},
 ): Ability<BRDState> => {
-	return makeResourceAbility("BRD", name, unlockLevel, cdName, {
-		...params,
-	});
+	return makeResourceAbility("BRD", name, unlockLevel, cdName, params);
 };
 
 makeWeaponskill_BRD("HEAVY_SHOT", 1, {

--- a/src/Game/Jobs/DNC.ts
+++ b/src/Game/Jobs/DNC.ts
@@ -6,7 +6,7 @@ import { BuffType, ProcMode, WarningType } from "../Common";
 import { TraitKey } from "../Data";
 import { DNCResourceKey, DNCActionKey, DNCCooldownKey } from "../Data/Jobs/DNC";
 import { GameConfig } from "../GameConfig";
-import { GameState, PlayerState } from "../GameState";
+import { GameState } from "../GameState";
 import { makeComboModifier, Modifiers, PotencyModifier } from "../Potency";
 import { CoolDown, getResourceInfo, makeResource, Resource, ResourceInfo } from "../Resources";
 import {
@@ -107,7 +107,7 @@ export class DNCState extends GameState {
 		return new DNCStatusPropsGenerator(this);
 	}
 
-	override jobSpecificAddDamageBuffCovers(node: ActionNode, _skill: Skill<PlayerState>): void {
+	override jobSpecificAddDamageBuffCovers(node: ActionNode, _skill: Skill<GameState>): void {
 		if (this.hasResourceAvailable("TECHNICAL_FINISH")) {
 			node.addBuff(BuffType.TechnicalFinish);
 		}

--- a/src/Game/Jobs/DNC.ts
+++ b/src/Game/Jobs/DNC.ts
@@ -1,8 +1,7 @@
 import { DNCStatusPropsGenerator } from "../../Components/Jobs/DNC";
 import { StatusPropsGenerator } from "../../Components/StatusDisplay";
-import { controller } from "../../Controller/Controller";
 import { ActionNode } from "../../Controller/Record";
-import { BuffType, WarningType } from "../Common";
+import { BuffType } from "../Common";
 import { TraitKey } from "../Data";
 import { DNCResourceKey, DNCActionKey, DNCCooldownKey } from "../Data/Jobs/DNC";
 import { GameConfig } from "../GameConfig";
@@ -28,14 +27,14 @@ import {
 const makeDNCResource = (
 	rsc: DNCResourceKey,
 	maxValue: number,
-	params?: { timeout?: number; default?: number },
+	params?: { timeout?: number; default?: number; warnOnOvercap?: boolean },
 ) => {
 	makeResource("DNC", rsc, maxValue, params ?? {});
 };
 
 // Gauge resources
-makeDNCResource("ESPRIT_GAUGE", 100);
-makeDNCResource("FEATHER_GAUGE", 4);
+makeDNCResource("ESPRIT_GAUGE", 100, { warnOnOvercap: true });
+makeDNCResource("FEATHER_GAUGE", 4, { warnOnOvercap: true });
 makeDNCResource("STANDARD_DANCE", 2);
 makeDNCResource("TECHNICAL_DANCE", 4);
 
@@ -45,7 +44,7 @@ makeDNCResource("SILKEN_FLOW", 1, { timeout: 30 });
 makeDNCResource("FLOURISHING_SYMMETRY", 1, { timeout: 30 });
 makeDNCResource("FLOURISHING_FLOW", 1, { timeout: 30 });
 
-makeDNCResource("THREEFOLD_FAN_DANCE", 1, { timeout: 30 });
+makeDNCResource("THREEFOLD_FAN_DANCE", 1, { timeout: 30, warnOnOvercap: true });
 makeDNCResource("FOURFOLD_FAN_DANCE", 1, { timeout: 30 });
 
 makeDNCResource("FINISHING_MOVE_READY", 1, { timeout: 30 });
@@ -169,9 +168,6 @@ export class DNCState extends GameState {
 	}
 
 	gainProc(proc: DNCResourceKey) {
-		if (this.hasResourceAvailable(proc) && proc === "THREEFOLD_FAN_DANCE") {
-			controller.reportWarning(WarningType.FanThreeOverwrite);
-		}
 		this.gainStatus(proc);
 	}
 
@@ -180,12 +176,6 @@ export class DNCState extends GameState {
 	}
 
 	gainResource(rscType: "ESPRIT_GAUGE" | "FEATHER_GAUGE", amount: number) {
-		const resource = this.resources.get(rscType);
-		if (resource.availableAmount() + amount > resource.maxValue) {
-			controller.reportWarning(
-				rscType === "ESPRIT_GAUGE" ? WarningType.EspritOvercap : WarningType.FeatherOvercap,
-			);
-		}
 		this.resources.get(rscType).gain(amount);
 	}
 

--- a/src/Game/Jobs/DNC.ts
+++ b/src/Game/Jobs/DNC.ts
@@ -88,7 +88,7 @@ export class DNCState extends GameState {
 
 		// Disable Esprit Gauge for level 70 duties
 		if (!this.hasTraitUnlocked("ESPRIT")) {
-			this.resources.set(new Resource("ESPRIT_GAUGE", 0, 0));
+			this.resources.set(new Resource("ESPRIT_GAUGE", 0, 0, true));
 		}
 
 		const enAvantStacks = this.hasTraitUnlocked("ENHANCED_EN_AVANT_II") ? 3 : 2;

--- a/src/Game/Jobs/DNC.ts
+++ b/src/Game/Jobs/DNC.ts
@@ -20,7 +20,6 @@ import {
 	makeResourceAbility,
 	makeWeaponskill,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	ResourceCalculationFn,
 	Skill,
 	StatePredicate,
@@ -315,7 +314,7 @@ const makeGCD_DNC = (
 				state.simulatePartyEspritGain();
 			}
 		},
-		params.onConfirm ?? NO_EFFECT,
+		params.onConfirm,
 		(state) => state.processComboStatus(name),
 	);
 	return makeWeaponskill("DNC", name, unlockLevel, {

--- a/src/Game/Jobs/DNC.ts
+++ b/src/Game/Jobs/DNC.ts
@@ -7,7 +7,7 @@ import { TraitKey } from "../Data";
 import { DNCResourceKey, DNCActionKey, DNCCooldownKey } from "../Data/Jobs/DNC";
 import { GameConfig } from "../GameConfig";
 import { GameState } from "../GameState";
-import { makeComboModifier, Modifiers, PotencyModifier } from "../Potency";
+import { Modifiers, PotencyModifier } from "../Potency";
 import { CoolDown, getResourceInfo, makeResource, Resource, ResourceInfo } from "../Resources";
 import {
 	Ability,
@@ -15,7 +15,6 @@ import {
 	ConditionalSkillReplace,
 	CooldownGroupProperties,
 	EffectFn,
-	getBasePotency,
 	makeAbility,
 	makeResourceAbility,
 	makeWeaponskill,
@@ -295,21 +294,9 @@ const makeGCD_DNC = (
 	);
 	return makeWeaponskill("DNC", name, unlockLevel, {
 		...params,
-		onConfirm: onConfirm,
+		onConfirm,
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = [];
-			if (
-				params.combo &&
-				state.resources.get(params.combo.resource).availableAmount() ===
-					params.combo.resourceValue
-			) {
-				mods.push(
-					makeComboModifier(
-						getBasePotency(state, params.combo.potency) -
-							getBasePotency(state, params.potency),
-					),
-				);
-			}
 			if (state.hasResourceAvailable("STANDARD_FINISH")) {
 				const modifier =
 					state.resources.get("STANDARD_BONUS").availableAmount() === 2

--- a/src/Game/Jobs/DRG.ts
+++ b/src/Game/Jobs/DRG.ts
@@ -2,14 +2,13 @@
 
 import { controller } from "../../Controller/Controller";
 import { BuffType, WarningType } from "../Common";
-import { makeComboModifier, Modifiers, makePositionalModifier, PotencyModifier } from "../Potency";
+import { Modifiers, PotencyModifier } from "../Potency";
 import {
 	Ability,
 	combineEffects,
 	ConditionalSkillReplace,
 	CooldownGroupProperties,
 	EffectFn,
-	getBasePotency,
 	makeAbility,
 	makeResourceAbility,
 	ResourceCalculationFn,
@@ -301,32 +300,6 @@ const makeWeaponskill_DRG = (
 		recastTime: (state) => state.config.adjustedSksGCD(),
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = params.jobPotencyModifiers?.(state) ?? [];
-			const hitPositional =
-				params.positional && state.hitPositional(params.positional.location);
-			if (params.combo && state.checkCombo(params.combo.resource)) {
-				mods.push(
-					makeComboModifier(
-						getBasePotency(state, params.combo.potency) -
-							getBasePotency(state, params.potency),
-					),
-				);
-				// typescript isn't smart enough to elide the null check
-				if (params.positional && hitPositional) {
-					mods.push(
-						makePositionalModifier(
-							getBasePotency(state, params.positional.comboPotency) -
-								getBasePotency(state, params.combo.potency),
-						),
-					);
-				}
-			} else if (params.positional && hitPositional) {
-				mods.push(
-					makePositionalModifier(
-						getBasePotency(state, params.positional.potency) -
-							getBasePotency(state, params.potency),
-					),
-				);
-			}
 			if (
 				name === "PIERCING_TALON" &&
 				state.hasResourceAvailable("ENHANCED_PIERCING_TALON")

--- a/src/Game/Jobs/DRG.ts
+++ b/src/Game/Jobs/DRG.ts
@@ -22,7 +22,7 @@ import {
 	StatePredicate,
 	Weaponskill,
 } from "../Skills";
-import { GameState, PlayerState } from "../GameState";
+import { GameState } from "../GameState";
 import { makeResource, CoolDown, Event } from "../Resources";
 import { GameConfig } from "../GameConfig";
 import { ActionNode } from "../../Controller/Record";
@@ -121,7 +121,7 @@ export class DRGState extends GameState {
 		return new DRGStatusPropsGenerator(this);
 	}
 
-	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<PlayerState>): void {
+	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<GameState>): void {
 		if (this.hasResourceAvailable("POWER_SURGE")) {
 			node.addBuff(BuffType.PowerSurge);
 		}

--- a/src/Game/Jobs/DRG.ts
+++ b/src/Game/Jobs/DRG.ts
@@ -15,7 +15,6 @@ import {
 	ResourceCalculationFn,
 	makeWeaponskill,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	PotencyModifierFn,
 	Skill,
 	SkillAutoReplace,
@@ -300,7 +299,7 @@ const makeWeaponskill_DRG = (
 		secondaryCooldown?: CooldownGroupProperties;
 	},
 ): Weaponskill<DRGState> => {
-	const onConfirm: EffectFn<DRGState> = combineEffects(params.onConfirm ?? NO_EFFECT, (state) => {
+	const onConfirm: EffectFn<DRGState> = combineEffects(params.onConfirm, (state) => {
 		// fix gcd combo state
 		if (name !== "PIERCING_TALON") {
 			state.fixDRGComboState(name);
@@ -308,13 +307,12 @@ const makeWeaponskill_DRG = (
 		// remove life surge
 		state.tryConsumeResource("LIFE_SURGE");
 	});
-	const onApplication: EffectFn<DRGState> = params.onApplication ?? NO_EFFECT;
 	const jobPotencyMod: PotencyModifierFn<DRGState> =
 		params.jobPotencyModifiers ?? ((state) => []);
 	return makeWeaponskill("DRG", name, unlockLevel, {
 		...params,
-		onConfirm: onConfirm,
-		onApplication: onApplication,
+		onConfirm,
+		onApplication: params.onApplication,
 		recastTime: (state) => state.config.adjustedSksGCD(),
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = jobPotencyMod(state);

--- a/src/Game/Jobs/DRK.ts
+++ b/src/Game/Jobs/DRK.ts
@@ -19,7 +19,6 @@ import {
 	makeWeaponskill,
 	MakeAbilityParams,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	Spell,
 	StatePredicate,
 	Weaponskill,
@@ -275,7 +274,7 @@ const makeDRKWeaponskill = (
 	return makeWeaponskill("DRK", name, unlockLevel, {
 		...params,
 		onConfirm: combineEffects(
-			params.onConfirm ?? NO_EFFECT,
+			params.onConfirm,
 			(state) => state.bloodWeaponConfirm(params.applicationDelay),
 			(state) => state.processComboStatus(name),
 		),
@@ -291,9 +290,7 @@ const makeDRKSpell = (
 ): Spell<DRKState> => {
 	return makeSpell("DRK", name, unlockLevel, {
 		...params,
-		onConfirm: combineEffects(params.onConfirm ?? NO_EFFECT, (state) =>
-			state.processComboStatus(name),
-		),
+		onConfirm: combineEffects(params.onConfirm, (state) => state.processComboStatus(name)),
 		recastTime: (state) => state.config.adjustedGCD(), // sps
 		jobPotencyModifiers: (state) => getDarksideAndComboModifiers(params, state),
 	});

--- a/src/Game/Jobs/DRK.ts
+++ b/src/Game/Jobs/DRK.ts
@@ -5,13 +5,12 @@ import { GameConfig } from "../GameConfig";
 import { controller } from "../../Controller/Controller";
 import { ActionNode } from "../../Controller/Record";
 import { Aspect, WarningType } from "../Common";
-import { Modifiers, Potency, makeComboModifier } from "../Potency";
+import { Modifiers, Potency } from "../Potency";
 import {
 	Ability,
 	combineEffects,
 	ConditionalSkillReplace,
 	EffectFn,
-	getBasePotency,
 	FAKE_SKILL_ANIMATION_LOCK,
 	makeAbility,
 	makeResourceAbility,
@@ -248,24 +247,6 @@ type DRKGCDParams = {
 	secondaryCooldown?: CooldownGroupProperties;
 };
 
-const getDarksideAndComboModifiers = (params: DRKGCDParams, state: Readonly<DRKState>) => {
-	const mods = [];
-	if (state.hasResourceAvailable("DARKSIDE")) {
-		mods.push(Modifiers.Darkside);
-	}
-	if (
-		params.combo &&
-		state.resources.get(params.combo.resource).availableAmount() === params.combo.resourceValue
-	) {
-		mods.push(
-			makeComboModifier(
-				getBasePotency(state, params.combo.potency) - getBasePotency(state, params.potency),
-			),
-		);
-	}
-	return mods;
-};
-
 const makeDRKWeaponskill = (
 	name: DRKActionKey,
 	unlockLevel: number,
@@ -279,7 +260,8 @@ const makeDRKWeaponskill = (
 			(state) => state.processComboStatus(name),
 		),
 		recastTime: (state) => state.config.adjustedSksGCD(),
-		jobPotencyModifiers: (state) => getDarksideAndComboModifiers(params, state),
+		jobPotencyModifiers: (state) =>
+			state.hasResourceAvailable("DARKSIDE") ? [Modifiers.Darkside] : [],
 	});
 };
 
@@ -292,7 +274,8 @@ const makeDRKSpell = (
 		...params,
 		onConfirm: combineEffects(params.onConfirm, (state) => state.processComboStatus(name)),
 		recastTime: (state) => state.config.adjustedGCD(), // sps
-		jobPotencyModifiers: (state) => getDarksideAndComboModifiers(params, state),
+		jobPotencyModifiers: (state) =>
+			state.hasResourceAvailable("DARKSIDE") ? [Modifiers.Darkside] : [],
 	});
 };
 

--- a/src/Game/Jobs/DRK.ts
+++ b/src/Game/Jobs/DRK.ts
@@ -521,7 +521,7 @@ makeDRKWeaponskill("BLOODSPILLER", 62, {
 	applicationDelay: 0.8,
 	validateAttempt: hasBloodOrDelirium,
 	highlightIf: hasBloodOrDelirium,
-	replaceIf: deliriumReplacements.filter((rep) => rep.newSkill !== "BLOODSPILLER"),
+	replaceIf: deliriumReplacements,
 	potency: [
 		["NEVER", 500],
 		["MELEE_MASTERY_II_TANK", 600],
@@ -564,7 +564,7 @@ makeDRKWeaponskill("QUIETUS", 64, {
 		applicationDelay: delay,
 		validateAttempt: deliriumReplacements[i + 1].condition,
 		highlightIf: deliriumReplacements[i + 1].condition,
-		replaceIf: deliriumReplacements.filter((rep) => rep.newSkill !== name),
+		replaceIf: deliriumReplacements,
 		potency,
 		onConfirm: (state) => state.tryConsumeResource("DELIRIUM"),
 		// Delirium combo actions inherently grant 200 MP

--- a/src/Game/Jobs/GNB.ts
+++ b/src/Game/Jobs/GNB.ts
@@ -21,7 +21,7 @@ import {
 	StatePredicate,
 	Weaponskill,
 } from "../Skills";
-import { GameState, PlayerState } from "../GameState";
+import { GameState } from "../GameState";
 import { makeResource, CoolDown, Event, Resource } from "../Resources";
 import { GameConfig } from "../GameConfig";
 import { ActionNode } from "../../Controller/Record";
@@ -121,7 +121,7 @@ export class GNBState extends GameState {
 		return new GNBStatusPropsGenerator(this);
 	}
 
-	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<PlayerState>): void {
+	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<GameState>): void {
 		if (this.hasResourceAvailable("NO_MERCY")) {
 			node.addBuff(BuffType.NoMercy);
 		}

--- a/src/Game/Jobs/GNB.ts
+++ b/src/Game/Jobs/GNB.ts
@@ -14,7 +14,6 @@ import {
 	ResourceCalculationFn,
 	makeWeaponskill,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	PotencyModifierFn,
 	Skill,
 	SkillAutoReplace,
@@ -236,7 +235,7 @@ const makeWeaponskill_GNB = (
 		secondaryCooldown?: CooldownGroupProperties;
 	},
 ): Weaponskill<GNBState> => {
-	const onConfirm: EffectFn<GNBState> = combineEffects(params.onConfirm ?? NO_EFFECT, (state) => {
+	const onConfirm: EffectFn<GNBState> = combineEffects(params.onConfirm, (state) => {
 		// fix gcd combo state
 		if (name !== "SONIC_BREAK") {
 			state.fixGNBComboState(name);
@@ -249,13 +248,12 @@ const makeWeaponskill_GNB = (
 		state.tryConsumeResource("READY_TO_TEAR");
 		state.tryConsumeResource("READY_TO_GOUGE");
 	});
-	const onApplication: EffectFn<GNBState> = params.onApplication ?? NO_EFFECT;
 	const jobPotencyMod: PotencyModifierFn<GNBState> =
 		params.jobPotencyModifiers ?? ((state) => []);
 	return makeWeaponskill("GNB", name, unlockLevel, {
 		...params,
-		onConfirm: onConfirm,
-		onApplication: onApplication,
+		onConfirm,
+		onApplication: params.onApplication,
 		recastTime: (state) => state.config.adjustedSksGCD(),
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = jobPotencyMod(state);

--- a/src/Game/Jobs/GNB.ts
+++ b/src/Game/Jobs/GNB.ts
@@ -1,7 +1,6 @@
 // Skill and state declarations for GNB
 
-import { controller } from "../../Controller/Controller";
-import { BuffType, WarningType } from "../Common";
+import { BuffType } from "../Common";
 import { Modifiers, PotencyModifier } from "../Potency";
 import {
 	Ability,
@@ -31,12 +30,17 @@ import { GNBResourceKey } from "../Data/Jobs/GNB";
 const makeGNBResource = (
 	rsc: GNBResourceKey,
 	maxValue: number,
-	params?: { timeout?: number; default?: number; warningOnTimeout?: WarningType },
+	params?: {
+		timeout?: number;
+		default?: number;
+		warnOnTimeout?: boolean;
+		warnOnOvercap?: boolean;
+	},
 ) => {
 	makeResource("GNB", rsc, maxValue, params ?? {});
 };
 
-makeGNBResource("POWDER_GAUGE", 3);
+makeGNBResource("POWDER_GAUGE", 3, { warnOnOvercap: true });
 makeGNBResource("ROYAL_GUARD", 1);
 
 // TODO: get precise durations
@@ -52,13 +56,13 @@ makeGNBResource("GREAT_NEBULA", 1, { timeout: 15 });
 makeGNBResource("HEART_OF_LIGHT", 1, { timeout: 15 });
 makeGNBResource("HEART_OF_STONE", 1, { timeout: 8 });
 
-makeGNBResource("READY_TO_BLAST", 1, { timeout: 10 });
-makeGNBResource("READY_TO_BREAK", 1, { timeout: 30 });
-makeGNBResource("READY_TO_GOUGE", 1, { timeout: 10 });
-makeGNBResource("READY_TO_RAZE", 1, { timeout: 10 });
-makeGNBResource("READY_TO_REIGN", 1, { timeout: 30 });
-makeGNBResource("READY_TO_RIP", 1, { timeout: 10 });
-makeGNBResource("READY_TO_TEAR", 1, { timeout: 10 });
+makeGNBResource("READY_TO_BLAST", 1, { timeout: 10, warnOnTimeout: true });
+makeGNBResource("READY_TO_BREAK", 1, { timeout: 30, warnOnTimeout: true });
+makeGNBResource("READY_TO_GOUGE", 1, { timeout: 10, warnOnTimeout: true });
+makeGNBResource("READY_TO_RAZE", 1, { timeout: 10, warnOnTimeout: true });
+makeGNBResource("READY_TO_REIGN", 1, { timeout: 30, warnOnTimeout: true });
+makeGNBResource("READY_TO_RIP", 1, { timeout: 10, warnOnTimeout: true });
+makeGNBResource("READY_TO_TEAR", 1, { timeout: 10, warnOnTimeout: true });
 
 makeGNBResource("SONIC_BREAK_DOT", 1, { timeout: 30 });
 makeGNBResource("SUPERBOLIDE", 1, { timeout: 10 });
@@ -172,10 +176,6 @@ export class GNBState extends GameState {
 
 	// gain a cart
 	gainCartridge(carts: number) {
-		const maxCarts = this.hasTraitUnlocked("CARTRIDGE_CHARGE_II") ? 3 : 2;
-		if (this.resources.get("POWDER_GAUGE").availableAmount() + carts > maxCarts) {
-			controller.reportWarning(WarningType.CartridgeOvercap);
-		}
 		this.resources.get("POWDER_GAUGE").gain(carts);
 	}
 

--- a/src/Game/Jobs/GNB.ts
+++ b/src/Game/Jobs/GNB.ts
@@ -226,7 +226,7 @@ const makeWeaponskill_GNB = (
 ): Weaponskill<GNBState> => {
 	const onConfirm: EffectFn<GNBState> = combineEffects(params.onConfirm, (state) => {
 		// fix gcd combo state
-		if (name !== "SONIC_BREAK") {
+		if (!["SONIC_BREAK", "BURST_STRIKE", "DOUBLE_DOWN", "LIGHTNING_SHOT"].includes(name)) {
 			state.fixGNBComboState(name);
 		}
 

--- a/src/Game/Jobs/GNB.ts
+++ b/src/Game/Jobs/GNB.ts
@@ -2,19 +2,17 @@
 
 import { controller } from "../../Controller/Controller";
 import { BuffType, WarningType } from "../Common";
-import { makeComboModifier, Modifiers, PotencyModifier } from "../Potency";
+import { Modifiers, PotencyModifier } from "../Potency";
 import {
 	Ability,
 	combineEffects,
 	ConditionalSkillReplace,
 	CooldownGroupProperties,
 	EffectFn,
-	getBasePotency,
 	makeAbility,
 	ResourceCalculationFn,
 	makeWeaponskill,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	PotencyModifierFn,
 	Skill,
 	SkillAutoReplace,
 	StatePredicate,
@@ -216,7 +214,6 @@ const makeWeaponskill_GNB = (
 			resourceValue: number;
 		};
 		falloff?: number;
-		jobPotencyModifiers?: PotencyModifierFn<GNBState>;
 		applicationDelay?: number;
 		animationLock?: number;
 		validateAttempt?: StatePredicate<GNBState>;
@@ -240,31 +237,12 @@ const makeWeaponskill_GNB = (
 		state.tryConsumeResource("READY_TO_TEAR");
 		state.tryConsumeResource("READY_TO_GOUGE");
 	});
-	const jobPotencyMod: PotencyModifierFn<GNBState> =
-		params.jobPotencyModifiers ?? ((state) => []);
 	return makeWeaponskill("GNB", name, unlockLevel, {
 		...params,
 		onConfirm,
 		recastTime: (state) => state.config.adjustedSksGCD(),
-		jobPotencyModifiers: (state) => {
-			const mods: PotencyModifier[] = jobPotencyMod(state);
-			if (
-				params.combo &&
-				state.resources.get(params.combo.resource).availableAmount() ===
-					params.combo.resourceValue
-			) {
-				mods.push(
-					makeComboModifier(
-						getBasePotency(state, params.combo.potency) -
-							getBasePotency(state, params.potency),
-					),
-				);
-			}
-			if (state.hasResourceAvailable("NO_MERCY")) {
-				mods.push(Modifiers.NoMercy);
-			}
-			return mods;
-		},
+		jobPotencyModifiers: (state) =>
+			state.hasResourceAvailable("NO_MERCY") ? [Modifiers.NoMercy] : [],
 	});
 };
 
@@ -293,13 +271,8 @@ const makeAbility_GNB = (
 ): Ability<GNBState> => {
 	return makeAbility("GNB", name, unlockLevel, cdName, {
 		...params,
-		jobPotencyModifiers: (state) => {
-			const mods: PotencyModifier[] = [];
-			if (state.hasResourceAvailable("NO_MERCY")) {
-				mods.push(Modifiers.NoMercy);
-			}
-			return mods;
-		},
+		jobPotencyModifiers: (state) =>
+			state.hasResourceAvailable("NO_MERCY") ? [Modifiers.NoMercy] : [],
 	});
 };
 

--- a/src/Game/Jobs/GNB.ts
+++ b/src/Game/Jobs/GNB.ts
@@ -96,7 +96,7 @@ export class GNBState extends GameState {
 		this.cooldowns.set(new CoolDown("cd_GNASHING_FANG", this.config.adjustedSksGCD(30), 1, 1));
 
 		const powderGaugeMax = this.hasTraitUnlocked("CARTRIDGE_CHARGE_II") ? 3 : 2;
-		this.resources.set(new Resource("POWDER_GAUGE", powderGaugeMax, 0));
+		this.resources.set(new Resource("POWDER_GAUGE", powderGaugeMax, 0, true));
 
 		this.registerRecurringEvents([
 			{

--- a/src/Game/Jobs/MCH.ts
+++ b/src/Game/Jobs/MCH.ts
@@ -27,7 +27,6 @@ import {
 	makeAbility,
 	makeResourceAbility,
 	makeWeaponskill,
-	NO_EFFECT,
 	ResourceCalculationFn,
 	SkillAutoReplace,
 	StatePredicate,
@@ -328,7 +327,7 @@ const makeWeaponskill_MCH = (
 	},
 ): Weaponskill<MCHState> => {
 	const onConfirm: EffectFn<MCHState> = combineEffects(
-		params.onConfirm ?? NO_EFFECT,
+		params.onConfirm,
 		(state) => state.processComboStatus(name),
 		(state) => {
 			if (name !== "FULL_METAL_FIELD") {
@@ -347,11 +346,10 @@ const makeWeaponskill_MCH = (
 			}
 		},
 	);
-	const onApplication: EffectFn<MCHState> = params.onApplication ?? NO_EFFECT;
 	return makeWeaponskill("MCH", name, unlockLevel, {
 		...params,
 		onConfirm,
-		onApplication,
+		onApplication: params.onApplication,
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = [];
 			if (
@@ -401,7 +399,7 @@ const makeAbility_MCH = (
 		secondaryCooldown?: CooldownGroupProperties;
 	},
 ): Ability<MCHState> => {
-	const onConfirm: EffectFn<MCHState> = combineEffects(params.onConfirm ?? NO_EFFECT);
+	const onConfirm: EffectFn<MCHState> = combineEffects(params.onConfirm);
 	return makeAbility("MCH", name, unlockLevel, cdName, {
 		...params,
 		onConfirm: onConfirm,
@@ -429,7 +427,7 @@ const makeResourceAbility_MCH = (
 		secondaryCooldown?: CooldownGroupProperties;
 	},
 ): Ability<MCHState> => {
-	const onConfirm: EffectFn<MCHState> = combineEffects(params.onConfirm ?? NO_EFFECT);
+	const onConfirm: EffectFn<MCHState> = combineEffects(params.onConfirm);
 	return makeResourceAbility("MCH", name, unlockLevel, cdName, {
 		...params,
 		onConfirm,

--- a/src/Game/Jobs/MCH.ts
+++ b/src/Game/Jobs/MCH.ts
@@ -7,7 +7,7 @@ import { ActionKey, TraitKey } from "../Data";
 import { MCHResourceKey, MCHActionKey, MCHCooldownKey } from "../Data/Jobs/MCH";
 import { GameConfig } from "../GameConfig";
 import { GameState } from "../GameState";
-import { makeComboModifier, Modifiers, Potency, PotencyModifier } from "../Potency";
+import { Modifiers, Potency, PotencyModifier } from "../Potency";
 import {
 	CoolDown,
 	getResourceInfo,
@@ -23,7 +23,6 @@ import {
 	ConditionalSkillReplace,
 	CooldownGroupProperties,
 	EffectFn,
-	getBasePotency,
 	makeAbility,
 	makeResourceAbility,
 	makeWeaponskill,
@@ -351,18 +350,6 @@ const makeWeaponskill_MCH = (
 		onConfirm,
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = [];
-			if (
-				params.combo &&
-				state.resources.get(params.combo.resource).availableAmount() ===
-					params.combo.resourceValue
-			) {
-				mods.push(
-					makeComboModifier(
-						getBasePotency(state, params.combo.potency) -
-							getBasePotency(state, params.potency),
-					),
-				);
-			}
 			if (state.hasResourceAvailable("REASSEMBLED") || name === "FULL_METAL_FIELD") {
 				mods.push(Modifiers.AutoCDH);
 			}

--- a/src/Game/Jobs/MCH.ts
+++ b/src/Game/Jobs/MCH.ts
@@ -349,7 +349,6 @@ const makeWeaponskill_MCH = (
 	return makeWeaponskill("MCH", name, unlockLevel, {
 		...params,
 		onConfirm,
-		onApplication: params.onApplication,
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = [];
 			if (
@@ -399,15 +398,7 @@ const makeAbility_MCH = (
 		secondaryCooldown?: CooldownGroupProperties;
 	},
 ): Ability<MCHState> => {
-	const onConfirm: EffectFn<MCHState> = combineEffects(params.onConfirm);
-	return makeAbility("MCH", name, unlockLevel, cdName, {
-		...params,
-		onConfirm: onConfirm,
-		jobPotencyModifiers: (state) => {
-			const mods: PotencyModifier[] = [];
-			return mods;
-		},
-	});
+	return makeAbility("MCH", name, unlockLevel, cdName, params);
 };
 
 const makeResourceAbility_MCH = (
@@ -463,7 +454,7 @@ makeWeaponskill_MCH("HEATED_SLUG_SHOT", 60, {
 	applicationDelay: 0.8,
 	recastTime: (state) => state.config.adjustedSksGCD(),
 	onConfirm: (state) => state.gainResource("HEAT_GAUGE", 5),
-	highlightIf: (state) => state.resources.get("HEAT_COMBO").availableAmount() === 1,
+	highlightIf: (state) => state.hasResourceExactly("HEAT_COMBO", 1),
 });
 
 makeWeaponskill_MCH("HEATED_CLEAN_SHOT", 64, {
@@ -487,7 +478,7 @@ makeWeaponskill_MCH("HEATED_CLEAN_SHOT", 64, {
 		state.gainResource("HEAT_GAUGE", 5);
 		state.gainResource("BATTERY_GAUGE", 10);
 	},
-	highlightIf: (state) => state.resources.get("HEAT_COMBO").availableAmount() === 2,
+	highlightIf: (state) => state.hasResourceExactly("HEAT_COMBO", 2),
 });
 
 makeResourceAbility_MCH("REASSEMBLE", 10, "cd_REASSEMBLE", {

--- a/src/Game/Jobs/MCH.ts
+++ b/src/Game/Jobs/MCH.ts
@@ -2,7 +2,7 @@ import { MCHStatusPropsGenerator } from "../../Components/Jobs/MCH";
 import { StatusPropsGenerator } from "../../Components/StatusDisplay";
 import { controller } from "../../Controller/Controller";
 import { ActionNode } from "../../Controller/Record";
-import { Aspect, WarningType } from "../Common";
+import { Aspect } from "../Common";
 import { ActionKey, TraitKey } from "../Data";
 import { MCHResourceKey, MCHActionKey, MCHCooldownKey } from "../Data/Jobs/MCH";
 import { GameConfig } from "../GameConfig";
@@ -35,26 +35,31 @@ import {
 const makeMCHResource = (
 	rsc: MCHResourceKey,
 	maxValue: number,
-	params?: { timeout?: number; default?: number },
+	params?: {
+		timeout?: number;
+		default?: number;
+		warnOnOvercap?: boolean;
+		warnOnTimeout?: boolean;
+	},
 ) => {
 	makeResource("MCH", rsc, maxValue, params ?? {});
 };
 
 // Gauge resources
-makeMCHResource("HEAT_GAUGE", 100);
-makeMCHResource("BATTERY_GAUGE", 100);
+makeMCHResource("HEAT_GAUGE", 100, { warnOnOvercap: true });
+makeMCHResource("BATTERY_GAUGE", 100, { warnOnOvercap: true });
 
 // Status Effects
-makeMCHResource("REASSEMBLED", 1, { timeout: 5 });
-makeMCHResource("OVERHEATED", 5, { timeout: 10 });
+makeMCHResource("REASSEMBLED", 1, { timeout: 5, warnOnTimeout: true });
+makeMCHResource("OVERHEATED", 5, { timeout: 10, warnOnTimeout: true });
 makeMCHResource("WILDFIRE", 1, { timeout: 10 });
 makeMCHResource("WILDFIRE_SELF", 1, { timeout: 10 });
 makeMCHResource("FLAMETHROWER", 1, { timeout: 10 });
 makeMCHResource("BIOBLASTER", 1, { timeout: 15 });
 makeMCHResource("TACTICIAN", 1, { timeout: 15 });
-makeMCHResource("HYPERCHARGED", 1, { timeout: 30 });
-makeMCHResource("EXCAVATOR_READY", 1, { timeout: 30 });
-makeMCHResource("FULL_METAL_MACHINIST", 1, { timeout: 30 });
+makeMCHResource("HYPERCHARGED", 1, { timeout: 30, warnOnTimeout: true });
+makeMCHResource("EXCAVATOR_READY", 1, { timeout: 30, warnOnTimeout: true });
+makeMCHResource("FULL_METAL_MACHINIST", 1, { timeout: 30, warnOnTimeout: true });
 
 // Combos & other tracking
 makeMCHResource("HEAT_COMBO", 2, { timeout: 30 });
@@ -194,12 +199,6 @@ export class MCHState extends GameState {
 	}
 
 	gainResource(rscType: "HEAT_GAUGE" | "BATTERY_GAUGE", amount: number) {
-		const resource = this.resources.get(rscType);
-		if (resource.availableAmount() + amount > resource.maxValue) {
-			controller.reportWarning(
-				rscType === "HEAT_GAUGE" ? WarningType.HeatOvercap : WarningType.BatteryOvercap,
-			);
-		}
 		this.resources.get(rscType).gain(amount);
 	}
 

--- a/src/Game/Jobs/MNK.ts
+++ b/src/Game/Jobs/MNK.ts
@@ -719,9 +719,6 @@ const BLITZ_REPLACES: ConditionalSkillReplace<MNKState>[] = [
 	},
 ];
 
-const getBlitzReplacer = (i: number) =>
-	BLITZ_REPLACES.slice(0, i).concat(BLITZ_REPLACES.slice(i + 1));
-
 const clearBeastChakra: EffectFn<MNKState> = (state) => {
 	BEAST_CHAKRA_KEYS.forEach((key) => state.tryConsumeResource(key, true));
 	state.setForm("formless");
@@ -732,7 +729,7 @@ const gainNadi: (nadi: "lunar" | "solar") => EffectFn<MNKState> =
 
 makeMNKWeaponskill("MASTERFUL_BLITZ", 60, {
 	applicationDelay: 0,
-	replaceIf: getBlitzReplacer(0),
+	replaceIf: BLITZ_REPLACES,
 	validateAttempt: (state) => false,
 });
 
@@ -760,7 +757,7 @@ makeMNKWeaponskill("MASTERFUL_BLITZ", 60, {
 		...traitKey,
 		startOnHotbar: false,
 		applicationDelay,
-		replaceIf: getBlitzReplacer(4),
+		replaceIf: BLITZ_REPLACES,
 		highlightIf: (state) => true,
 		potency,
 		falloff: 0.4,
@@ -795,7 +792,7 @@ makeMNKWeaponskill("MASTERFUL_BLITZ", 60, {
 		...traitKey,
 		startOnHotbar: false,
 		applicationDelay,
-		replaceIf: getBlitzReplacer(1),
+		replaceIf: BLITZ_REPLACES,
 		highlightIf: (state) => true,
 		potency,
 		falloff: 0.4,
@@ -806,7 +803,7 @@ makeMNKWeaponskill("MASTERFUL_BLITZ", 60, {
 makeMNKWeaponskill("CELESTIAL_REVOLUTION", 60, {
 	startOnHotbar: false,
 	applicationDelay: 0.89,
-	replaceIf: getBlitzReplacer(3),
+	replaceIf: BLITZ_REPLACES,
 	highlightIf: (state) => true,
 	potency: 600,
 	onConfirm: combineEffects(clearBeastChakra, (state) =>
@@ -840,7 +837,7 @@ makeMNKWeaponskill("CELESTIAL_REVOLUTION", 60, {
 		...traitKey,
 		startOnHotbar: false,
 		applicationDelay,
-		replaceIf: getBlitzReplacer(2),
+		replaceIf: BLITZ_REPLACES,
 		highlightIf: (state) => true,
 		potency,
 		falloff: 0.4,

--- a/src/Game/Jobs/MNK.ts
+++ b/src/Game/Jobs/MNK.ts
@@ -29,7 +29,6 @@ import {
 	makeWeaponskill,
 	MakeAbilityParams,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	PotencyModifierFn,
 	SkillAutoReplace,
 	StatePredicate,
@@ -279,7 +278,7 @@ const makeMNKWeaponskill = (
 		recastTime: (state) =>
 			state.config.adjustedSksGCD(params.recastTime ?? 2.5, state.inherentSpeedModifier()),
 		onConfirm: combineEffects(
-			params.onConfirm ?? NO_EFFECT,
+			params.onConfirm,
 			name !== "SIX_SIDED_STAR" && params.potency
 				? (state, node) => {
 						const potency = node.getInitialPotency();
@@ -287,7 +286,7 @@ const makeMNKWeaponskill = (
 							state.maybeGainChakra(potency.modifiers.includes(Modifiers.AutoCrit));
 						}
 					}
-				: NO_EFFECT,
+				: undefined,
 			params.form
 				? (state) => {
 						const nextForm = params.form!.nextForm;
@@ -317,8 +316,8 @@ const makeMNKWeaponskill = (
 							state.setForm(nextForm);
 						}
 					}
-				: NO_EFFECT,
-			params.ball ? (state) => state.tryConsumeResource(params.ball!.rsc) : NO_EFFECT,
+				: undefined,
+			params.ball ? (state) => state.tryConsumeResource(params.ball!.rsc) : undefined,
 		),
 		jobPotencyModifiers: (state) => {
 			const mods = params.jobPotencyModifiers?.(state) ?? [];

--- a/src/Game/Jobs/MNK.ts
+++ b/src/Game/Jobs/MNK.ts
@@ -60,7 +60,8 @@ makeMNKResource("OPO_OPO_FORM", 1, { timeout: 30 });
 makeMNKResource("RAPTOR_FORM", 1, { timeout: 30 });
 makeMNKResource("COEURL_FORM", 1, { timeout: 30 });
 makeMNKResource("PERFECT_BALANCE", 3, { timeout: 20 });
-makeMNKResource("FORMLESS_FIST", 1, { timeout: 30 });
+// Begin combat in an indefinite formless fist.
+makeMNKResource("FORMLESS_FIST", 1, { timeout: 30, default: 1 });
 makeMNKResource("RIDDLE_OF_EARTH", 1, { timeout: 10 });
 makeMNKResource("EARTHS_RESOLVE", 1, { timeout: 15 });
 makeMNKResource("EARTHS_RUMINATION", 1, { timeout: 30 });
@@ -251,6 +252,9 @@ const makeMNKWeaponskill = (
 		: undefined;
 	return makeWeaponskill("MNK", name, unlockLevel, {
 		...params,
+		// Do not pass positional data to the constructor, since we want to compute the ball positional
+		// modifier independently.
+		positional: undefined,
 		highlightIf: (state) => {
 			// probably a more efficient way to write this expression but i'm lazy
 			if (!formCondition && !params.ball && !params.highlightIf) {

--- a/src/Game/Jobs/MNK.ts
+++ b/src/Game/Jobs/MNK.ts
@@ -39,7 +39,12 @@ import {
 const makeMNKResource = (
 	rsc: MNKResourceKey,
 	maxValue: number,
-	params?: { timeout?: number; default?: number },
+	params?: {
+		timeout?: number;
+		default?: number;
+		warnOnTimeout?: boolean;
+		warnOnOvercap?: boolean;
+	},
 ) => {
 	makeResource("MNK", rsc, maxValue, params ?? {});
 };
@@ -48,9 +53,9 @@ const makeMNKResource = (
 makeMNKResource("CHAKRA", 5, { default: 5 });
 makeMNKResource("BEAST_CHAKRA", 1);
 makeMNKResource("NADI", 1);
-makeMNKResource("OPO_OPOS_FURY", 1);
-makeMNKResource("RAPTORS_FURY", 1);
-makeMNKResource("COEURLS_FURY", 2);
+makeMNKResource("OPO_OPOS_FURY", 1, { warnOnOvercap: true });
+makeMNKResource("RAPTORS_FURY", 1, { warnOnOvercap: true });
+makeMNKResource("COEURLS_FURY", 2, { warnOnOvercap: true });
 
 // Statuses
 // extended durations taken from ama's combat sim
@@ -66,11 +71,11 @@ makeMNKResource("RIDDLE_OF_EARTH", 1, { timeout: 10 });
 makeMNKResource("EARTHS_RESOLVE", 1, { timeout: 15 });
 makeMNKResource("EARTHS_RUMINATION", 1, { timeout: 30 });
 makeMNKResource("RIDDLE_OF_FIRE", 1, { timeout: 20.72 });
-makeMNKResource("FIRES_RUMINATION", 1, { timeout: 20 });
+makeMNKResource("FIRES_RUMINATION", 1, { timeout: 20, warnOnTimeout: true });
 makeMNKResource("BROTHERHOOD", 1, { timeout: 20 });
 makeMNKResource("MEDITATIVE_BROTHERHOOD", 1, { timeout: 20 });
 makeMNKResource("RIDDLE_OF_WIND", 1, { timeout: 15.78 });
-makeMNKResource("WINDS_RUMINATION", 1, { timeout: 15 });
+makeMNKResource("WINDS_RUMINATION", 1, { timeout: 15, warnOnTimeout: true });
 makeMNKResource("SIX_SIDED_STAR", 1, { timeout: 5 });
 
 // Trackers

--- a/src/Game/Jobs/NIN.ts
+++ b/src/Game/Jobs/NIN.ts
@@ -22,7 +22,6 @@ import {
 	MakeResourceAbilityParams,
 	makeWeaponskill,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	PotencyModifierFn,
 	Skill,
 	SkillAutoReplace,
@@ -322,7 +321,7 @@ const makeNINWeaponskill = (
 				? (state) =>
 						state.tryConsumeResource("RAIJU_READY", true) &&
 						controller.reportWarning(WarningType.RaijuOverwrite)
-				: NO_EFFECT,
+				: undefined,
 			(state) => state.processComboStatus(name),
 		),
 		jobPotencyModifiers: (state) => {
@@ -779,7 +778,7 @@ tcjReplaces.forEach(
 					? (state) => state.stackRaijuReady()
 					: name === "SUITON_JIN" || name === "HUTON_TEN"
 						? (state) => state.gainStatus("SHADOW_WALKER")
-						: NO_EFFECT,
+						: undefined,
 			),
 		});
 	},
@@ -1004,12 +1003,12 @@ NINJUTSU_POTENCY_LIST.forEach(([name, level, applicationDelay, potency, falloff]
 						// gain a whole stack of shukuchi
 						state.cooldowns.get("cd_SHUKUCHI").restore(60);
 					}
-				: NO_EFFECT,
+				: undefined,
 			name === "RAITON"
 				? (state) => state.stackRaijuReady()
 				: name === "SUITON" || name === "HUTON"
 					? (state) => state.gainStatus("SHADOW_WALKER")
-					: NO_EFFECT,
+					: undefined,
 			(state) => state.clearMudraInfo(),
 		),
 		jobPotencyModifiers: (state) => {

--- a/src/Game/Jobs/NIN.ts
+++ b/src/Game/Jobs/NIN.ts
@@ -9,14 +9,13 @@ import { ActionKey, TraitKey } from "../Data";
 import { NINActionKey, NINCooldownKey, NINResourceKey } from "../Data/Jobs/NIN";
 import { GameConfig } from "../GameConfig";
 import { GameState } from "../GameState";
-import { Modifiers, makeComboModifier, makePositionalModifier } from "../Potency";
+import { Modifiers } from "../Potency";
 import { getResourceInfo, makeResource, ResourceInfo, CoolDown } from "../Resources";
 import {
 	Ability,
 	combineEffects,
 	ConditionalSkillReplace,
 	EffectFn,
-	getBasePotency,
 	makeAbility,
 	makeResourceAbility,
 	MakeResourceAbilityParams,
@@ -326,33 +325,6 @@ const makeNINWeaponskill = (
 		),
 		jobPotencyModifiers: (state) => {
 			const mods = params.jobPotencyModifiers?.(state) ?? [];
-			const hitPositional =
-				params.positional && state.hitPositional(params.positional.location);
-			// TODO refactor all this for all melee jobs
-			if (params.combo && state.hasResourceAvailable(params.combo.resource)) {
-				mods.push(
-					makeComboModifier(
-						getBasePotency(state, params.combo.potency) -
-							getBasePotency(state, params.potency),
-					),
-				);
-				// typescript isn't smart enough to elide the null check
-				if (params.positional && hitPositional) {
-					mods.push(
-						makePositionalModifier(
-							getBasePotency(state, params.positional.comboPotency) -
-								getBasePotency(state, params.combo.potency),
-						),
-					);
-				}
-			} else if (params.positional && hitPositional) {
-				mods.push(
-					makePositionalModifier(
-						getBasePotency(state, params.positional.potency) -
-							getBasePotency(state, params.potency),
-					),
-				);
-			}
 			// Kamaitachi does not consume Bunshin
 			if (state.hasResourceAvailable("BUNSHIN") && name !== "PHANTOM_KAMAITACHI") {
 				if (name === "DEATH_BLOSSOM" || name === "HAKKE_MUJINSATSU") {
@@ -409,17 +381,6 @@ const makeNINAbility = (
 		),
 		jobPotencyModifiers: (state) => {
 			const mods = params.jobPotencyModifiers?.(state) ?? [];
-			const hitPositional =
-				params.positional && state.hitPositional(params.positional.location);
-			// TODO refactor all this for all melee jobs
-			if (params.positional && hitPositional) {
-				mods.push(
-					makePositionalModifier(
-						getBasePotency(state, params.positional.potency) -
-							getBasePotency(state, params.potency),
-					),
-				);
-			}
 			if (state.hasResourceAvailable("DOKUMORI")) {
 				mods.push(Modifiers.Dokumori);
 			}

--- a/src/Game/Jobs/NIN.ts
+++ b/src/Game/Jobs/NIN.ts
@@ -678,13 +678,6 @@ const JIN_REPLACEMENTS: ConditionalSkillReplace<NINState>[] = [
 	},
 ];
 
-const getTenReplace = (skill: NINActionKey) =>
-	TEN_REPLACEMENTS.filter((replace) => replace.newSkill !== skill);
-const getChiReplace = (skill: NINActionKey) =>
-	CHI_REPLACEMENTS.filter((replace) => replace.newSkill !== skill);
-const getJinReplace = (skill: NINActionKey) =>
-	JIN_REPLACEMENTS.filter((replace) => replace.newSkill !== skill);
-
 // name, level, app delay, potency, falloff
 const NINJUTSU_POTENCY_LIST: Array<
 	[NINActionKey, number, number, number | Array<[TraitKey, number]>, number | undefined]
@@ -756,7 +749,11 @@ tcjReplaces.forEach(
 		)!;
 		const mudra = name.substring(name.length - 3);
 		const replacer =
-			mudra === "TEN" ? getTenReplace : mudra === "CHI" ? getChiReplace : getJinReplace;
+			mudra === "TEN"
+				? TEN_REPLACEMENTS
+				: mudra === "CHI"
+					? CHI_REPLACEMENTS
+					: JIN_REPLACEMENTS;
 		makeWeaponskill("NIN", name, 70, {
 			startOnHotbar: false,
 			// @ts-expect-error compiler is not smart enough to validate the destructure
@@ -766,7 +763,7 @@ tcjReplaces.forEach(
 			potency,
 			// @ts-expect-error compiler is not smart enough to validate the destructure
 			falloff,
-			replaceIf: replacer(name),
+			replaceIf: replacer,
 			validateAttempt: condition,
 			onConfirm: combineEffects(
 				(state: NINState) =>
@@ -801,7 +798,7 @@ const dotonConfirm = combineEffects(
 makeWeaponskill("NIN", "DOTON_CHI", 70, {
 	startOnHotbar: false,
 	recastTime: 1.5,
-	replaceIf: getChiReplace("DOTON_CHI"),
+	replaceIf: CHI_REPLACEMENTS,
 	validateAttempt: DOTON_TCJ_CONDITION,
 	onConfirm: (state: NINState) => state.pushMudra(2, true),
 });
@@ -810,16 +807,16 @@ makeWeaponskill("NIN", "DOTON_CHI", 70, {
 // They technically are abilities rather than weaponskills, but it is easier to code them as weaponskills.
 (
 	[
-		["TEN", 30, getTenReplace],
-		["CHI", 35, getChiReplace],
-		["JIN", 45, getJinReplace],
-	] as Array<[NINActionKey, number, (key: NINActionKey) => ConditionalSkillReplace<NINState>[]]>
+		["TEN", 30, TEN_REPLACEMENTS],
+		["CHI", 35, CHI_REPLACEMENTS],
+		["JIN", 45, JIN_REPLACEMENTS],
+	] as Array<[NINActionKey, number, ConditionalSkillReplace<NINState>[]]>
 ).forEach(([name, level, replacer], i) => {
 	makeWeaponskill("NIN", name, level, {
 		recastTime: 0.5,
 		// Nobody ever weaves under mudras because it bunnies, so just treat their animation lock the same as recast.
 		animationLock: 0.5,
-		replaceIf: replacer(name),
+		replaceIf: replacer,
 		secondaryCooldown: {
 			cdName: "cd_MUDRA",
 			cooldown: 20,

--- a/src/Game/Jobs/PCT.ts
+++ b/src/Game/Jobs/PCT.ts
@@ -20,6 +20,7 @@ import {
 import { GameState } from "../GameState";
 import { makeResource, CoolDown } from "../Resources";
 import { GameConfig } from "../GameConfig";
+import { controller } from "../../Controller/Controller";
 import { ActionNode } from "../../Controller/Record";
 import { ActionKey, TraitKey } from "../Data";
 import { PCTStatusPropsGenerator } from "../../Components/Jobs/PCT";
@@ -31,7 +32,12 @@ import { PCTResourceKey, PCTActionKey, PCTCooldownKey } from "../Data/Jobs/PCT";
 const makePCTResource = (
 	rsc: PCTResourceKey,
 	maxValue: number,
-	params?: { timeout?: number; default?: number; warnOnOvercap?: boolean },
+	params?: {
+		timeout?: number;
+		default?: number;
+		warnOnOvercap?: boolean;
+		warnOnTimeout?: boolean;
+	},
 ) => {
 	makeResource("PCT", rsc, maxValue, params ?? {});
 };
@@ -46,14 +52,14 @@ makePCTResource("PALETTE_GAUGE", 100, { warnOnOvercap: true });
 makePCTResource("PAINT", 5);
 
 makePCTResource("AETHERHUES", 2, { timeout: 30.8 });
-makePCTResource("MONOCHROME_TONES", 1, { warnOnOvercap: true });
+makePCTResource("MONOCHROME_TONES", 1);
 makePCTResource("SUBTRACTIVE_PALETTE", 3);
 makePCTResource("HAMMER_TIME", 3, { timeout: 30 });
 makePCTResource("INSPIRATION", 1, { timeout: 30 });
-makePCTResource("SUBTRACTIVE_SPECTRUM", 1, { timeout: 30 });
-makePCTResource("HYPERPHANTASIA", 5, { timeout: 30 });
-makePCTResource("RAINBOW_BRIGHT", 1, { timeout: 30 });
-makePCTResource("STARSTRUCK", 1, { timeout: 20 });
+makePCTResource("SUBTRACTIVE_SPECTRUM", 1, { timeout: 30, warnOnTimeout: true });
+makePCTResource("HYPERPHANTASIA", 5, { timeout: 30, warnOnTimeout: true });
+makePCTResource("RAINBOW_BRIGHT", 1, { timeout: 30, warnOnTimeout: true });
+makePCTResource("STARSTRUCK", 1, { timeout: 20, warnOnTimeout: true });
 makePCTResource("STARRY_MUSE", 1, { timeout: 20.5 });
 makePCTResource("TEMPERA_COAT", 1, { timeout: 10 });
 makePCTResource("TEMPERA_GRASSA", 1, { timeout: 10 });
@@ -760,6 +766,13 @@ makeAbility_PCT("SUBTRACTIVE_PALETTE", 60, "cd_SUBTRACTIVE", {
 			state.resources.get("PALETTE_GAUGE").consume(50);
 		}
 		// gain comet (caps at 1)
+		if (state.hasResourceAvailable("MONOCHROME_TONES")) {
+			controller.reportWarning({
+				kind: "custom",
+				en: "comet overwrite!",
+				zh: "彗星之黑被覆盖！",
+			});
+		}
 		if (state.hasTraitUnlocked("ENHANCED_PALETTE")) {
 			state.gainStatus("MONOCHROME_TONES");
 		}

--- a/src/Game/Jobs/PCT.ts
+++ b/src/Game/Jobs/PCT.ts
@@ -19,7 +19,7 @@ import {
 	Spell,
 	StatePredicate,
 } from "../Skills";
-import { GameState, PlayerState } from "../GameState";
+import { GameState } from "../GameState";
 import { getResourceInfo, makeResource, CoolDown, ResourceInfo } from "../Resources";
 import { GameConfig } from "../GameConfig";
 import { ActionNode } from "../../Controller/Record";
@@ -103,13 +103,13 @@ export class PCTState extends GameState {
 		return new PCTStatusPropsGenerator(this);
 	}
 
-	override jobSpecificAddDamageBuffCovers(node: ActionNode, _skill: Skill<PlayerState>): void {
+	override jobSpecificAddDamageBuffCovers(node: ActionNode, _skill: Skill<GameState>): void {
 		if (this.hasResourceAvailable("STARRY_MUSE")) {
 			node.addBuff(BuffType.StarryMuse);
 		}
 	}
 
-	override jobSpecificAddSpeedBuffCovers(node: ActionNode, skill: Skill<PlayerState>): void {
+	override jobSpecificAddSpeedBuffCovers(node: ActionNode, skill: Skill<GameState>): void {
 		if (
 			this.hasResourceAvailable("INSPIRATION") &&
 			HYPERPHANTASIA_SKILLS.includes(skill.name as PCTActionKey)

--- a/src/Game/Jobs/PCT.ts
+++ b/src/Game/Jobs/PCT.ts
@@ -1,7 +1,6 @@
 // Skill and state declarations for PCT.
 
-import { controller } from "../../Controller/Controller";
-import { BuffType, WarningType } from "../Common";
+import { BuffType } from "../Common";
 import { Modifiers, PotencyModifier } from "../Potency";
 import {
 	Ability,
@@ -32,7 +31,7 @@ import { PCTResourceKey, PCTActionKey, PCTCooldownKey } from "../Data/Jobs/PCT";
 const makePCTResource = (
 	rsc: PCTResourceKey,
 	maxValue: number,
-	params?: { timeout?: number; default?: number },
+	params?: { timeout?: number; default?: number; warnOnOvercap?: boolean },
 ) => {
 	makeResource("PCT", rsc, maxValue, params ?? {});
 };
@@ -43,11 +42,11 @@ makePCTResource("DEPICTIONS", 3);
 makePCTResource("CREATURE_CANVAS", 1, { default: 1 });
 makePCTResource("WEAPON_CANVAS", 1, { default: 1 });
 makePCTResource("LANDSCAPE_CANVAS", 1, { default: 1 });
-makePCTResource("PALETTE_GAUGE", 100);
+makePCTResource("PALETTE_GAUGE", 100, { warnOnOvercap: true });
 makePCTResource("PAINT", 5);
 
 makePCTResource("AETHERHUES", 2, { timeout: 30.8 });
-makePCTResource("MONOCHROME_TONES", 1);
+makePCTResource("MONOCHROME_TONES", 1, { warnOnOvercap: true });
 makePCTResource("SUBTRACTIVE_PALETTE", 3);
 makePCTResource("HAMMER_TIME", 3, { timeout: 30 });
 makePCTResource("INSPIRATION", 1, { timeout: 30 });
@@ -489,11 +488,7 @@ makeSpell_PCT("WATER_IN_BLUE", 15, {
 		blueCondition.condition(state) && !state.hasResourceAvailable("SUBTRACTIVE_PALETTE"),
 	onConfirm: (state) => {
 		state.doFiller();
-		const paletteGauge = state.resources.get("PALETTE_GAUGE");
-		if (paletteGauge.available(100)) {
-			controller.reportWarning(WarningType.PaletteOvercap);
-		}
-		paletteGauge.gain(25);
+		state.resources.get("PALETTE_GAUGE").gain(25);
 		if (state.hasTraitUnlocked("ENHANCED_ARTISTRY")) {
 			state.resources.get("PAINT").gain(1);
 		}
@@ -551,11 +546,7 @@ makeSpell_PCT("WATER_II_IN_BLUE", 45, {
 		blue2Condition.condition(state) && !state.hasResourceAvailable("SUBTRACTIVE_PALETTE"),
 	onConfirm: (state) => {
 		state.doFiller();
-		const paletteGauge = state.resources.get("PALETTE_GAUGE");
-		if (paletteGauge.available(100)) {
-			controller.reportWarning(WarningType.PaletteOvercap);
-		}
-		paletteGauge.gain(25);
+		state.resources.get("PALETTE_GAUGE").gain(25);
 		if (state.hasTraitUnlocked("ENHANCED_ARTISTRY")) {
 			state.resources.get("PAINT").gain(1);
 		}
@@ -769,9 +760,6 @@ makeAbility_PCT("SUBTRACTIVE_PALETTE", 60, "cd_SUBTRACTIVE", {
 			state.resources.get("PALETTE_GAUGE").consume(50);
 		}
 		// gain comet (caps at 1)
-		if (state.hasResourceAvailable("MONOCHROME_TONES")) {
-			controller.reportWarning(WarningType.CometOverwrite);
-		}
 		if (state.hasTraitUnlocked("ENHANCED_PALETTE")) {
 			state.gainStatus("MONOCHROME_TONES");
 		}

--- a/src/Game/Jobs/PCT.ts
+++ b/src/Game/Jobs/PCT.ts
@@ -13,7 +13,6 @@ import {
 	makeResourceAbility,
 	makeSpell,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	PotencyModifierFn,
 	Skill,
 	Spell,
@@ -260,8 +259,7 @@ const makeSpell_PCT = (
 			name === "HAMMER_BRUSH" ||
 			name === "POLISHING_HAMMER" ||
 			state.tryConsumeResource("SWIFTCAST");
-	}, params.onConfirm ?? NO_EFFECT);
-	const onApplication: EffectFn<PCTState> = params.onApplication ?? NO_EFFECT;
+	}, params.onConfirm);
 	return makeSpell("PCT", name, unlockLevel, {
 		replaceIf: params.replaceIf,
 		startOnHotbar: params.startOnHotbar,
@@ -292,8 +290,8 @@ const makeSpell_PCT = (
 			name === "HAMMER_BRUSH" ||
 			name === "POLISHING_HAMMER" ||
 			state.hasResourceAvailable("SWIFTCAST"),
-		onConfirm: onConfirm,
-		onApplication: onApplication,
+		onConfirm,
+		onApplication: params.onApplication,
 	});
 };
 

--- a/src/Game/Jobs/PLD.ts
+++ b/src/Game/Jobs/PLD.ts
@@ -22,7 +22,6 @@ import {
 	ResourceCalculationFn,
 	makeWeaponskill,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	PotencyModifierFn,
 	Skill,
 	Spell,
@@ -342,19 +341,18 @@ const makeWeaponskill_PLD = (
 		startsAuto?: boolean;
 	},
 ): Weaponskill<PLDState> => {
-	const onConfirm: EffectFn<PLDState> = combineEffects(params.onConfirm ?? NO_EFFECT, (state) => {
+	const onConfirm: EffectFn<PLDState> = combineEffects(params.onConfirm, (state) => {
 		// fix gcd combo state
 		if (name !== "SHIELD_LOB" && name !== "SHIELD_BASH" && name !== "GORING_BLADE") {
 			state.fixPLDPhysicalComboState(name);
 		}
 	});
-	const onApplication: EffectFn<PLDState> = params.onApplication ?? NO_EFFECT;
 	const jobPotencyMod: PotencyModifierFn<PLDState> =
 		params.jobPotencyModifiers ?? ((state) => []);
 	return makeWeaponskill("PLD", name, unlockLevel, {
 		...params,
-		onConfirm: onConfirm,
-		onApplication: onApplication,
+		onConfirm,
+		onApplication: params.onApplication,
 		startsAuto: params.startsAuto,
 		recastTime: (state) => state.config.adjustedSksGCD(),
 		jobPotencyModifiers: (state) => {
@@ -415,11 +413,7 @@ const makeSpell_PLD = (
 		} else {
 			state.tryConsumeRequiescat(name);
 		}
-	}, params.onConfirm ?? NO_EFFECT);
-	const onApplication: EffectFn<PLDState> = params.onApplication ?? NO_EFFECT;
-	const onExecute: EffectFn<PLDState> = combineEffects((state, node) => {
-		// pass
-	}, params.onExecute ?? NO_EFFECT);
+	}, params.onConfirm);
 	return makeSpell("PLD", name, unlockLevel, {
 		replaceIf: params.replaceIf,
 		startOnHotbar: params.startOnHotbar,
@@ -477,9 +471,9 @@ const makeSpell_PLD = (
 			*/
 			return state.isSpellInstant(name);
 		},
-		onConfirm: onConfirm,
-		onApplication: onApplication,
-		onExecute: onExecute,
+		onConfirm,
+		onApplication: params.onApplication,
+		onExecute: params.onExecute,
 		startsAuto: params.startsAuto,
 	});
 };

--- a/src/Game/Jobs/PLD.ts
+++ b/src/Game/Jobs/PLD.ts
@@ -415,9 +415,7 @@ const makeSpell_PLD = (
 		}
 	}, params.onConfirm);
 	return makeSpell("PLD", name, unlockLevel, {
-		replaceIf: params.replaceIf,
-		startOnHotbar: params.startOnHotbar,
-		highlightIf: params.highlightIf,
+		...params,
 		castTime: (state) => state.captureSpellCastTime(name, params.baseCastTime),
 		recastTime: (state) => state.config.adjustedGCD(),
 		manaCost: params.baseManaCost ?? 0,
@@ -457,9 +455,6 @@ const makeSpell_PLD = (
 			}
 			return mods;
 		},
-		falloff: params.falloff,
-		validateAttempt: params.validateAttempt,
-		applicationDelay: params.applicationDelay,
 		isInstantFn: (state) => {
 			/*
 			if (name !== "CLEMENCY") {
@@ -472,9 +467,6 @@ const makeSpell_PLD = (
 			return state.isSpellInstant(name);
 		},
 		onConfirm,
-		onApplication: params.onApplication,
-		onExecute: params.onExecute,
-		startsAuto: params.startsAuto,
 	});
 };
 
@@ -505,8 +497,6 @@ const makeAbility_PLD = (
 ): Ability<PLDState> => {
 	return makeAbility("PLD", name, unlockLevel, cdName, {
 		...params,
-		onConfirm: params.onConfirm,
-		startsAuto: params.startsAuto,
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = [];
 			if (state.hasResourceAvailable("FIGHT_OR_FLIGHT")) {

--- a/src/Game/Jobs/PLD.ts
+++ b/src/Game/Jobs/PLD.ts
@@ -3,7 +3,6 @@
 import { controller } from "../../Controller/Controller";
 import { BuffType, WarningType } from "../Common";
 import {
-	makeComboModifier,
 	makeRequiescatModifier,
 	makeDivineMightModifier,
 	Modifiers,
@@ -329,7 +328,6 @@ const makeWeaponskill_PLD = (
 			resourceValue: number;
 		};
 		falloff?: number;
-		jobPotencyModifiers?: PotencyModifierFn<PLDState>;
 		applicationDelay: number;
 		animationLock?: number;
 		validateAttempt?: StatePredicate<PLDState>;
@@ -347,34 +345,12 @@ const makeWeaponskill_PLD = (
 			state.fixPLDPhysicalComboState(name);
 		}
 	});
-	const jobPotencyMod: PotencyModifierFn<PLDState> =
-		params.jobPotencyModifiers ?? ((state) => []);
 	return makeWeaponskill("PLD", name, unlockLevel, {
 		...params,
 		onConfirm,
-		onApplication: params.onApplication,
-		startsAuto: params.startsAuto,
 		recastTime: (state) => state.config.adjustedSksGCD(),
-		jobPotencyModifiers: (state) => {
-			const mods: PotencyModifier[] = jobPotencyMod(state);
-			if (
-				params.combo &&
-				state.resources.get(params.combo.resource).availableAmount() ===
-					params.combo.resourceValue
-			) {
-				mods.push(
-					makeComboModifier(
-						getBasePotency(state, params.combo.potency) -
-							getBasePotency(state, params.potency),
-					),
-				);
-			}
-
-			if (state.hasResourceAvailable("FIGHT_OR_FLIGHT")) {
-				mods.push(Modifiers.FightOrFlight);
-			}
-			return mods;
-		},
+		jobPotencyModifiers: (state) =>
+			state.hasResourceAvailable("FIGHT_OR_FLIGHT") ? [Modifiers.FightOrFlight] : [],
 	});
 };
 

--- a/src/Game/Jobs/PLD.ts
+++ b/src/Game/Jobs/PLD.ts
@@ -30,7 +30,7 @@ import {
 	StatePredicate,
 	Weaponskill,
 } from "../Skills";
-import { GameState, PlayerState } from "../GameState";
+import { GameState } from "../GameState";
 import { makeResource, Event } from "../Resources";
 import { GameConfig } from "../GameConfig";
 import { ActionNode } from "../../Controller/Record";
@@ -156,7 +156,7 @@ export class PLDState extends GameState {
 		return new PLDStatusPropsGenerator(this);
 	}
 
-	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<PlayerState>): void {
+	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<GameState>): void {
 		if (this.hasResourceAvailable("FIGHT_OR_FLIGHT")) {
 			node.addBuff(BuffType.FightOrFlight);
 		}

--- a/src/Game/Jobs/PLD.ts
+++ b/src/Game/Jobs/PLD.ts
@@ -1,7 +1,7 @@
 // Skill and state declarations for PLD
 
 import { controller } from "../../Controller/Controller";
-import { BuffType, WarningType } from "../Common";
+import { BuffType } from "../Common";
 import {
 	makeRequiescatModifier,
 	makeDivineMightModifier,
@@ -41,7 +41,7 @@ import { PLDResourceKey, PLDActionKey, PLDCooldownKey } from "../Data/Jobs/PLD";
 const makePLDResource = (
 	rsc: PLDResourceKey,
 	maxValue: number,
-	params?: { timeout?: number; default?: number; warningOnTimeout?: WarningType },
+	params?: { timeout?: number; default?: number; warnOnTimeout?: boolean },
 ) => {
 	makeResource("PLD", rsc, maxValue, params ?? {});
 };
@@ -57,17 +57,17 @@ makePLDResource("HALLOWED_GROUND", 1, { timeout: 10 });
 makePLDResource("BULWARK", 1, { timeout: 10 });
 makePLDResource("GORING_BLADE_READY", 1, { timeout: 30 });
 makePLDResource("DIVINE_VEIL", 1, { timeout: 30 });
-makePLDResource("ATONEMENT_READY", 1, { timeout: 30 });
-makePLDResource("DIVINE_MIGHT", 1, { timeout: 30 });
+makePLDResource("ATONEMENT_READY", 1, { timeout: 30, warnOnTimeout: true });
+makePLDResource("DIVINE_MIGHT", 1, { timeout: 30, warnOnTimeout: true });
 makePLDResource("KNIGHTS_RESOLVE", 1, { timeout: 4 });
 makePLDResource("KNIGHTS_BENEDICTION", 1, { timeout: 12 });
-makePLDResource("REQUIESCAT", 4, { timeout: 30 });
-makePLDResource("CONFITEOR_READY", 1, { timeout: 30 });
+makePLDResource("REQUIESCAT", 4, { timeout: 30, warnOnTimeout: true });
+makePLDResource("CONFITEOR_READY", 1, { timeout: 30, warnOnTimeout: true });
 makePLDResource("PASSAGE_OF_ARMS", 1, { timeout: 18 });
-makePLDResource("SUPPLICATION_READY", 1, { timeout: 30 });
-makePLDResource("SEPULCHRE_READY", 1, { timeout: 30 });
+makePLDResource("SUPPLICATION_READY", 1, { timeout: 30, warnOnTimeout: true });
+makePLDResource("SEPULCHRE_READY", 1, { timeout: 30, warnOnTimeout: true });
 makePLDResource("HOLY_SHELTRON", 1, { timeout: 8 });
-makePLDResource("BLADE_OF_HONOR_READY", 1, { timeout: 30 });
+makePLDResource("BLADE_OF_HONOR_READY", 1, { timeout: 30, warnOnTimeout: true });
 makePLDResource("GUARDIAN", 1, { timeout: 15 });
 makePLDResource("GUARDIANS_WILL", 1, { timeout: 15 });
 

--- a/src/Game/Jobs/RDM.ts
+++ b/src/Game/Jobs/RDM.ts
@@ -1,7 +1,7 @@
 // Skill and state declarations for RDM.
 
 import { controller } from "../../Controller/Controller";
-import { Aspect, BuffType, ProcMode, WarningType } from "../Common";
+import { Aspect, BuffType, WarningType } from "../Common";
 import { makeComboModifier, Modifiers, PotencyModifier } from "../Potency";
 import {
 	Ability,
@@ -208,13 +208,7 @@ export class RDMState extends GameState {
 	}
 
 	maybeGainVerproc(proc: "VERFIRE_READY" | "VERSTONE_READY", chance: number = 0.5) {
-		const rand = this.rng();
-		if (
-			this.config.procMode === ProcMode.Always ||
-			(this.config.procMode === ProcMode.RNG && rand < chance)
-		) {
-			this.gainVerproc(proc);
-		}
+		this.maybeGainProc(proc, chance, true);
 	}
 
 	// Advance the appropriate combo resources (RDMMeleeCounter, RDMFinisherCounter, RDMAoECounter)

--- a/src/Game/Jobs/RDM.ts
+++ b/src/Game/Jobs/RDM.ts
@@ -2,13 +2,12 @@
 
 import { controller } from "../../Controller/Controller";
 import { Aspect, BuffType, WarningType } from "../Common";
-import { makeComboModifier, Modifiers, PotencyModifier } from "../Potency";
+import { Modifiers, PotencyModifier } from "../Potency";
 import {
 	Ability,
 	combineEffects,
 	ConditionalSkillReplace,
 	EffectFn,
-	getBasePotency,
 	makeAbility,
 	makeResourceAbility,
 	makeSpell,
@@ -383,18 +382,6 @@ const makeMeleeGCD = (
 		onConfirm: onConfirm,
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = [];
-			if (
-				params.combo &&
-				state.resources.get(params.combo.resource).availableAmount() ===
-					params.combo.resourceValue
-			) {
-				mods.push(
-					makeComboModifier(
-						getBasePotency(state, params.combo.potency) -
-							getBasePotency(state, params.potency),
-					),
-				);
-			}
 			if (!isPhysical) {
 				if (state.hasResourceAvailable("EMBOLDEN")) {
 					mods.push(Modifiers.EmboldenMagic);

--- a/src/Game/Jobs/RDM.ts
+++ b/src/Game/Jobs/RDM.ts
@@ -22,7 +22,7 @@ import {
 	StatePredicate,
 	Weaponskill,
 } from "../Skills";
-import { GameState, PlayerState } from "../GameState";
+import { GameState } from "../GameState";
 import { getResourceInfo, makeResource, CoolDown, Resource, ResourceInfo } from "../Resources";
 import { GameConfig } from "../GameConfig";
 import { ActionNode } from "../../Controller/Record";
@@ -117,7 +117,7 @@ export class RDMState extends GameState {
 		return new RDMStatusPropsGenerator(this);
 	}
 
-	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<PlayerState>): void {
+	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<GameState>): void {
 		if (this.hasResourceAvailable("EMBOLDEN") && skill.aspect !== Aspect.Physical) {
 			node.addBuff(BuffType.Embolden);
 		}

--- a/src/Game/Jobs/RDM.ts
+++ b/src/Game/Jobs/RDM.ts
@@ -14,7 +14,6 @@ import {
 	makeSpell,
 	makeWeaponskill,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	PotencyModifierFn,
 	Skill,
 	SkillAutoReplace,
@@ -337,7 +336,7 @@ const makeSpell_RDM = (
 		(state) => state.processManafic(),
 		// onConfirm must be checked before acceleration is consume
 		// to make sure procs are properly gained
-		params.onConfirm ?? NO_EFFECT,
+		params.onConfirm,
 		(state) => state.processDualcastAndInstants(name),
 		(state) => state.processComboStatus(name),
 	);
@@ -397,7 +396,7 @@ const makeMeleeGCD = (
 	const onConfirm: EffectFn<RDMState> = combineEffects(
 		(state) => state.processManafic(),
 		(state) => state.processComboStatus(name),
-		params.onConfirm ?? NO_EFFECT,
+		params.onConfirm,
 	);
 	return makeWeaponskill("RDM", name, unlockLevel, {
 		...params,

--- a/src/Game/Jobs/RPR.ts
+++ b/src/Game/Jobs/RPR.ts
@@ -8,7 +8,7 @@ import { CommonActionKey } from "../Data/Shared/Common";
 import { RoleActionKey } from "../Data/Shared/Role";
 import { GameConfig } from "../GameConfig";
 import { GameState } from "../GameState";
-import { makeComboModifier, makePositionalModifier, Modifiers, PotencyModifier } from "../Potency";
+import { Modifiers, PotencyModifier } from "../Potency";
 import { CoolDown, makeResource } from "../Resources";
 import {
 	Ability,
@@ -18,7 +18,6 @@ import {
 	CooldownGroupProperties,
 	EffectFn,
 	FAKE_SKILL_ANIMATION_LOCK,
-	getBasePotency,
 	getSkill,
 	makeAbility,
 	makeResourceAbility,
@@ -502,28 +501,6 @@ const makeRPRWeaponskill = (
 		onConfirm,
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = basePotencyModifiers(state);
-			if (
-				params.combo &&
-				state.resources.get(params.combo.resource).availableAmount() ===
-					params.combo.resourceValue
-			) {
-				mods.push(
-					makeComboModifier(
-						getBasePotency(state, params.combo.potency) -
-							getBasePotency(state, params.potency),
-					),
-				);
-			}
-
-			if (params.positional && state.hitPositional(params.positional.location)) {
-				mods.push(
-					makePositionalModifier(
-						getBasePotency(state, params.positional.potency) -
-							getBasePotency(state, params.potency),
-					),
-				);
-			}
-
 			if (
 				["GIBBET", "EXECUTIONERS_GIBBET"].includes(name) &&
 				state.hasResourceAvailable("ENHANCED_GIBBET")

--- a/src/Game/Jobs/RPR.ts
+++ b/src/Game/Jobs/RPR.ts
@@ -7,7 +7,7 @@ import { RPRResourceKey, RPRActionKey, RPRCooldownKey } from "../Data/Jobs/RPR";
 import { CommonActionKey } from "../Data/Shared/Common";
 import { RoleActionKey } from "../Data/Shared/Role";
 import { GameConfig } from "../GameConfig";
-import { GameState, PlayerState } from "../GameState";
+import { GameState } from "../GameState";
 import { makeComboModifier, makePositionalModifier, Modifiers, PotencyModifier } from "../Potency";
 import { CoolDown, makeResource } from "../Resources";
 import {
@@ -97,7 +97,7 @@ export class RPRState extends GameState {
 		return new RPRStatusPropsGenerator(this);
 	}
 
-	override jobSpecificAddDamageBuffCovers(node: ActionNode, _skill: Skill<PlayerState>): void {
+	override jobSpecificAddDamageBuffCovers(node: ActionNode, _skill: Skill<GameState>): void {
 		if (this.hasResourceAvailable("ARCANE_CIRCLE")) {
 			node.addBuff(BuffType.ArcaneCircle);
 		}

--- a/src/Game/Jobs/RPR.ts
+++ b/src/Game/Jobs/RPR.ts
@@ -453,8 +453,8 @@ const makeRPRSpell = (
 	return makeSpell("RPR", name, unlockLevel, {
 		...params,
 		recastTime: (state) => state.config.adjustedGCD(params.recastTime),
-		onConfirm: onConfirm,
-		validateAttempt: validateAttempt,
+		onConfirm,
+		validateAttempt,
 		isInstantFn: (state) =>
 			!(
 				name === "COMMUNIO" ||
@@ -499,7 +499,7 @@ const makeRPRWeaponskill = (
 	);
 	return makeWeaponskill("RPR", name, unlockLevel, {
 		...params,
-		onConfirm: onConfirm,
+		onConfirm,
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = basePotencyModifiers(state);
 			if (
@@ -558,7 +558,7 @@ const makeRPRWeaponskill = (
 
 			return mods;
 		},
-		validateAttempt: validateAttempt,
+		validateAttempt,
 	});
 };
 
@@ -591,8 +591,8 @@ const makeRPRAbility = (
 
 	return makeAbility("RPR", name, unlockLevel, cdName, {
 		...params,
-		onConfirm: onConfirm,
-		validateAttempt: validateAttempt,
+		onConfirm,
+		validateAttempt,
 		jobPotencyModifiers: basePotencyModifiers,
 	});
 };
@@ -634,9 +634,7 @@ makeRPRWeaponskill("WAXING_SLICE", 5, {
 	aspect: Aspect.Physical,
 	recastTime: (state) => state.config.adjustedSksGCD(),
 	applicationDelay: 0.58,
-	highlightIf: function (state: Readonly<RPRState>): boolean {
-		return state.resources.get("RPR_COMBO").availableAmount() === 1;
-	},
+	highlightIf: (state) => state.hasResourceExactly("RPR_COMBO", 1),
 });
 
 makeRPRWeaponskill("INFERNAL_SLICE", 30, {
@@ -657,9 +655,7 @@ makeRPRWeaponskill("INFERNAL_SLICE", 30, {
 	aspect: Aspect.Physical,
 	recastTime: (state) => state.config.adjustedSksGCD(),
 	applicationDelay: 0.54,
-	highlightIf: function (state: Readonly<RPRState>): boolean {
-		return state.resources.get("RPR_COMBO").availableAmount() === 2;
-	},
+	highlightIf: (state) => state.hasResourceExactly("RPR_COMBO", 2),
 });
 
 makeRPRWeaponskill("SOUL_SLICE", 60, {
@@ -790,9 +786,7 @@ makeRPRWeaponskill("PLENTIFUL_HARVEST", 88, {
 		state.hasResourceAvailable("IMMORTAL_SACRIFICE", 1) &&
 		!state.hasResourceAvailable("BLOODSOWN_CIRCLE"),
 	onConfirm: (state) => {
-		state.resources
-			.get("IMMORTAL_SACRIFICE")
-			.consume(state.resources.get("IMMORTAL_SACRIFICE").availableAmount());
+		state.tryConsumeResource("IMMORTAL_SACRIFICE", true);
 		state.setTimedResource("IDEAL_HOST", 1);
 		state.setTimedResource("PERFECTIO_OCCULTA", 1);
 	},
@@ -816,8 +810,7 @@ makeRPRSpell("COMMUNIO", 90, {
 		state.hasResourceAvailable("ENSHROUDED") &&
 		state.resources.get("LEMURE_SHROUD").availableAmount() === 1,
 	onConfirm: (state) => {
-		if (state.hasResourceAvailable("PERFECTIO_OCCULTA")) {
-			state.resources.get("PERFECTIO_OCCULTA").consume(1);
+		if (state.tryConsumeResource("PERFECTIO_OCCULTA")) {
 			state.setTimedResource("PERFECTIO_PARATA", 1);
 		}
 		state.exitEnshroud();
@@ -971,7 +964,7 @@ makeRPRAbility("SACRIFICIUM", 92, "cd_SACRIFICIUM", {
 	cooldown: 1,
 	validateAttempt: (state) => state.hasResourceAvailable("OBLATIO"),
 	highlightIf: (state) => state.hasResourceAvailable("OBLATIO"),
-	onConfirm: (state) => state.resources.get("OBLATIO").consume(1),
+	onConfirm: (state) => state.tryConsumeResource("OBLATIO"),
 });
 
 makeResourceAbility("RPR", "ARCANE_CIRCLE", 72, "cd_ARCANE_CIRCLE", {
@@ -1050,9 +1043,9 @@ makeResourceAbility("RPR", "ENSHROUD", 80, "cd_ENSHROUD", {
 	validateAttempt: (state) => {
 		return state.hasResourceAvailable("SHROUD", 50) || state.hasResourceAvailable("IDEAL_HOST");
 	},
-	onConfirm: combineEffects(baseOnConfirm("ENSHROUD"), (state: RPRState) => {
-		state.enterEnshroud();
-	}) as EffectFn<GameState>,
+	onConfirm: combineEffects(baseOnConfirm("ENSHROUD"), (state) =>
+		state.enterEnshroud(),
+	) as EffectFn<RPRState>,
 });
 
 makeRPRWeaponskill("PERFECTIO", 100, {
@@ -1130,7 +1123,7 @@ makeRPRAbility("ARCANE_CREST_POP", 40, "cd_ARCANE_CREST_POP", {
 	animationLock: FAKE_SKILL_ANIMATION_LOCK,
 	startOnHotbar: false,
 	onConfirm: (state) => {
-		state.resources.get("CREST_OF_TIME_BORROWED").consume(1);
+		state.tryConsumeResource("CREST_OF_TIME_BORROWED");
 		state.setTimedResource("CREST_OF_TIME_RETURNED", 1);
 	},
 	validateAttempt: (state) => state.hasResourceAvailable("CREST_OF_TIME_BORROWED"),
@@ -1165,9 +1158,7 @@ makeRPRWeaponskill("NIGHTMARE_SCYTHE", 45, {
 	recastTime: (state) => state.config.adjustedSksGCD(),
 	falloff: 0,
 	applicationDelay: 0.8,
-	highlightIf: function (state: Readonly<RPRState>): boolean {
-		return state.resources.get("RPR_AOE_COMBO").availableAmount() === 1;
-	},
+	highlightIf: (state) => state.hasResourceExactly("RPR_AOE_COMBO", 1),
 });
 
 makeRPRWeaponskill("SOUL_SCYTHE", 65, {

--- a/src/Game/Jobs/RPR.ts
+++ b/src/Game/Jobs/RPR.ts
@@ -25,7 +25,6 @@ import {
 	makeSpell,
 	makeWeaponskill,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	ResourceCalculationFn,
 	Skill,
 	Spell,
@@ -444,10 +443,7 @@ const makeRPRSpell = (
 		onApplication?: EffectFn<RPRState>;
 	},
 ): Spell<RPRState> => {
-	const onConfirm: EffectFn<RPRState> = combineEffects(
-		baseOnConfirm(name),
-		params.onConfirm ?? NO_EFFECT,
-	);
+	const onConfirm: EffectFn<RPRState> = combineEffects(baseOnConfirm(name), params.onConfirm);
 
 	const validateAttempt: StatePredicate<RPRState> = combinePredicatesAnd(
 		(state) => !state.resources.get("ENSHROUDED").available(1) || isEnshroudSkill(name),
@@ -495,10 +491,7 @@ const makeRPRWeaponskill = (
 		highlightIf?: StatePredicate<RPRState>;
 	},
 ): Weaponskill<RPRState> => {
-	const onConfirm: EffectFn<RPRState> = combineEffects(
-		baseOnConfirm(name),
-		params.onConfirm ?? NO_EFFECT,
-	);
+	const onConfirm: EffectFn<RPRState> = combineEffects(baseOnConfirm(name), params.onConfirm);
 
 	const validateAttempt: StatePredicate<RPRState> = combinePredicatesAnd(
 		(state) => !state.resources.get("ENSHROUDED").available(1) || isEnshroudSkill(name),
@@ -589,7 +582,7 @@ const makeRPRAbility = (
 		onApplication?: EffectFn<RPRState>;
 	},
 ): Ability<RPRState> => {
-	const onConfirm = combineEffects(baseOnConfirm(name), params.onConfirm ?? NO_EFFECT);
+	const onConfirm = combineEffects(baseOnConfirm(name), params.onConfirm);
 
 	const validateAttempt: StatePredicate<RPRState> = combinePredicatesAnd(
 		(state) => !state.resources.get("ENSHROUDED").available(1) || isEnshroudSkill(name),

--- a/src/Game/Jobs/RoleActions.ts
+++ b/src/Game/Jobs/RoleActions.ts
@@ -8,7 +8,6 @@ import {
 	ALL_JOBS,
 	JOBS,
 } from "../Data/Jobs";
-import { WarningType } from "../Common";
 import {
 	combineEffects,
 	makeAbility,
@@ -27,7 +26,7 @@ import { SHARED_LIMIT_BREAK_RESOURCES, LimitBreakResourceKey } from "../Data/Sha
 // And so do limit breaks! :(
 const cancelDualcast = (state: GameState) => {
 	if (state.job === "RDM" && state.tryConsumeResource("DUALCAST")) {
-		controller.reportWarning(WarningType.DualcastEaten);
+		controller.reportWarning({ kind: "custom", en: "dualcast dropped" });
 	}
 };
 

--- a/src/Game/Jobs/SAM.ts
+++ b/src/Game/Jobs/SAM.ts
@@ -13,7 +13,6 @@ import {
 	makeResourceAbility,
 	makeWeaponskill,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	PotencyModifierFn,
 	ResourceCalculationFn,
 	Skill,
@@ -283,7 +282,7 @@ const makeGCD_SAM = (
 		onApplication?: EffectFn<SAMState>;
 	},
 ): Weaponskill<SAMState> => {
-	const onApplication: EffectFn<SAMState> = params.onApplication ?? NO_EFFECT;
+	const onApplication: EffectFn<SAMState> | undefined = params.onApplication;
 	const jobPotencyModifiers = (state: Readonly<SAMState>) => {
 		const mods: PotencyModifier[] = state.hasResourceAvailable("FUGETSU")
 			? [state.getFugetsuModifier()]

--- a/src/Game/Jobs/SAM.ts
+++ b/src/Game/Jobs/SAM.ts
@@ -1,7 +1,7 @@
 // Skill and state declarations for SAM.
 
 import { controller } from "../../Controller/Controller";
-import { BuffType, WarningType } from "../Common";
+import { BuffType } from "../Common";
 import { Modifiers, PotencyModifier } from "../Potency";
 import {
 	Ability,
@@ -32,28 +32,32 @@ import { StatusPropsGenerator } from "../../Components/StatusDisplay";
 import { SAMResourceKey, SAMCooldownKey } from "../Data/Jobs/SAM";
 
 // === JOB GAUGE ELEMENTS AND STATUS EFFECTS ===
-const makeSAMResource = (rsc: SAMResourceKey, maxValue: number, params?: { timeout: number }) => {
+const makeSAMResource = (
+	rsc: SAMResourceKey,
+	maxValue: number,
+	params?: { timeout?: number; warnOnOvercap?: boolean; warnOnTimeout?: boolean },
+) => {
 	makeResource("SAM", rsc, maxValue, params ?? {});
 };
 
-makeSAMResource("MEIKYO_SHISUI", 3, { timeout: 20 });
+makeSAMResource("MEIKYO_SHISUI", 3, { timeout: 20, warnOnTimeout: true });
 makeSAMResource("FUGETSU", 1, { timeout: 40 });
 makeSAMResource("FUKA", 1, { timeout: 40 });
 makeSAMResource("ZANSHIN_READY", 1, { timeout: 30 });
-makeSAMResource("TENDO", 1, { timeout: 30 });
+makeSAMResource("TENDO", 1, { timeout: 30, warnOnTimeout: true });
 makeSAMResource("OGI_READY", 1, { timeout: 30 });
-makeSAMResource("TSUBAME_GAESHI_READY", 1, { timeout: 30 });
+makeSAMResource("TSUBAME_GAESHI_READY", 1, { timeout: 30, warnOnTimeout: true });
 makeSAMResource("THIRD_EYE", 1, { timeout: 4 });
 makeSAMResource("TENGENTSU", 1, { timeout: 4 });
 makeSAMResource("TENGENTSUS_FORESIGHT", 1, { timeout: 9 });
 makeSAMResource("ENHANCED_ENPI", 1, { timeout: 15 });
 makeSAMResource("MEDITATE", 1, { timeout: 15.2 }); // based on a random DSR P7 log I saw
 
-makeSAMResource("KENKI", 100);
-makeSAMResource("SETSU", 1);
-makeSAMResource("GETSU", 1);
-makeSAMResource("KA_SEN", 1);
-makeSAMResource("MEDITATION", 3);
+makeSAMResource("KENKI", 100, { warnOnOvercap: true });
+makeSAMResource("SETSU", 1, { warnOnOvercap: true });
+makeSAMResource("GETSU", 1, { warnOnOvercap: true });
+makeSAMResource("KA_SEN", 1, { warnOnOvercap: true });
+makeSAMResource("MEDITATION", 3, { warnOnOvercap: true });
 
 makeSAMResource("HIGANBANA_DOT", 1, { timeout: 60 });
 
@@ -186,25 +190,15 @@ export class SAMState extends GameState {
 	}
 
 	gainKenki(kenkiAmount: number) {
-		if (this.resources.get("KENKI").availableAmount() + kenkiAmount > 100) {
-			controller.reportWarning(WarningType.KenkiOvercap);
-		}
 		this.resources.get("KENKI").gain(kenkiAmount);
 	}
 
 	gainMeditation() {
-		if (this.resources.get("MEDITATION").availableAmount() === 3) {
-			controller.reportWarning(WarningType.MeditationOvercap);
-		}
 		this.resources.get("MEDITATION").gain(1);
 	}
 
 	gainSen(sen: SAMResourceKey) {
-		const resource = this.resources.get(sen);
-		if (resource.available(1)) {
-			controller.reportWarning(WarningType.SenOvercap);
-		}
-		resource.gain(1);
+		this.resources.get(sen).gain(1);
 	}
 
 	countSen(): number {

--- a/src/Game/Jobs/SAM.ts
+++ b/src/Game/Jobs/SAM.ts
@@ -21,7 +21,7 @@ import {
 	StatePredicate,
 	Weaponskill,
 } from "../Skills";
-import { GameState, PlayerState } from "../GameState";
+import { GameState } from "../GameState";
 import { makeResource, CoolDown, Event, EventTag } from "../Resources";
 import { GameConfig } from "../GameConfig";
 import { localizeResourceType } from "../../Components/Localization";
@@ -109,7 +109,7 @@ export class SAMState extends GameState {
 		return this.hasTraitUnlocked("ENHANCED_FUGETSU_AND_FUKA") ? 13 : 10;
 	}
 
-	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<PlayerState>): void {
+	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<GameState>): void {
 		if (this.hasResourceAvailable("ENHANCED_ENPI") && skill.name === "ENPI") {
 			node.addBuff(BuffType.EnhancedEnpi);
 		}
@@ -118,7 +118,7 @@ export class SAMState extends GameState {
 		}
 	}
 
-	override jobSpecificAddSpeedBuffCovers(node: ActionNode, skill: Skill<PlayerState>): void {
+	override jobSpecificAddSpeedBuffCovers(node: ActionNode, skill: Skill<GameState>): void {
 		if (this.hasResourceAvailable("FUKA") && skill.cdName === "cd_GCD") {
 			node.addBuff(BuffType.Fuka);
 		}

--- a/src/Game/Jobs/SAM.ts
+++ b/src/Game/Jobs/SAM.ts
@@ -267,7 +267,6 @@ const makeGCD_SAM = (
 		onApplication?: EffectFn<SAMState>;
 	},
 ): Weaponskill<SAMState> => {
-	const onApplication: EffectFn<SAMState> | undefined = params.onApplication;
 	const jobPotencyModifiers = (state: Readonly<SAMState>) => {
 		const mods: PotencyModifier[] = state.hasResourceAvailable("FUGETSU")
 			? [state.getFugetsuModifier()]
@@ -293,7 +292,6 @@ const makeGCD_SAM = (
 		potency: params.basePotency,
 		jobPotencyModifiers,
 		isInstantFn: (state) => !(params.baseCastTime && params.baseCastTime > 0),
-		onApplication,
 	});
 };
 

--- a/src/Game/Jobs/SGE.ts
+++ b/src/Game/Jobs/SGE.ts
@@ -30,7 +30,6 @@ import {
 	MakeResourceAbilityParams,
 	makeSpell,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	PotencyModifierFn,
 	ResourceCalculationFn,
 	Skill,
@@ -437,7 +436,7 @@ const makeSGESpell = (
 			}
 			state.tryConsumeResource("ZOE");
 		},
-		params.onConfirm ?? NO_EFFECT,
+		params.onConfirm,
 	);
 	return makeSpell("SGE", name, unlockLevel, {
 		...params,
@@ -457,7 +456,7 @@ const makeSGESpell = (
 			eudaimoniaPotencies.forEach((eudaimoniaPotency) => {
 				controller.resolveHealingPotency(eudaimoniaPotency);
 			});
-		}, params.onApplication ?? NO_EFFECT),
+		}, params.onApplication),
 	});
 };
 

--- a/src/Game/Jobs/SGE.ts
+++ b/src/Game/Jobs/SGE.ts
@@ -7,7 +7,7 @@ import { Aspect, BuffType } from "../Common";
 import { RESOURCES } from "../Data";
 import { SGEResourceKey, SGEActionKey, SGECooldownKey } from "../Data/Jobs/SGE";
 import { GameConfig } from "../GameConfig";
-import { GameState, PlayerState } from "../GameState";
+import { GameState } from "../GameState";
 import { Modifiers, Potency, PotencyModifier } from "../Potency";
 import {
 	CoolDown,
@@ -181,7 +181,7 @@ export class SGEState extends GameState {
 		recurringAddersgallGain(this.resources.get("ADDERSGALL"));
 	}
 
-	override jobSpecificAddHealingBuffCovers(node: ActionNode, skill: Skill<PlayerState>): void {
+	override jobSpecificAddHealingBuffCovers(node: ActionNode, skill: Skill<GameState>): void {
 		if (this.hasResourceAvailable("AUTOPHYSIS")) {
 			node.addBuff(BuffType.Autophysis);
 		}

--- a/src/Game/Jobs/SMN.ts
+++ b/src/Game/Jobs/SMN.ts
@@ -431,19 +431,16 @@ const makeAbility_SMN = (
 	},
 ): Ability<SMNState> =>
 	makeAbility("SMN", name, unlockLevel, cdName, {
+		...params,
 		jobPotencyModifiers: (state) =>
 			state.hasResourceAvailable("SEARING_LIGHT") ? [Modifiers.SearingLight] : [],
-		...params,
 	});
 
-// manual stand-in for toSpliced, available in ES2023
-function toSpliced<T>(arr: T[], i: number): T[] {
-	const newArr = arr.slice();
-	newArr.splice(i, 1);
-	return newArr;
-}
-
 const R3_REPLACE_LIST: ConditionalSkillReplace<SMNState>[] = [
+	{
+		newSkill: "RUIN_III",
+		condition: (state) => state.activeDemi === ActiveDemiValue.NONE,
+	},
 	{
 		newSkill: "ASTRAL_IMPULSE",
 		condition: (state) => state.activeDemi === ActiveDemiValue.BAHAMUT,
@@ -476,9 +473,9 @@ makeSpell_SMN("ASTRAL_IMPULSE", 58, {
 		["ARCANE_MASTERY", 500],
 	],
 	manaCost: 300,
-	replaceIf: toSpliced(R3_REPLACE_LIST, 0),
+	replaceIf: R3_REPLACE_LIST,
 	applicationDelay: 0.67,
-	validateAttempt: R3_REPLACE_LIST[0].condition,
+	validateAttempt: R3_REPLACE_LIST[1].condition,
 	startOnHotbar: false,
 });
 
@@ -488,22 +485,26 @@ makeSpell_SMN("FOUNTAIN_OF_FIRE", 80, {
 		["ARCANE_MASTERY", 580],
 	],
 	manaCost: 300,
-	replaceIf: toSpliced(R3_REPLACE_LIST, 1),
+	replaceIf: R3_REPLACE_LIST,
 	applicationDelay: 1.07,
-	validateAttempt: R3_REPLACE_LIST[1].condition,
+	validateAttempt: R3_REPLACE_LIST[2].condition,
 	startOnHotbar: false,
 });
 
 makeSpell_SMN("UMBRAL_IMPULSE", 100, {
 	basePotency: 620,
 	manaCost: 300,
-	replaceIf: toSpliced(R3_REPLACE_LIST, 2),
+	replaceIf: R3_REPLACE_LIST,
 	applicationDelay: 0.8,
-	validateAttempt: R3_REPLACE_LIST[2].condition,
+	validateAttempt: R3_REPLACE_LIST[3].condition,
 	startOnHotbar: false,
 });
 
 const OUTBURST_REPLACE_LIST: ConditionalSkillReplace<SMNState>[] = [
+	{
+		newSkill: "OUTBURST",
+		condition: (state) => state.activeDemi === ActiveDemiValue.NONE,
+	},
 	{
 		newSkill: "ASTRAL_FLARE",
 		condition: (state) => state.activeDemi === ActiveDemiValue.BAHAMUT,
@@ -547,9 +548,9 @@ makeSpell_SMN("TRI_DISASTER", 74, {
 makeSpell_SMN("ASTRAL_FLARE", 58, {
 	basePotency: 180,
 	manaCost: 300,
-	replaceIf: toSpliced(OUTBURST_REPLACE_LIST, 0),
+	replaceIf: OUTBURST_REPLACE_LIST,
 	applicationDelay: 0.54,
-	validateAttempt: OUTBURST_REPLACE_LIST[0].condition,
+	validateAttempt: OUTBURST_REPLACE_LIST[1].condition,
 	falloff: 0,
 	startOnHotbar: false,
 });
@@ -557,9 +558,9 @@ makeSpell_SMN("ASTRAL_FLARE", 58, {
 makeSpell_SMN("BRAND_OF_PURGATORY", 80, {
 	basePotency: 240,
 	manaCost: 300,
-	replaceIf: toSpliced(OUTBURST_REPLACE_LIST, 1),
+	replaceIf: OUTBURST_REPLACE_LIST,
 	applicationDelay: 0.8,
-	validateAttempt: OUTBURST_REPLACE_LIST[1].condition,
+	validateAttempt: OUTBURST_REPLACE_LIST[2].condition,
 	falloff: 0,
 	startOnHotbar: false,
 });
@@ -567,7 +568,7 @@ makeSpell_SMN("BRAND_OF_PURGATORY", 80, {
 makeSpell_SMN("UMBRAL_FLARE", 100, {
 	basePotency: 280,
 	manaCost: 300,
-	replaceIf: toSpliced(OUTBURST_REPLACE_LIST, 2),
+	replaceIf: OUTBURST_REPLACE_LIST,
 	applicationDelay: 0.53,
 	validateAttempt: OUTBURST_REPLACE_LIST[2].condition,
 	falloff: 0,
@@ -913,7 +914,7 @@ const DEMI_COOLDOWN_GROUP: CooldownGroupProperties = {
 ].forEach((info, i) =>
 	makeSpell_SMN(info.name as SMNActionKey, info.level, {
 		applicationDelay: 0.76,
-		replaceIf: toSpliced(DEMI_REPLACE_LIST, i),
+		replaceIf: DEMI_REPLACE_LIST,
 		secondaryCooldown: DEMI_COOLDOWN_GROUP,
 		validateAttempt: (state) => !state.hasActivePet && state.nextDemi === info.activeValue,
 		drawsAggro: true,
@@ -1126,7 +1127,7 @@ makeAbility_SMN("DEATHFLARE", 60, "cd_ASTRAL_FLOW", {
 	potency: 500,
 	applicationDelay: 0.8,
 	cooldown: 20,
-	replaceIf: toSpliced(ASTRAL_FLOW_REPLACE_LIST, 0),
+	replaceIf: ASTRAL_FLOW_REPLACE_LIST,
 	highlightIf: (state) => true,
 	validateAttempt: ASTRAL_FLOW_REPLACE_LIST[0].condition,
 	falloff: 0.5,
@@ -1136,7 +1137,7 @@ makeAbility_SMN("DEATHFLARE", 60, "cd_ASTRAL_FLOW", {
 makeAbility_SMN("REKINDLE", 80, "cd_ASTRAL_FLOW", {
 	applicationDelay: 1.03,
 	cooldown: 20,
-	replaceIf: toSpliced(ASTRAL_FLOW_REPLACE_LIST, 1),
+	replaceIf: ASTRAL_FLOW_REPLACE_LIST,
 	highlightIf: (state) => true,
 	validateAttempt: ASTRAL_FLOW_REPLACE_LIST[1].condition,
 	onConfirm: (state) => state.gainStatus("REKINDLE"),
@@ -1147,7 +1148,7 @@ makeAbility_SMN("SUNFLARE", 100, "cd_ASTRAL_FLOW", {
 	potency: 800,
 	applicationDelay: 0.8,
 	cooldown: 20,
-	replaceIf: toSpliced(ASTRAL_FLOW_REPLACE_LIST, 2),
+	replaceIf: ASTRAL_FLOW_REPLACE_LIST,
 	highlightIf: (state) => true,
 	validateAttempt: ASTRAL_FLOW_REPLACE_LIST[2].condition,
 	falloff: 0.5,
@@ -1160,7 +1161,7 @@ makeSpell_SMN("CRIMSON_CYCLONE", 86, {
 		["ARCANE_MASTERY", 490],
 	],
 	applicationDelay: 0.8,
-	replaceIf: toSpliced(ASTRAL_FLOW_REPLACE_LIST, 3),
+	replaceIf: ASTRAL_FLOW_REPLACE_LIST,
 	highlightIf: (state) => true,
 	validateAttempt: ASTRAL_FLOW_REPLACE_LIST[3].condition,
 	onConfirm: (state) => {
@@ -1177,7 +1178,7 @@ makeSpell_SMN("CRIMSON_STRIKE", 86, {
 		["ARCANE_MASTERY", 490],
 	],
 	applicationDelay: 0.76,
-	replaceIf: toSpliced(ASTRAL_FLOW_REPLACE_LIST, 4),
+	replaceIf: ASTRAL_FLOW_REPLACE_LIST,
 	highlightIf: (state) => true,
 	validateAttempt: ASTRAL_FLOW_REPLACE_LIST[4].condition,
 	onConfirm: (state) => state.tryConsumeResource("CRIMSON_STRIKE_READY"),
@@ -1192,7 +1193,7 @@ makeAbility_SMN("MOUNTAIN_BUSTER", 86, "cd_MOUNTAIN_BUSTER", {
 	],
 	cooldown: 1,
 	applicationDelay: 0.76,
-	replaceIf: toSpliced(ASTRAL_FLOW_REPLACE_LIST, 5),
+	replaceIf: ASTRAL_FLOW_REPLACE_LIST,
 	highlightIf: (state) => true,
 	validateAttempt: ASTRAL_FLOW_REPLACE_LIST[5].condition,
 	onConfirm: (state) => state.tryConsumeResource("TITANS_FAVOR"),
@@ -1208,7 +1209,7 @@ makeSpell_SMN("SLIPSTREAM", 86, {
 		["ARCANE_MASTERY", 490],
 	],
 	applicationDelay: 1.02,
-	replaceIf: toSpliced(ASTRAL_FLOW_REPLACE_LIST, 6),
+	replaceIf: ASTRAL_FLOW_REPLACE_LIST,
 	highlightIf: (state) => true,
 	validateAttempt: ASTRAL_FLOW_REPLACE_LIST[6].condition,
 	onConfirm: (state, node) => {
@@ -1266,7 +1267,7 @@ const ENKINDLE_REPLACE_LIST: ConditionalSkillReplace<SMNState>[] = [
 	makeAbility_SMN(info.name as SMNActionKey, info.level, "cd_ENKINDLE", {
 		applicationDelay: 0,
 		cooldown: 20,
-		replaceIf: toSpliced(ENKINDLE_REPLACE_LIST, i),
+		replaceIf: ENKINDLE_REPLACE_LIST,
 		validateAttempt: (state) => state.activeDemi === info.activeValue,
 		onConfirm: (state, node) => state.queueEnkindle(node, info.name as SMNActionKey),
 		startOnHotbar: i === 0,

--- a/src/Game/Jobs/SMN.ts
+++ b/src/Game/Jobs/SMN.ts
@@ -19,7 +19,7 @@ import {
 	Spell,
 	StatePredicate,
 } from "../Skills";
-import { GameState, PlayerState } from "../GameState";
+import { GameState } from "../GameState";
 import { makeResource, CoolDown, Event, OverTimeBuff } from "../Resources";
 import { GameConfig } from "../GameConfig";
 import { ActionNode } from "../../Controller/Record";
@@ -155,7 +155,7 @@ export class SMNState extends GameState {
 		return new SMNStatusPropsGenerator(this);
 	}
 
-	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<PlayerState>): void {
+	override jobSpecificAddDamageBuffCovers(node: ActionNode, skill: Skill<GameState>): void {
 		if (this.hasResourceAvailable("SEARING_LIGHT")) {
 			node.addBuff(BuffType.SearingLight);
 		}

--- a/src/Game/Jobs/SMN.ts
+++ b/src/Game/Jobs/SMN.ts
@@ -13,7 +13,6 @@ import {
 	makeAbility,
 	makeResourceAbility,
 	makeSpell,
-	NO_EFFECT,
 	Skill,
 	SkillAutoReplace,
 	Spell,
@@ -389,10 +388,7 @@ const makeSpell_SMN = (
 	const baseRecastTime = params.baseRecastTime ?? 2.5;
 	const onConfirm: EffectFn<SMNState> | undefined =
 		baseCastTime > 0
-			? combineEffects(
-					(state) => state.tryConsumeResource("SWIFTCAST"),
-					params.onConfirm ?? NO_EFFECT,
-				)
+			? combineEffects((state) => state.tryConsumeResource("SWIFTCAST"), params.onConfirm)
 			: params.onConfirm;
 	return makeSpell("SMN", name, unlockLevel, {
 		...params,

--- a/src/Game/Jobs/WAR.ts
+++ b/src/Game/Jobs/WAR.ts
@@ -6,7 +6,7 @@ import { TraitKey, CooldownKey } from "../Data";
 import { WARResourceKey, WARActionKey } from "../Data/Jobs/WAR";
 import { GameConfig } from "../GameConfig";
 import { GameState } from "../GameState";
-import { makeComboModifier, Modifiers, PotencyModifier } from "../Potency";
+import { Modifiers, PotencyModifier } from "../Potency";
 import { CoolDown, Event, getResourceInfo, makeResource, ResourceInfo } from "../Resources";
 import {
 	Ability,
@@ -14,7 +14,6 @@ import {
 	ConditionalSkillReplace,
 	CooldownGroupProperties,
 	EffectFn,
-	getBasePotency,
 	makeAbility,
 	makeResourceAbility,
 	makeWeaponskill,
@@ -134,7 +133,7 @@ export class WARState extends GameState {
 	}
 
 	hasComboStatus(comboName: "STORM_COMBO" | "TEMPEST_COMBO", state: number): boolean {
-		return this.resources.get(comboName).availableAmount() === state;
+		return this.hasResourceExactly(comboName, state);
 	}
 
 	gainBeastGauge(amount: number) {
@@ -239,17 +238,6 @@ const makeWeaponskill_WAR = (
 		recastTime: (state) => state.config.adjustedSksGCD(),
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = jobPotencyMod(state);
-			if (
-				params.combo &&
-				state.hasComboStatus(params.combo.resource, params.combo.resourceValue)
-			) {
-				mods.push(
-					makeComboModifier(
-						getBasePotency(state, params.combo.potency) -
-							getBasePotency(state, params.potency),
-					),
-				);
-			}
 			if (state.hasResourceAvailable("SURGING_TEMPEST")) {
 				mods.push(Modifiers.SurgingTempest);
 			}

--- a/src/Game/Jobs/WAR.ts
+++ b/src/Game/Jobs/WAR.ts
@@ -19,7 +19,6 @@ import {
 	makeResourceAbility,
 	makeWeaponskill,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	PotencyModifierFn,
 	SkillAutoReplace,
 	StatePredicate,
@@ -214,7 +213,7 @@ const makeWeaponskill_WAR = (
 	},
 ): Weaponskill<WARState> => {
 	const onConfirm: EffectFn<WARState> = combineEffects(
-		params.onConfirm ?? NO_EFFECT,
+		params.onConfirm,
 		(state) => state.processComboStatus(name),
 		// All Weaponskills affected by Inner Release will consume Inner Release stacks
 		// and grant Burgeoning Fury stacks.
@@ -232,13 +231,12 @@ const makeWeaponskill_WAR = (
 			}
 		},
 	);
-	const onApplication: EffectFn<WARState> = params.onApplication ?? NO_EFFECT;
 	const jobPotencyMod: PotencyModifierFn<WARState> =
 		params.jobPotencyModifiers ?? ((state) => []);
 	return makeWeaponskill("WAR", name, unlockLevel, {
 		...params,
-		onConfirm: onConfirm,
-		onApplication: onApplication,
+		onConfirm,
+		onApplication: params.onApplication,
 		recastTime: (state) => state.config.adjustedSksGCD(),
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = jobPotencyMod(state);

--- a/src/Game/Jobs/WAR.ts
+++ b/src/Game/Jobs/WAR.ts
@@ -236,7 +236,6 @@ const makeWeaponskill_WAR = (
 	return makeWeaponskill("WAR", name, unlockLevel, {
 		...params,
 		onConfirm,
-		onApplication: params.onApplication,
 		recastTime: (state) => state.config.adjustedSksGCD(),
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = jobPotencyMod(state);
@@ -286,7 +285,6 @@ const makeAbility_WAR = (
 ): Ability<WARState> => {
 	return makeAbility("WAR", name, unlockLevel, cdName, {
 		...params,
-		onConfirm: params.onConfirm,
 		jobPotencyModifiers: (state) => {
 			const mods: PotencyModifier[] = [];
 			if (state.hasResourceAvailable("SURGING_TEMPEST")) {

--- a/src/Game/Jobs/WHM.ts
+++ b/src/Game/Jobs/WHM.ts
@@ -20,7 +20,6 @@ import {
 	MakeResourceAbilityParams,
 	makeSpell,
 	MOVEMENT_SKILL_ANIMATION_LOCK,
-	NO_EFFECT,
 	PotencyModifierFn,
 	Skill,
 	SkillAutoReplace,
@@ -240,12 +239,12 @@ const makeWHMSpell = (
 		jobHealingPotencyModifiers,
 		onConfirm: combineEffects(
 			(state) => state.tryConsumeResource("THIN_AIR"),
-			params.baseCastTime ? (state) => state.tryConsumeResource("SWIFTCAST") : NO_EFFECT,
-			params.onConfirm ?? NO_EFFECT,
+			params.baseCastTime ? (state) => state.tryConsumeResource("SWIFTCAST") : undefined,
+			params.onConfirm,
 		),
 		onApplication: combineEffects(
-			params.potency ? (state) => state.startLilyTimer() : NO_EFFECT,
-			params.onApplication ?? NO_EFFECT,
+			params.potency ? (state) => state.startLilyTimer() : undefined,
+			params.onApplication,
 		),
 	});
 };

--- a/src/Game/Jobs/WHM.ts
+++ b/src/Game/Jobs/WHM.ts
@@ -7,7 +7,7 @@ import { BuffType, ProcMode } from "../Common";
 import { TraitKey } from "../Data";
 import { WHMActionKey, WHMCooldownKey, WHMResourceKey } from "../Data/Jobs/WHM";
 import { GameConfig } from "../GameConfig";
-import { GameState, PlayerState } from "../GameState";
+import { GameState } from "../GameState";
 import { Modifiers, PotencyModifier } from "../Potency";
 import { makeResource, CoolDown } from "../Resources";
 import {
@@ -138,7 +138,7 @@ export class WHMState extends GameState {
 		}
 	}
 
-	override jobSpecificAddHealingBuffCovers(node: ActionNode, skill: Skill<PlayerState>): void {
+	override jobSpecificAddHealingBuffCovers(node: ActionNode, skill: Skill<GameState>): void {
 		if (this.hasTraitUnlocked("ENHANCED_ASYLUM") && this.hasResourceAvailable("ASYLUM")) {
 			node.addBuff(BuffType.Asylum);
 		}

--- a/src/Game/Jobs/WHM.ts
+++ b/src/Game/Jobs/WHM.ts
@@ -3,7 +3,7 @@
 import { WHMStatusPropsGenerator } from "../../Components/Jobs/WHM";
 import { StatusPropsGenerator } from "../../Components/StatusDisplay";
 import { ActionNode } from "../../Controller/Record";
-import { BuffType, ProcMode } from "../Common";
+import { BuffType } from "../Common";
 import { TraitKey } from "../Data";
 import { WHMActionKey, WHMCooldownKey, WHMResourceKey } from "../Data/Jobs/WHM";
 import { GameConfig } from "../GameConfig";
@@ -486,16 +486,7 @@ makeWHMSpell("CURE", 2, {
 	],
 	baseCastTime: 1.5,
 	manaCost: 400,
-	onConfirm: (state) => {
-		const rand = state.rng();
-		const chance = 0.15;
-		if (
-			state.config.procMode === ProcMode.Always ||
-			(state.config.procMode === ProcMode.RNG && rand < chance)
-		) {
-			state.gainStatus("FREECURE");
-		}
-	},
+	onConfirm: (state) => state.maybeGainProc("FREECURE", 0.15),
 });
 
 makeWHMSpell("CURE_II", 30, {

--- a/src/Game/Jobs/WHM.ts
+++ b/src/Game/Jobs/WHM.ts
@@ -34,7 +34,12 @@ import { localize } from "../../Components/Localization";
 const makeWHMResource = (
 	rsc: WHMResourceKey,
 	maxValue: number,
-	params?: { timeout?: number; default?: number },
+	params?: {
+		timeout?: number;
+		default?: number;
+		warnOnTimeout?: boolean;
+		warnOnOvercap?: boolean;
+	},
 ) => {
 	makeResource("WHM", rsc, maxValue, params ?? {});
 };
@@ -42,12 +47,12 @@ const makeWHMResource = (
 // Gauge resources
 makeWHMResource("LILLIES", 3);
 makeWHMResource("LILY_TIMER", 1);
-makeWHMResource("BLOOD_LILY", 3);
+makeWHMResource("BLOOD_LILY", 3, { warnOnOvercap: true });
 
 // Statuses
 makeWHMResource("FREECURE", 1, { timeout: 15 });
 makeWHMResource("PRESENCE_OF_MIND", 1, { timeout: 15 });
-makeWHMResource("SACRED_SIGHT", 3, { timeout: 30 });
+makeWHMResource("SACRED_SIGHT", 3, { timeout: 30, warnOnTimeout: true });
 makeWHMResource("REGEN", 1, { timeout: 18 });
 makeWHMResource("AERO_II", 1, { timeout: 30 });
 makeWHMResource("MEDICA_II", 1, { timeout: 15 });

--- a/src/Game/Skills.ts
+++ b/src/Game/Skills.ts
@@ -44,6 +44,9 @@ export type StatePredicate<T> = (state: Readonly<T>) => boolean;
 export type EffectFn<T> = (state: T, node: ActionNode) => void;
 export type PotencyModifierFn<T> = (state: Readonly<T>) => PotencyModifier[];
 
+// empty function
+export function NO_EFFECT<T extends GameState>(state: T, node: ActionNode) {}
+
 /**
  * Create a new EffectFn that performs f1 followed by each function in fs.
  */
@@ -148,14 +151,14 @@ interface BaseSkill<T extends GameState> {
 	//
 	// Universal effects like MP consumption and queueing the damage application event should not
 	// be specified here, and are automatically handled in GameState.useSkill.
-	readonly onConfirm?: EffectFn<T>;
+	readonly onConfirm: EffectFn<T>;
 
 	// Perform events at skill application. This function should always be called `applicationDelay`
 	// simulation seconds after `onConfirm`, assuming `onConfirm` did not produce any errors.
 	//
 	// Universal effects like damage application should not be specified here, and are automatically
 	// handled in GameState.useSkill.
-	readonly onApplication?: EffectFn<T>;
+	readonly onApplication: EffectFn<T>;
 
 	// The simulation delay, in seconds, between which `onConfirm` and `onApplication` are called.
 	readonly applicationDelay: number;
@@ -426,7 +429,7 @@ export function makeSpell<T extends GameState>(
 		validateAttempt: params.validateAttempt ?? ((state) => true),
 		isInstantFn: params.isInstantFn ?? ((state) => false), // Spells should be assumed to have a cast time unless otherwise specified
 		onExecute,
-		onConfirm: params.onConfirm,
+		onConfirm: params.onConfirm ?? NO_EFFECT,
 		onApplication,
 		applicationDelay: params.applicationDelay ?? 0,
 		startsAuto: params.startsAuto ?? false,
@@ -485,7 +488,7 @@ export function makeWeaponskill<T extends GameState>(
 		validateAttempt: params.validateAttempt ?? ((state) => true),
 		isInstantFn: params.isInstantFn ?? ((state) => true), // Weaponskills should be assumed to be instant unless otherwise specified
 		onExecute,
-		onConfirm: params.onConfirm,
+		onConfirm: params.onConfirm ?? NO_EFFECT,
 		onApplication,
 		applicationDelay: params.applicationDelay ?? 0,
 		startsAuto: params.startsAuto ?? true,
@@ -573,7 +576,7 @@ export function makeAbility<T extends GameState>(
 		applicationDelay: params.applicationDelay ?? 0,
 		validateAttempt,
 		onExecute,
-		onConfirm: params.onConfirm,
+		onConfirm: params.onConfirm ?? NO_EFFECT,
 		onApplication,
 		startsAuto: params.startsAuto ?? false,
 	};
@@ -694,8 +697,8 @@ export function makeLimitBreak<T extends GameState>(
 		applicationDelay: params.applicationDelay ?? 0,
 		validateAttempt: params.validateAttempt ?? ((state) => true),
 		onExecute,
-		onConfirm: params.onConfirm,
-		onApplication: params.onApplication,
+		onConfirm: params.onConfirm ?? NO_EFFECT,
+		onApplication: params.onApplication ?? NO_EFFECT,
 		startsAuto: false,
 	};
 	jobs.forEach((job) => setSkill(job, info.name, info));

--- a/src/Game/Skills.ts
+++ b/src/Game/Skills.ts
@@ -756,7 +756,8 @@ export function getConditionalReplacement<T extends GameState>(
 	const skill = getSkill(state.job, key);
 	for (const candidate of skill.replaceIf) {
 		if (candidate.newSkill === key) {
-			console.error(`Skill ${key} tried to replace itself with the same skill`);
+			// Ignore if the replacement would try to produce the original skill.
+			continue;
 		}
 		const candidateSkill = getSkill(state.job, candidate.newSkill);
 		if (!candidateSkill) {

--- a/src/Game/Skills.ts
+++ b/src/Game/Skills.ts
@@ -1,6 +1,6 @@
 import { Aspect, LevelSync } from "./Common";
 import { ActionNode } from "../Controller/Record";
-import { PlayerState, GameState } from "./GameState";
+import { GameState, GameState } from "./GameState";
 import { makeCooldown, getResourceInfo, ResourceInfo } from "./Resources";
 import { PotencyModifier } from "./Potency";
 import { ShellJob, ALL_JOBS } from "./Data/Jobs";
@@ -27,7 +27,7 @@ export type SkillAutoReplace = {
 // satisfied the level requirement of the replacing skill is always checked before the condition;
 // multiple replacements for a single skill should have disjoint conditions.
 // This replacement check is NOT performed recursively.
-export type ConditionalSkillReplace<T extends PlayerState> = {
+export type ConditionalSkillReplace<T extends GameState> = {
 	newSkill: ActionKey;
 	condition: (state: Readonly<T>) => boolean;
 };
@@ -45,12 +45,12 @@ export type EffectFn<T> = (state: T, node: ActionNode) => void;
 export type PotencyModifierFn<T> = (state: Readonly<T>) => PotencyModifier[];
 
 // empty function
-export function NO_EFFECT<T extends PlayerState>(state: T, node: ActionNode) {}
+export function NO_EFFECT<T extends GameState>(state: T, node: ActionNode) {}
 
 /**
  * Create a new EffectFn that performs f1 followed by each function in fs.
  */
-export function combineEffects<T extends PlayerState>(
+export function combineEffects<T extends GameState>(
 	f1: EffectFn<T>,
 	...fs: Array<EffectFn<T>>
 ): EffectFn<T> {
@@ -62,7 +62,7 @@ export function combineEffects<T extends PlayerState>(
 	};
 }
 
-export function combinePredicatesAnd<T extends PlayerState>(
+export function combinePredicatesAnd<T extends GameState>(
 	f1: StatePredicate<T>,
 	...fs: Array<StatePredicate<T>>
 ): StatePredicate<T> {
@@ -80,7 +80,7 @@ export interface CooldownGroupProperties {
  *
  * Use the `Skill` type in type annotations instead of this interface.
  */
-interface BaseSkill<T extends PlayerState> {
+interface BaseSkill<T extends GameState> {
 	// === COSMETIC PROPERTIES ===
 	readonly name: ActionKey;
 	readonly assetPath: string; // path relative to the Components/Asset/Skills folder
@@ -164,7 +164,7 @@ interface BaseSkill<T extends PlayerState> {
 	readonly startsAuto: boolean;
 }
 
-export type GCD<T extends PlayerState> = BaseSkill<T> & {
+export type GCD<T extends GameState> = BaseSkill<T> & {
 	// GCDs have cast/recast + MP cost, but oGCDs do not.
 	// The only exception is BLU (as far as I [sz] know). Let us pray we never cross that particular bridge.
 	readonly castTimeFn: ResourceCalculationFn<T>;
@@ -174,20 +174,20 @@ export type GCD<T extends PlayerState> = BaseSkill<T> & {
 	readonly isInstantFn: StatePredicate<T>;
 };
 
-export type Spell<T extends PlayerState> = GCD<T> & {
+export type Spell<T extends GameState> = GCD<T> & {
 	kind: "spell";
 };
 
-export type Weaponskill<T extends PlayerState> = GCD<T> & {
+export type Weaponskill<T extends GameState> = GCD<T> & {
 	kind: "weaponskill";
 };
 
-export type Ability<T extends PlayerState> = BaseSkill<T> & {
+export type Ability<T extends GameState> = BaseSkill<T> & {
 	kind: "ability";
 };
 
 // Limit breaks (mostly) have a cast time but don't otherwise actually interact with the GCD
-export type LimitBreak<T extends PlayerState> = BaseSkill<T> & {
+export type LimitBreak<T extends GameState> = BaseSkill<T> & {
 	kind: "limitbreak";
 	readonly castTimeFn: ResourceCalculationFn<T>;
 };
@@ -206,13 +206,13 @@ export type LimitBreak<T extends PlayerState> = BaseSkill<T> & {
  *   // castTimeFn, recastTimeFn, etc. are valid here
  * }
  */
-export type Skill<T extends PlayerState> = Spell<T> | Weaponskill<T> | Ability<T> | LimitBreak<T>;
+export type Skill<T extends GameState> = Spell<T> | Weaponskill<T> | Ability<T> | LimitBreak<T>;
 
 // Map tracking skills for each job.
 // This is automatically populated by the makeWeaponskill, makeSpell, and makeAbility helper functions.
 // Unfortunately, I [sz] don't really know of a good way to encode the relationship between
 // the ShellJob and Skill<T>, so we'll just have to live with performing casts at certain locations.
-const skillMap: Map<ShellJob, Map<ActionKey, Skill<PlayerState>>> = new Map();
+const skillMap: Map<ShellJob, Map<ActionKey, Skill<GameState>>> = new Map();
 // Track asset paths for all skills so we can load icons for multiple timelines
 const skillAssetPaths: Map<ActionKey, string> = new Map();
 
@@ -248,7 +248,7 @@ export function getResourceKeyFromBuffName(s: string): ResourceKey | undefined {
 
 // Return a particular skill for a job.
 // Raises if the skill is not found.
-export function getSkill<T extends PlayerState>(job: ShellJob, skillName: ActionKey): Skill<T> {
+export function getSkill<T extends GameState>(job: ShellJob, skillName: ActionKey): Skill<T> {
 	return skillMap.get(job)!.get(skillName)!;
 }
 
@@ -262,12 +262,12 @@ export function jobHasSkill(job: ShellJob, skillName: ActionKey): boolean {
 }
 
 // Return the map of all skills for a job.
-export function getAllSkills<T extends PlayerState>(job: ShellJob): Map<ActionKey, Skill<T>> {
+export function getAllSkills<T extends GameState>(job: ShellJob): Map<ActionKey, Skill<T>> {
 	return skillMap.get(job)!;
 }
 
-function setSkill<T extends PlayerState>(job: ShellJob, skillName: ActionKey, skill: Skill<T>) {
-	skillMap.get(job)!.set(skillName, skill as Skill<PlayerState>);
+function setSkill<T extends GameState>(job: ShellJob, skillName: ActionKey, skill: Skill<T>) {
+	skillMap.get(job)!.set(skillName, skill as Skill<GameState>);
 	normalizedSkillNameMap.set(ACTIONS[skillName].name.toLowerCase(), skillName);
 	skillAssetPaths.set(skillName, skill.assetPath);
 }
@@ -276,7 +276,7 @@ ALL_JOBS.forEach((job) => skillMap.set(job, new Map()));
 
 // Helper function to transform an optional<number | function> that has a default number value into a function.
 // If no default is provided, 0 is used instead.
-export function fnify<T extends PlayerState>(
+export function fnify<T extends GameState>(
 	arg?: number | ResourceCalculationFn<T>,
 	defaultValue?: number,
 ): ResourceCalculationFn<T> {
@@ -289,7 +289,7 @@ export function fnify<T extends PlayerState>(
 	}
 }
 
-function convertTraitPotencyArray<T extends PlayerState>(
+function convertTraitPotencyArray<T extends GameState>(
 	arr: Array<[TraitKey, number]>,
 ): ResourceCalculationFn<T> {
 	console.assert(arr.length > 0, `invalid trait potency array: ${arr}`);
@@ -311,7 +311,7 @@ function convertTraitPotencyArray<T extends PlayerState>(
 	};
 }
 
-export function getBasePotency<T extends PlayerState>(
+export function getBasePotency<T extends GameState>(
 	state: Readonly<T>,
 	potencyArg?: number | Array<[TraitKey, number]> | ResourceCalculationFn<T>,
 ): number {
@@ -327,7 +327,7 @@ function normalizeAssetPath(job: ShellJob, key: ActionKey) {
 }
 
 // Shared parameters for all skill kinds
-export interface MakeSkillParams<T extends PlayerState> {
+export interface MakeSkillParams<T extends GameState> {
 	assetPath: string;
 	autoUpgrade: SkillAutoReplace;
 	autoDowngrade: SkillAutoReplace;
@@ -355,7 +355,7 @@ export interface MakeSkillParams<T extends PlayerState> {
 }
 
 // Parameters for a spell or weaponskill
-export interface MakeGCDParams<T extends PlayerState> extends MakeSkillParams<T> {
+export interface MakeGCDParams<T extends GameState> extends MakeSkillParams<T> {
 	castTime: number | ResourceCalculationFn<T>;
 	recastTime: number | ResourceCalculationFn<T>;
 	isInstantFn: StatePredicate<T>;
@@ -379,7 +379,7 @@ export interface MakeGCDParams<T extends PlayerState> extends MakeSkillParams<T>
  * - onConfirm: empty function
  * - onApplication: empty function
  */
-export function makeSpell<T extends PlayerState>(
+export function makeSpell<T extends GameState>(
 	jobs: ShellJob | ShellJob[],
 	name: ActionKey,
 	unlockLevel: number,
@@ -438,7 +438,7 @@ export function makeSpell<T extends PlayerState>(
 	return info;
 }
 
-export function makeWeaponskill<T extends PlayerState>(
+export function makeWeaponskill<T extends GameState>(
 	jobs: ShellJob | ShellJob[],
 	name: ActionKey,
 	unlockLevel: number,
@@ -498,7 +498,7 @@ export function makeWeaponskill<T extends PlayerState>(
 }
 
 // Parameters for an ability
-export interface MakeAbilityParams<T extends PlayerState> extends MakeSkillParams<T> {
+export interface MakeAbilityParams<T extends GameState> extends MakeSkillParams<T> {
 	requiresCombat: boolean;
 	cooldown: number;
 	maxCharges: number;
@@ -521,7 +521,7 @@ export interface MakeAbilityParams<T extends PlayerState> extends MakeSkillParam
  * - cooldown: the cooldown (in seconds) of the ability; no resourceInfos entry is added if this is unspecified
  * - maxCharges: the maximum number of charges an ability has, default 1
  */
-export function makeAbility<T extends PlayerState>(
+export function makeAbility<T extends GameState>(
 	jobs: ShellJob | ShellJob[],
 	name: ActionKey,
 	unlockLevel: number,
@@ -587,7 +587,7 @@ export function makeAbility<T extends PlayerState>(
 	return info;
 }
 
-export type MakeResourceAbilityParams<T extends PlayerState> = {
+export type MakeResourceAbilityParams<T extends GameState> = {
 	rscType: ResourceKey;
 	cooldown: number;
 	applicationDelay: number;
@@ -600,7 +600,7 @@ export type MakeResourceAbilityParams<T extends PlayerState> = {
  *
  * Any additional effects should be encoded in `onConfirm` or `onApplication`.
  */
-export function makeResourceAbility<T extends PlayerState>(
+export function makeResourceAbility<T extends GameState>(
 	jobs: ShellJob | ShellJob[],
 	name: ActionKey,
 	unlockLevel: number,
@@ -643,7 +643,7 @@ export function makeResourceAbility<T extends PlayerState>(
  * select which skill icon is shown
  * - tier: which tier of limit break is this?
  */
-export function makeLimitBreak<T extends PlayerState>(
+export function makeLimitBreak<T extends GameState>(
 	jobs: ShellJob | ShellJob[],
 	name: LimitBreakActionKey,
 	cdName: CooldownKey,
@@ -710,7 +710,7 @@ const NEVER_SKILL = makeAbility(ALL_JOBS, "NEVER", 1, "NEVER", {
 	validateAttempt: (state) => false,
 });
 
-export class SkillsList<T extends PlayerState> {
+export class SkillsList<T extends GameState> {
 	job: ShellJob;
 
 	constructor(state: GameState) {
@@ -744,7 +744,7 @@ export function getAutoReplacedSkillName(
 	return skill.name;
 }
 
-export function getConditionalReplacement<T extends PlayerState>(
+export function getConditionalReplacement<T extends GameState>(
 	key: ActionKey,
 	state: T,
 ): ActionKey {
@@ -789,7 +789,7 @@ export class DisplayedSkills {
 	// Get the list of skills to display in the current game state.
 	// `replaceIf` and `autoUpgrade`/`autoDowngrade`` conditions are checked here;
 	// `autoUpgrade`/`autoDowngrade` conditions are also checked in the constructor.
-	getCurrentSkillNames<T extends PlayerState>(state: T): ActionKey[] {
+	getCurrentSkillNames<T extends GameState>(state: T): ActionKey[] {
 		return this.#skills.map((skillName) => getConditionalReplacement(skillName, state));
 	}
 }

--- a/src/__test__/corpus.test.ts
+++ b/src/__test__/corpus.test.ts
@@ -1,0 +1,171 @@
+// This file runs comparison tests for our secret test corpus, which is not shared publicly
+// because they were either transcribed from fflogs without explicit consent, or received via
+// discord DM without explicit permission to post publicly.
+// If you have any timeline files to test, place them in src/__test__/secretTestTimelines/,
+// and running this testing task will automatically generate a JSON file containing information
+// on damage table summaries and action timestamps. These expectation files are written to
+// src/__test__/secretTestOutputs/, and will be used as a baseline comparison on subsequent test runs.
+// To regenerate expectations for a single timeline, delete the corresponding expectation file and rerun it.
+//
+// You can run this file on its own with `npm run test -t corpus`.
+
+import fs from "node:fs";
+import { damageData, rotationTestSetup, rotationTestTeardown } from "./utils";
+import { controller } from "../Controller/Controller";
+
+// A list of timelines in src/__test__/secretTestTimelines which already have corresponding outputs
+// in src/__test__/secretTestOutputs.
+const timelinesToExpect: string[] = [];
+// A list of timelines that do not yet have corresponding outputs. This test will generate output
+// information for them.
+const timelinesToGenerate: string[] = [];
+
+const TL_DIR = "src/__test__/secretTestTimelines/";
+const OUT_DIR = "src/__test__/secretTestOutputs/";
+
+beforeEach(rotationTestSetup);
+afterEach(rotationTestTeardown);
+
+try {
+	const timelineDir = fs.opendirSync(TL_DIR);
+	if (!fs.statSync(OUT_DIR).isDirectory()) {
+		fs.mkdirSync(OUT_DIR);
+	}
+	const outDir = fs.opendirSync(OUT_DIR);
+	const timelineDamageMaps = new Map<string, boolean>();
+	// @ts-expect-error ts doesn't like top-level await, but vitest doesn't care
+	for await (const dirent of timelineDir) {
+		if (dirent.isFile()) {
+			timelineDamageMaps.set(dirent.name, false);
+		}
+	}
+	// @ts-expect-error ts doesn't like top-level await, but vitest doesn't care
+	for await (const dirent of outDir) {
+		// strip the .json suffix
+		const name = dirent.name.substring(0, dirent.name.length - 5);
+		if (dirent.isFile() && timelineDamageMaps.has(name)) {
+			timelineDamageMaps.set(name, true);
+		}
+	}
+	timelineDamageMaps.forEach((value, key) =>
+		(value ? timelinesToExpect : timelinesToGenerate).push(key),
+	);
+} catch {
+	console.log("Could not open secretTestTimelines; skipping tests.");
+}
+
+interface DotTableInfo {
+	label: string;
+	summary: {
+		totalTicks: number;
+		maxTicks: number;
+		dotCoverageTimeFraction: number;
+		cumulativeGap: number;
+		cumulativeOverride: number;
+		totalPotencyWithoutPot: number;
+		totalPotPotency: number;
+	};
+}
+
+interface SerializedTimelineOutput {
+	summary: {
+		time: number;
+		lastDamageApplicationTime: number;
+		totalPotency: {
+			applied: number;
+			pending: number;
+		};
+		gcdSkills: {
+			applied: number;
+			pending: number;
+		};
+		mainTableSummary: {
+			totalPotencyWithoutPot: number;
+			totalPotPotency: number;
+		};
+	};
+	dotTables: DotTableInfo[];
+	// result produced by action log CSV export
+	actionLog: any[][];
+}
+
+const sim = (tlPath: string) => {
+	const content = JSON.parse(fs.readFileSync(tlPath, "utf8"));
+	controller.setTinctureBuffPercentage(8);
+	controller.loadBattleRecordFromFile(content);
+	const dotTables: DotTableInfo[] = [];
+	damageData.dotTables.forEach((value, key) => {
+		return {
+			label: key,
+			summary: {
+				totalTicks: value.summary.totalTicks,
+				maxTicks: value.summary.maxTicks,
+				dotCoverageTimeFraction: value.summary.dotCoverageTimeFraction,
+				cumulativeGap: value.summary.cumulativeGap,
+				cumulativeOverride: value.summary.cumulativeOverride,
+				totalPotencyWithoutPot: value.summary.totalPotencyWithoutPot,
+				totalPotPotency: value.summary.totalPotPotency,
+			},
+		};
+	});
+	return {
+		summary: {
+			time: damageData.time,
+			totalPotency: damageData.totalPotency,
+			lastDamageApplicationTime: damageData.lastDamageApplicationTime,
+			gcdSkills: damageData.gcdSkills,
+			mainTableSummary: {
+				totalPotencyWithoutPot: damageData.mainTableSummary.totalPotencyWithoutPot,
+				totalPotPotency: damageData.mainTableSummary.totalPotPotency,
+			},
+		},
+		dotTables,
+		actionLog: controller.getActionsLogCsv(),
+	} as SerializedTimelineOutput;
+};
+
+// Copied with slight modification from utils.ts
+// Recursively check the fields with floating point forgiveness
+function checkNumbersInObject(
+	expected: object | number | string,
+	actual: object | number | string,
+	path: string,
+) {
+	expect(typeof expected === typeof actual);
+	if (typeof expected === "number") {
+		expect(expected).toBeCloseTo(actual, 5);
+	} else if (typeof expected === "string") {
+		expect(expected).toEqual(actual);
+	} else {
+		Object.keys(expected).forEach((key) => {
+			const expectedValue = expected[key as keyof typeof expected];
+			const actualValue = actual[key as keyof typeof expected];
+			checkNumbersInObject(expectedValue, actualValue, `${path}.${key}`);
+		});
+	}
+}
+
+timelinesToExpect.length &&
+	describe("timelines with existing expectations", () => {
+		timelinesToExpect.forEach((name) => {
+			it(`${name} matches previous potencies`, () => {
+				const expectedOutput = JSON.parse(
+					fs.readFileSync(OUT_DIR + name + ".json", { encoding: "utf8" }),
+				);
+				const actualOutput = sim(TL_DIR + name);
+				checkNumbersInObject(expectedOutput, actualOutput, "<summary>");
+			});
+		});
+	});
+
+timelinesToGenerate.length &&
+	describe("timelines that need to generate expectations", () => {
+		timelinesToGenerate.forEach((name) => {
+			it(`${name} is able to generate an expectation file`, () => {
+				const newSummary = sim(TL_DIR + name);
+				fs.writeFileSync(OUT_DIR + name + ".json", JSON.stringify(newSummary));
+			});
+		});
+	});
+
+it("canary test", () => {});

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,16 @@
 [
 	{
+		"date": "7/10/25",
+		"changes": [
+			"[MNK] Now begins encounters with Formless Fist active by default.",
+			"[DRG] Fixed a bug where using combo actions out of sequence granted combo potency bonus."
+		],
+		"changes_zh": [
+			"【武士】现在会从战斗开始有\"无相身形\"。",
+			"【龙骑士】修复了用错误的连击技能会给连击威力增加的问题。"
+		]
+	},
+	{
 		"date": "7/8/25",
 		"changes": [
 			"[AST] Added initial support for AST.",

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -3,14 +3,15 @@
 		"date": "7/10/25",
 		"changes": [
 			"[MNK] Now begins encounters with Formless Fist active by default.",
-			"[DRG] Fixed a bug where using combo actions out of sequence granted combo potency bonus.",
+			"[DRG][NIN] Fixed a bug where using combo actions out of sequence granted combo potency bonus.",
 			"[AST] Fixed Macrocosmos/Microcosmos."
 		],
 		"changes_zh": [
 			"【武士】现在会从战斗开始有\"无相身形\"。",
-			"【龙骑士】修复了用错误的连击技能会给连击威力增加的问题。",
+			"【龙骑士】【忍者】修复了用错误的连击技能会给连击威力增加的问题。",
 			"【占星术士】修复了大宇宙和小宇宙。"
-		]
+		],
+		"level": "minor"
 	},
 	{
 		"date": "7/8/25",

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -3,11 +3,13 @@
 		"date": "7/10/25",
 		"changes": [
 			"[MNK] Now begins encounters with Formless Fist active by default.",
-			"[DRG] Fixed a bug where using combo actions out of sequence granted combo potency bonus."
+			"[DRG] Fixed a bug where using combo actions out of sequence granted combo potency bonus.",
+			"[AST] Fixed Macrocosmos/Microcosmos."
 		],
 		"changes_zh": [
 			"【武士】现在会从战斗开始有\"无相身形\"。",
-			"【龙骑士】修复了用错误的连击技能会给连击威力增加的问题。"
+			"【龙骑士】修复了用错误的连击技能会给连击威力增加的问题。",
+			"【占星术士】修复了大宇宙和小宇宙。"
 		]
 	},
 	{


### PR DESCRIPTION
Resolves #186.

I found 2 additional bugs in the course of making the listed refactors:
1. I straight up forgot to implement AST's Macro/Microcosmos
2. MNK and NIN did not check the position in a combo tree when applying combo potencies, only that the combo tree itself was active.

I also incidentally made MNK start encounters with Formless Fist active (I meant to do it yesterday but forgot).