### PR TITLE
Prevent accidental timeline slot button clicks

### DIFF
--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,12 @@
 [
 	{
+		"date": "8/17/25",
+		"changes": [
+			"Changed timeline slot buttons to trigger only if the mouse was both pressed and released on top of them."
+		],
+		"level": "minor"
+	},
+	{
 		"date": "8/11/25",
 		"changes": [
 			"Made some internal adjustments to the implementation of click/drag selection and skill arrangements.",


### PR DESCRIPTION
Got a report by discord DM that dragging the cursor across a timeline button despite pressing mousedown elsewhere in the canvas will trigger the button, which is common with the "clone timeline slot" button when scrolling horizontally. This PR adds a `mouseDownInHitbox` flag that lets handlers check whether the initial mouseDown event's coordinates occurred within the hitbox.