### PR TITLE
Misc adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ https://xivintheshell.com
 
 Let us know if you encounter bugs and/or have questions or concerns.
 
-Initial idea: Galahad Donnadieu @ Exodus (`ukitaeshiya`)  
-Initial developer: Ellyn Waterford @ Sargatanas (`miyehn`)  
-Currently maintained by: [@developers](https://github.com/orgs/xivintheshell/teams/developers) of [FFXIV in the Shell](https://github.com/xivintheshell).
+Currently maintained by shanzhe (Shanzhe Qi @ Seraph) and other [@developers](https://github.com/orgs/xivintheshell/teams/developers) of [XIV in the Shell](https://github.com/xivintheshell).
 
 Many thanks to the players from The Balance discord server for their invaluable feedback.
 

--- a/src/Components/ColorTheme.tsx
+++ b/src/Components/ColorTheme.tsx
@@ -252,6 +252,10 @@ export type ThemeColors = {
 	bgLowContrast: string;
 	bgMediumContrast: string;
 	bgHighContrast: string;
+	timelineEditor: {
+		headerFooter: string;
+		bgAlternateRow: string;
+	};
 	resources: {
 		gcdBar: string;
 		lockBar: string;
@@ -356,6 +360,10 @@ const DARK_THEME_COLORS: ThemeColors = {
 	bgLowContrast: "#333",
 	bgMediumContrast: "#393939",
 	bgHighContrast: "#626262",
+	timelineEditor: {
+		headerFooter: "#424242",
+		bgAlternateRow: "#282828",
+	},
 	resources: {
 		gcdBar: "#5cab43",
 		lockBar: "#737373",
@@ -606,6 +614,10 @@ const LIGHT_THEME_COLORS: ThemeColors = {
 	bgLowContrast: "#efefef",
 	bgMediumContrast: "lightgrey",
 	bgHighContrast: "darkgrey",
+	timelineEditor: {
+		headerFooter: "#cacaca",
+		bgAlternateRow: "#eeeeee",
+	},
 	resources: {
 		gcdBar: "#8edc72",
 		lockBar: "#cbcbcb",

--- a/src/Components/TimelineEditor.tsx
+++ b/src/Components/TimelineEditor.tsx
@@ -60,23 +60,23 @@ const getBorderStyling = (colors: ThemeColors) => {
 };
 
 const INDEX_TD_STYLE: CSSProperties = {
-	width: "1%", // seems like this is auto expanded to contain its content
+	width: "1.5%",
 	textAlign: "right",
-	paddingRight: "1em",
-	paddingLeft: "1em",
+	paddingRight: "0.3em",
+	paddingLeft: "0.3em",
 };
 
 const TIMESTAMP_TD_STYLE: CSSProperties = {
-	width: "1%", // seems like this is auto expanded to contain its content
+	width: "12%", // seems like this is auto expanded to contain its content
 	textAlign: "right",
-	paddingRight: "1em",
-	paddingLeft: "1em",
+	paddingRight: "0.3em",
+	paddingLeft: "0.3em",
 };
 
 const ACTION_TD_STYLE: CSSProperties = {
-	// and seems like the last column is auto expanded to fill the rest of the table
+	width: "86.5%", // seems like the last column is auto expanded to fill the rest of the table even without this line
 	textAlign: "left",
-	paddingLeft: "1em",
+	paddingLeft: "0.3em",
 };
 
 const TR_STYLE: CSSProperties = {

--- a/src/Components/TimelineEditor.tsx
+++ b/src/Components/TimelineEditor.tsx
@@ -108,7 +108,7 @@ function TimelineActionElement(props: {
 }) {
 	const colors = getCurrentThemeColors();
 	// Every other row should be highlighted slightly to provide contrast.
-	let bgColor = props.index % 2 === 1 ? colors.bgLowContrast : "transparent";
+	let bgColor = "transparent";
 	// These checks to override background color should happen in this specific order.
 	if (props.isSelected) {
 		bgColor = "rgba(151,111,246,0.25)";
@@ -661,7 +661,7 @@ export function TimelineEditor() {
 				tabIndex={-1}
 				style={{
 					height: "0.8em",
-					background: colors.bgHighContrast,
+					background: colors.bgMediumContrast,
 					userSelect: "none",
 					...(isEndDragTarget ? getDropTargetStyle(colors) : {}),
 				}}
@@ -688,7 +688,7 @@ export function TimelineEditor() {
 	}
 
 	const thStyle: CSSProperties = {
-		backgroundColor: colors.bgHighContrast,
+		backgroundColor: colors.bgMediumContrast,
 	};
 	return <div
 		onClick={(evt) => {

--- a/src/Components/TimelineEditor.tsx
+++ b/src/Components/TimelineEditor.tsx
@@ -60,26 +60,27 @@ const getBorderStyling = (colors: ThemeColors) => {
 };
 
 const INDEX_TD_STYLE: CSSProperties = {
-	width: "1.5%",
+	width: "1%", // seems like this is auto expanded to contain its content
 	textAlign: "right",
-	paddingRight: "0.3em",
-	paddingLeft: "0.3em",
+	paddingRight: "1em",
+	paddingLeft: "1em",
 };
 
 const TIMESTAMP_TD_STYLE: CSSProperties = {
-	width: "12%",
+	width: "1%", // seems like this is auto expanded to contain its content
 	textAlign: "right",
-	paddingRight: "0.3em",
-	paddingLeft: "0.3em",
+	paddingRight: "1em",
+	paddingLeft: "1em",
 };
 
 const ACTION_TD_STYLE: CSSProperties = {
-	width: "86.5%",
+	// and seems like the last column is auto expanded to fill the rest of the table
 	textAlign: "left",
-	paddingLeft: "0.3em",
+	paddingLeft: "1em",
 };
 
 const TR_STYLE: CSSProperties = {
+	width: "100%",
 	height: "1.6em",
 	userSelect: "none",
 };
@@ -108,7 +109,7 @@ function TimelineActionElement(props: {
 }) {
 	const colors = getCurrentThemeColors();
 	// Every other row should be highlighted slightly to provide contrast.
-	let bgColor = "transparent";
+	let bgColor = props.index % 2 === 1 ? colors.timelineEditor.bgAlternateRow : "transparent";
 	// These checks to override background color should happen in this specific order.
 	if (props.isSelected) {
 		bgColor = "rgba(151,111,246,0.25)";
@@ -661,7 +662,7 @@ export function TimelineEditor() {
 				tabIndex={-1}
 				style={{
 					height: "0.8em",
-					background: colors.bgMediumContrast,
+					background: colors.timelineEditor.headerFooter,
 					userSelect: "none",
 					...(isEndDragTarget ? getDropTargetStyle(colors) : {}),
 				}}
@@ -688,7 +689,7 @@ export function TimelineEditor() {
 	}
 
 	const thStyle: CSSProperties = {
-		backgroundColor: colors.bgMediumContrast,
+		backgroundColor: colors.timelineEditor.headerFooter,
 	};
 	return <div
 		onClick={(evt) => {
@@ -708,6 +709,8 @@ export function TimelineEditor() {
 				{
 					content: <table
 						style={{
+							position: "relative",
+							width: "100%",
 							borderCollapse: "collapse",
 							borderColor: colors.bgMediumContrast,
 							borderWidth: "1px",


### PR DESCRIPTION
Readme: me and Eshiya we have enough credit in the about section already (and the tool's deviated enough from the original BLM in the Shell), so I'm removing us and putting shanzhe there

Timeline editor:
* Title and footer background color: I changed them to `bgMediumContrast` because it has text on top and `bgHighContrast` might be a bit too close to text color
* Removing alternating row background: I think the table grid already serves the purpose of differentiating all the rows (and each row here is pretty short anyway), so alternating background might be redundant. This is what it looks like after the change:<img width="1217" height="491" alt="image" src="https://github.com/user-attachments/assets/e30aac4a-9636-43fb-96ce-4cecd31deb65" />
If we have concerns, we can make the grid lines more prominent (`bgHighContrast`)
Or keep the alternating background and potentially remove the grid, but might want to tone it down a bit, closer to the contrast level of `colors.timeline.tracks`, so it guides the users but doesn't draw too much attention
(Timeline tracks uses alternating background because each row is reallly long, even grid lines might not be enough for guiding users)