### PR TITLE
Assorted NIN and WAR fixes

### DIFF
--- a/src/Game/Jobs/WAR.ts
+++ b/src/Game/Jobs/WAR.ts
@@ -360,11 +360,11 @@ makeWeaponskill_WAR("STORMS_EYE", 50, {
 		resource: "STORM_COMBO",
 		resourceValue: 2,
 	},
-	applicationDelay: 0.62,
+	applicationDelay: 1.65,
 	onConfirm: (state) => {
 		if (state.hasComboStatus("STORM_COMBO", 2)) {
 			state.gainBeastGauge(10);
-			state.gainSurgingTempestGCD(30, 0.62, 1.7);
+			state.gainSurgingTempestGCD(30, 1.65, 1.7);
 		}
 	},
 	highlightIf: (state) => state.hasComboStatus("STORM_COMBO", 2),
@@ -444,7 +444,7 @@ makeWeaponskill_WAR("DECIMATE", 60, {
 		);
 	},
 	onConfirm: (state) => {
-		if (!state.tryConsumeResource("INNER_RELEASE")) {
+		if (!state.hasResourceAvailable("INNER_RELEASE")) {
 			state.resources.get("BEAST_GAUGE").consume(50);
 		}
 		reduceInfuriateCooldown(state);

--- a/src/Game/Jobs/WAR.ts
+++ b/src/Game/Jobs/WAR.ts
@@ -40,14 +40,22 @@ const makeWARResource = (
 makeWARResource("BEAST_GAUGE", 100, { warnOnOvercap: true });
 
 // Status Effects
+// From logs, it looks like all buffs applied by Inner Release are extended longer than their tooltip.
+// However, the buffs are applied instantly on ability usage, so we just add this offset to their
+// duration. In my own testing I found this duration to be 0.73-0.74s.
+const IR_DELAY = 0.74;
+const PRIMAL_REND_APPLICATION_DELAY = 1.16;
 makeWARResource("SURGING_TEMPEST", 1, { timeout: 60 });
 makeWARResource("NASCENT_CHAOS", 1, { timeout: 30 });
-makeWARResource("INNER_RELEASE", 3, { timeout: 15 });
-makeWARResource("INNER_STRENGTH", 1, { timeout: 15 });
+makeWARResource("INNER_RELEASE", 3, { timeout: 15 + IR_DELAY });
+makeWARResource("INNER_STRENGTH", 1, { timeout: 15 + IR_DELAY });
 makeWARResource("BURGEONING_FURY", 3, { timeout: 30 });
 makeWARResource("WRATHFUL", 1, { timeout: 30 });
-makeWARResource("PRIMAL_REND_READY", 1, { timeout: 30, warnOnTimeout: true });
-makeWARResource("PRIMAL_RUINATION_READY", 1, { timeout: 20, warnOnTimeout: true });
+makeWARResource("PRIMAL_REND_READY", 1, { timeout: 30 + IR_DELAY, warnOnTimeout: true });
+makeWARResource("PRIMAL_RUINATION_READY", 1, {
+	timeout: 20 + PRIMAL_REND_APPLICATION_DELAY,
+	warnOnTimeout: true,
+});
 
 makeWARResource("THRILL_OF_BATTLE", 1, { timeout: 10 });
 makeWARResource("EQUILIBRIUM", 1, { timeout: 15 });
@@ -490,7 +498,7 @@ makeAbility_WAR("INNER_RELEASE", 70, "cd_INNER_RELEASE", {
 
 makeWeaponskill_WAR("PRIMAL_REND", 90, {
 	potency: 700,
-	applicationDelay: 1.16,
+	applicationDelay: PRIMAL_REND_APPLICATION_DELAY,
 	falloff: 0.5,
 	animationLock: 1.2,
 	validateAttempt: (state) => state.hasResourceAvailable("PRIMAL_REND_READY"),

--- a/src/Game/Potency.ts
+++ b/src/Game/Potency.ts
@@ -507,6 +507,8 @@ export const Modifiers = {
 	HollowNozuchi: {
 		kind: "adder",
 		source: PotencyModifierType.HOLLOW_NOZUCHI,
+		// Because additive mods are applied before multiplication by target count, we can use a single
+		// modifier for hollow nozuchi.
 		additiveAmount: 70,
 	} as PotencyAdder,
 	Kazematoi: {

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -4,6 +4,7 @@
 		"changes": [
 			"[WAR] Fixed a bug where Decimate consumed 2 stacks of Inner Release, and failed to grant Burgeoning Fury.",
 			"[WAR] Fixed Storm's Eye using an incorrect application delay.",
+			"[WAR] Extended the duration of the Inner Release, Primal Rend Ready, and Primal Ruination buffs to match in-game behavior.",
 			"[NIN] Fixed a bug where using Gust Slash without an active combo incorrectly advanced combo state.",
 			"[NIN] Fixed a bug where damage from Doton ticks was not computed.",
 			"[NIN] Fixed a bug where using Katon under Ten Chi Jin did not trigger Hollow Nozuchi."

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,16 @@
 [
 	{
+		"date": "8/11/25",
+		"changes": [
+			"[WAR] Fixed a bug where Decimate consumed 2 stacks of Inner Release, and failed to grant Burgeoning Fury.",
+			"[WAR] Fixed Storm's Eye using an incorrect application delay.",
+			"[NIN] Fixed a bug where using Gust Slash without an active combo incorrectly advanced combo state.",
+			"[NIN] Fixed a bug where damage from Doton ticks was not computed.",
+			"[NIN] Fixed a bug where using Katon under Ten Chi Jin did not trigger Hollow Nozuchi."
+		],
+		"level": "minor"
+	},
+	{
 		"date": "8/10/25",
 		"changes": [
 			"[NIN] Fixed a bug where Ninjutsu abilities were not buffed by Kunai's Bane and Dokumori."


### PR DESCRIPTION
Reported on Discord: https://discord.com/channels/277897135515762698/1307922201726685236/1404508653851119658
- [WAR] Fixed a bug where Decimate consumed 2 stacks of Inner Release, and failed to grant Burgeoning Fury.
- [WAR] Fixed Storm's Eye using an incorrect application delay.
- [WAR] Extended the duration of the Inner Release, Primal Rend Ready, and Primal Ruination buffs to match in-game behavior. (test log: https://www.fflogs.com/reports/GKFwgDTQ6dfhNLc7?boss=-3&difficulty=0&view=events&type=auras&source=41&ability=1002624)
  - the 12-GCD sequence in the discord message looks to be impossible with this buff duration and the default 0.7s animation lock; lowering it to 0.62s made it possible

Found myself while testing:
- [NIN] Fixed a bug where using Gust Slash without an active combo incorrectly advanced combo state.
- [NIN] Fixed a bug where damage from Doton ticks was not computed. (#216)
- [NIN] Fixed a bug where using Katon under Ten Chi Jin did not trigger Hollow Nozuchi.