### PR TITLE
PlayerConfig refactor

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
     - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "xiv-in-the-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@base-ui-components/react": "^1.0.0-alpha.8",
+        "@base-ui-components/react": "^1.0.0-beta.2",
         "@types/jquery": "^3.5.14",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.3",
@@ -95,23 +95,26 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
-      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@base-ui-components/react": {
-      "version": "1.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@base-ui-components/react/-/react-1.0.0-alpha.8.tgz",
-      "integrity": "sha512-tGSksjEjA9TPguCXzFZU2cpvvsE6lnkVWVI0qSk3Zl/jQiE9F6opPVBp1uzHcJou7hj7fr6pEgtNf7WzsiXh4Q==",
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@base-ui-components/react/-/react-1.0.0-beta.2.tgz",
+      "integrity": "sha512-jfAUfSgXvsfr8mQi7r/6gLG8U1Ybr77NN8WK5IXXM0c/hBvFDBtvUfwDJACV0gXiYbSKpA+dRzZz01V1tULobA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.0",
-        "@floating-ui/react": "^0.27.7",
-        "@floating-ui/utils": "^0.2.9",
-        "@react-aria/overlays": "^3.27.0",
-        "prop-types": "^15.8.1",
+        "@babel/runtime": "^7.27.6",
+        "@base-ui-components/utils": "0.1.0",
+        "@floating-ui/react-dom": "^2.1.5",
+        "@floating-ui/utils": "^0.2.10",
+        "reselect": "^5.1.1",
+        "tabbable": "^6.2.0",
         "use-sync-external-store": "^1.5.0"
       },
       "engines": {
@@ -120,6 +123,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui-components/utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@base-ui-components/utils/-/utils-0.1.0.tgz",
+      "integrity": "sha512-9+uaWyF1o/PgXqHLJnC81IIG0HlV3o9eFCQ5hWZDMx5NHrFk0rrwqEFGQOB8lti/rnbxNPi+kYYw1D4e8xSn/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@floating-ui/utils": "^0.2.10",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.5.0"
       },
       "peerDependencies": {
         "@types/react": "^17 || ^18 || ^19",
@@ -827,42 +852,31 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/react": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.8.tgz",
-      "integrity": "sha512-EQJ4Th328y2wyHR3KzOUOoTW2UKjFk53fmyahfwExnFQ8vnsMYqKc+fFPOkeYtj5tcp1DUMiNJ7BFhed7e9ONw==",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.1.2",
-        "@floating-ui/utils": "^0.2.9",
-        "tabbable": "^6.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0",
-        "react-dom": ">=17.0.0"
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
+        "@floating-ui/dom": "^1.7.4"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -870,55 +884,10 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
-    },
-    "node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
-      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/intl-localematcher": "0.6.1",
-        "decimal.js": "^10.4.3",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
-      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
-      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.4",
-        "@formatjs/icu-skeleton-parser": "1.8.14",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
-      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.4",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
-      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -983,39 +952,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@internationalized/date": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
-      "integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "node_modules/@internationalized/message": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.7.tgz",
-      "integrity": "sha512-gLQlhEW4iO7DEFPf/U7IrIdA3UyLGS0opeqouaFwlMObLUzwexRjbygONHDVbC9G9oFLXsLyGKYkJwqXw/QADg==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0",
-        "intl-messageformat": "^10.1.0"
-      }
-    },
-    "node_modules/@internationalized/number": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.1.tgz",
-      "integrity": "sha512-UVsb4bCwbL944E0SX50CHFtWEeZ2uB5VozZ5yDXJdq6iPZsZO5p+bjVMZh2GxHf4Bs/7xtDCcPwEa2NU9DaG/g==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "node_modules/@internationalized/string": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.6.tgz",
-      "integrity": "sha512-LR2lnM4urJta5/wYJVV7m8qk5DrMZmLRTuFhbQO5b9/sKLHgty6unQy1Li4+Su2DWydmB4aZdS5uxBRXIq2aAw==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1099,187 +1035,6 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@react-aria/focus": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.20.2.tgz",
-      "integrity": "sha512-Q3rouk/rzoF/3TuH6FzoAIKrl+kzZi9LHmr8S5EqLAOyP9TXIKG34x2j42dZsAhrw7TbF9gA8tBKwnCNH4ZV+Q==",
-      "dependencies": {
-        "@react-aria/interactions": "^3.25.0",
-        "@react-aria/utils": "^3.28.2",
-        "@react-types/shared": "^3.29.0",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/i18n": {
-      "version": "3.12.8",
-      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.8.tgz",
-      "integrity": "sha512-V/Nau9WuwTwxfFffQL4URyKyY2HhRlu9zmzkF2Hw/j5KmEQemD+9jfaLueG2CJu85lYL06JrZXUdnhZgKnqMkA==",
-      "dependencies": {
-        "@internationalized/date": "^3.8.0",
-        "@internationalized/message": "^3.1.7",
-        "@internationalized/number": "^3.6.1",
-        "@internationalized/string": "^3.2.6",
-        "@react-aria/ssr": "^3.9.8",
-        "@react-aria/utils": "^3.28.2",
-        "@react-types/shared": "^3.29.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/interactions": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.0.tgz",
-      "integrity": "sha512-GgIsDLlO8rDU/nFn6DfsbP9rfnzhm8QFjZkB9K9+r+MTSCn7bMntiWQgMM+5O6BiA8d7C7x4zuN4bZtc0RBdXQ==",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.8",
-        "@react-aria/utils": "^3.28.2",
-        "@react-stately/flags": "^3.1.1",
-        "@react-types/shared": "^3.29.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/overlays": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.27.0.tgz",
-      "integrity": "sha512-2vZVgL7FrloN5Rh8sAhadGADJbuWg69DdSJB3fd2/h5VvcEhnIfNPu9Ma5XmdkApDoTboIEsKZ4QLYwRl98w6w==",
-      "dependencies": {
-        "@react-aria/focus": "^3.20.2",
-        "@react-aria/i18n": "^3.12.8",
-        "@react-aria/interactions": "^3.25.0",
-        "@react-aria/ssr": "^3.9.8",
-        "@react-aria/utils": "^3.28.2",
-        "@react-aria/visually-hidden": "^3.8.22",
-        "@react-stately/overlays": "^3.6.15",
-        "@react-types/button": "^3.12.0",
-        "@react-types/overlays": "^3.8.14",
-        "@react-types/shared": "^3.29.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/ssr": {
-      "version": "3.9.8",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.8.tgz",
-      "integrity": "sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "engines": {
-        "node": ">= 12"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/utils": {
-      "version": "3.28.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.28.2.tgz",
-      "integrity": "sha512-J8CcLbvnQgiBn54eeEvQQbIOfBF3A1QizxMw9P4cl9MkeR03ug7RnjTIdJY/n2p7t59kLeAB3tqiczhcj+Oi5w==",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.8",
-        "@react-stately/flags": "^3.1.1",
-        "@react-stately/utils": "^3.10.6",
-        "@react-types/shared": "^3.29.0",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/visually-hidden": {
-      "version": "3.8.22",
-      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.22.tgz",
-      "integrity": "sha512-EO3R8YTKZ7HkLl9k1Y2uBKYBgpJagth4/4W7mfpJZE24A3fQnCP8zx1sweXiAm0mirR4J6tNaK7Ia8ssP5TpOw==",
-      "dependencies": {
-        "@react-aria/interactions": "^3.25.0",
-        "@react-aria/utils": "^3.28.2",
-        "@react-types/shared": "^3.29.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-stately/flags": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.1.tgz",
-      "integrity": "sha512-XPR5gi5LfrPdhxZzdIlJDz/B5cBf63l4q6/AzNqVWFKgd0QqY5LvWJftXkklaIUpKSJkIKQb8dphuZXDtkWNqg==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "node_modules/@react-stately/overlays": {
-      "version": "3.6.15",
-      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.15.tgz",
-      "integrity": "sha512-LBaGpXuI+SSd5HSGzyGJA0Gy09V2tl2G/r0lllTYqwt0RDZR6p7IrhdGVXZm6vI0oWEnih7yLC32krkVQrffgQ==",
-      "dependencies": {
-        "@react-stately/utils": "^3.10.6",
-        "@react-types/overlays": "^3.8.14",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-stately/utils": {
-      "version": "3.10.6",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.6.tgz",
-      "integrity": "sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-types/button": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.12.0.tgz",
-      "integrity": "sha512-YrASNa+RqGQpzJcxNAahzNuTYVID1OE6HCorrEOXIyGS3EGogHsQmFs9OyThXnGHq6q4rLlA806/jWbP9uZdxA==",
-      "dependencies": {
-        "@react-types/shared": "^3.29.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-types/overlays": {
-      "version": "3.8.14",
-      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.14.tgz",
-      "integrity": "sha512-XJS67KHYhdMvPNHXNGdmc85gE+29QT5TwC58V4kxxHVtQh9fYzEEPzIV8K84XWSz04rRGe3fjDgRNbcqBektWQ==",
-      "dependencies": {
-        "@react-types/shared": "^3.29.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-types/shared": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
-      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.40.2",
@@ -1769,6 +1524,9 @@
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
       "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -3097,6 +2855,7 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -4657,17 +4416,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/intl-messageformat": {
-      "version": "10.7.16",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
-      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.4",
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/icu-messageformat-parser": "2.11.2",
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -6451,6 +6199,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
@@ -7107,7 +6861,8 @@
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -7348,7 +7103,10 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -8213,20 +7971,32 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
-      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog=="
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA=="
     },
     "@base-ui-components/react": {
-      "version": "1.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@base-ui-components/react/-/react-1.0.0-alpha.8.tgz",
-      "integrity": "sha512-tGSksjEjA9TPguCXzFZU2cpvvsE6lnkVWVI0qSk3Zl/jQiE9F6opPVBp1uzHcJou7hj7fr6pEgtNf7WzsiXh4Q==",
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@base-ui-components/react/-/react-1.0.0-beta.2.tgz",
+      "integrity": "sha512-jfAUfSgXvsfr8mQi7r/6gLG8U1Ybr77NN8WK5IXXM0c/hBvFDBtvUfwDJACV0gXiYbSKpA+dRzZz01V1tULobA==",
       "requires": {
-        "@babel/runtime": "^7.27.0",
-        "@floating-ui/react": "^0.27.7",
-        "@floating-ui/utils": "^0.2.9",
-        "@react-aria/overlays": "^3.27.0",
-        "prop-types": "^15.8.1",
+        "@babel/runtime": "^7.27.6",
+        "@base-ui-components/utils": "0.1.0",
+        "@floating-ui/react-dom": "^2.1.5",
+        "@floating-ui/utils": "^0.2.10",
+        "reselect": "^5.1.1",
+        "tabbable": "^6.2.0",
+        "use-sync-external-store": "^1.5.0"
+      }
+    },
+    "@base-ui-components/utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@base-ui-components/utils/-/utils-0.1.0.tgz",
+      "integrity": "sha512-9+uaWyF1o/PgXqHLJnC81IIG0HlV3o9eFCQ5hWZDMx5NHrFk0rrwqEFGQOB8lti/rnbxNPi+kYYw1D4e8xSn/Q==",
+      "requires": {
+        "@babel/runtime": "^7.27.6",
+        "@floating-ui/utils": "^0.2.10",
+        "reselect": "^5.1.1",
         "use-sync-external-store": "^1.5.0"
       }
     },
@@ -8551,90 +8321,34 @@
       }
     },
     "@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
       "requires": {
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
       "requires": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "@floating-ui/react": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.8.tgz",
-      "integrity": "sha512-EQJ4Th328y2wyHR3KzOUOoTW2UKjFk53fmyahfwExnFQ8vnsMYqKc+fFPOkeYtj5tcp1DUMiNJ7BFhed7e9ONw==",
-      "requires": {
-        "@floating-ui/react-dom": "^2.1.2",
-        "@floating-ui/utils": "^0.2.9",
-        "tabbable": "^6.0.0"
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
       "requires": {
-        "@floating-ui/dom": "^1.0.0"
+        "@floating-ui/dom": "^1.7.4"
       }
     },
     "@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
-    },
-    "@formatjs/ecma402-abstract": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
-      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
-      "requires": {
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/intl-localematcher": "0.6.1",
-        "decimal.js": "^10.4.3",
-        "tslib": "^2.8.0"
-      }
-    },
-    "@formatjs/fast-memoize": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
-      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
-      "requires": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "@formatjs/icu-messageformat-parser": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
-      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
-      "requires": {
-        "@formatjs/ecma402-abstract": "2.3.4",
-        "@formatjs/icu-skeleton-parser": "1.8.14",
-        "tslib": "^2.8.0"
-      }
-    },
-    "@formatjs/icu-skeleton-parser": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
-      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
-      "requires": {
-        "@formatjs/ecma402-abstract": "2.3.4",
-        "tslib": "^2.8.0"
-      }
-    },
-    "@formatjs/intl-localematcher": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
-      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
-      "requires": {
-        "tslib": "^2.8.0"
-      }
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
     },
     "@humanfs/core": {
       "version": "0.19.1",
@@ -8671,39 +8385,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
       "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
       "dev": true
-    },
-    "@internationalized/date": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
-      "integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
-      "requires": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "@internationalized/message": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.7.tgz",
-      "integrity": "sha512-gLQlhEW4iO7DEFPf/U7IrIdA3UyLGS0opeqouaFwlMObLUzwexRjbygONHDVbC9G9oFLXsLyGKYkJwqXw/QADg==",
-      "requires": {
-        "@swc/helpers": "^0.5.0",
-        "intl-messageformat": "^10.1.0"
-      }
-    },
-    "@internationalized/number": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.1.tgz",
-      "integrity": "sha512-UVsb4bCwbL944E0SX50CHFtWEeZ2uB5VozZ5yDXJdq6iPZsZO5p+bjVMZh2GxHf4Bs/7xtDCcPwEa2NU9DaG/g==",
-      "requires": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "@internationalized/string": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.6.tgz",
-      "integrity": "sha512-LR2lnM4urJta5/wYJVV7m8qk5DrMZmLRTuFhbQO5b9/sKLHgty6unQy1Li4+Su2DWydmB4aZdS5uxBRXIq2aAw==",
-      "requires": {
-        "@swc/helpers": "^0.5.0"
-      }
     },
     "@jridgewell/resolve-uri": {
       "version": "3.1.2",
@@ -8766,143 +8447,6 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true
-    },
-    "@react-aria/focus": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.20.2.tgz",
-      "integrity": "sha512-Q3rouk/rzoF/3TuH6FzoAIKrl+kzZi9LHmr8S5EqLAOyP9TXIKG34x2j42dZsAhrw7TbF9gA8tBKwnCNH4ZV+Q==",
-      "requires": {
-        "@react-aria/interactions": "^3.25.0",
-        "@react-aria/utils": "^3.28.2",
-        "@react-types/shared": "^3.29.0",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      }
-    },
-    "@react-aria/i18n": {
-      "version": "3.12.8",
-      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.8.tgz",
-      "integrity": "sha512-V/Nau9WuwTwxfFffQL4URyKyY2HhRlu9zmzkF2Hw/j5KmEQemD+9jfaLueG2CJu85lYL06JrZXUdnhZgKnqMkA==",
-      "requires": {
-        "@internationalized/date": "^3.8.0",
-        "@internationalized/message": "^3.1.7",
-        "@internationalized/number": "^3.6.1",
-        "@internationalized/string": "^3.2.6",
-        "@react-aria/ssr": "^3.9.8",
-        "@react-aria/utils": "^3.28.2",
-        "@react-types/shared": "^3.29.0",
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "@react-aria/interactions": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.0.tgz",
-      "integrity": "sha512-GgIsDLlO8rDU/nFn6DfsbP9rfnzhm8QFjZkB9K9+r+MTSCn7bMntiWQgMM+5O6BiA8d7C7x4zuN4bZtc0RBdXQ==",
-      "requires": {
-        "@react-aria/ssr": "^3.9.8",
-        "@react-aria/utils": "^3.28.2",
-        "@react-stately/flags": "^3.1.1",
-        "@react-types/shared": "^3.29.0",
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "@react-aria/overlays": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.27.0.tgz",
-      "integrity": "sha512-2vZVgL7FrloN5Rh8sAhadGADJbuWg69DdSJB3fd2/h5VvcEhnIfNPu9Ma5XmdkApDoTboIEsKZ4QLYwRl98w6w==",
-      "requires": {
-        "@react-aria/focus": "^3.20.2",
-        "@react-aria/i18n": "^3.12.8",
-        "@react-aria/interactions": "^3.25.0",
-        "@react-aria/ssr": "^3.9.8",
-        "@react-aria/utils": "^3.28.2",
-        "@react-aria/visually-hidden": "^3.8.22",
-        "@react-stately/overlays": "^3.6.15",
-        "@react-types/button": "^3.12.0",
-        "@react-types/overlays": "^3.8.14",
-        "@react-types/shared": "^3.29.0",
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "@react-aria/ssr": {
-      "version": "3.9.8",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.8.tgz",
-      "integrity": "sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==",
-      "requires": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "@react-aria/utils": {
-      "version": "3.28.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.28.2.tgz",
-      "integrity": "sha512-J8CcLbvnQgiBn54eeEvQQbIOfBF3A1QizxMw9P4cl9MkeR03ug7RnjTIdJY/n2p7t59kLeAB3tqiczhcj+Oi5w==",
-      "requires": {
-        "@react-aria/ssr": "^3.9.8",
-        "@react-stately/flags": "^3.1.1",
-        "@react-stately/utils": "^3.10.6",
-        "@react-types/shared": "^3.29.0",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      }
-    },
-    "@react-aria/visually-hidden": {
-      "version": "3.8.22",
-      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.22.tgz",
-      "integrity": "sha512-EO3R8YTKZ7HkLl9k1Y2uBKYBgpJagth4/4W7mfpJZE24A3fQnCP8zx1sweXiAm0mirR4J6tNaK7Ia8ssP5TpOw==",
-      "requires": {
-        "@react-aria/interactions": "^3.25.0",
-        "@react-aria/utils": "^3.28.2",
-        "@react-types/shared": "^3.29.0",
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "@react-stately/flags": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.1.tgz",
-      "integrity": "sha512-XPR5gi5LfrPdhxZzdIlJDz/B5cBf63l4q6/AzNqVWFKgd0QqY5LvWJftXkklaIUpKSJkIKQb8dphuZXDtkWNqg==",
-      "requires": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "@react-stately/overlays": {
-      "version": "3.6.15",
-      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.15.tgz",
-      "integrity": "sha512-LBaGpXuI+SSd5HSGzyGJA0Gy09V2tl2G/r0lllTYqwt0RDZR6p7IrhdGVXZm6vI0oWEnih7yLC32krkVQrffgQ==",
-      "requires": {
-        "@react-stately/utils": "^3.10.6",
-        "@react-types/overlays": "^3.8.14",
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "@react-stately/utils": {
-      "version": "3.10.6",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.6.tgz",
-      "integrity": "sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==",
-      "requires": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "@react-types/button": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.12.0.tgz",
-      "integrity": "sha512-YrASNa+RqGQpzJcxNAahzNuTYVID1OE6HCorrEOXIyGS3EGogHsQmFs9OyThXnGHq6q4rLlA806/jWbP9uZdxA==",
-      "requires": {
-        "@react-types/shared": "^3.29.0"
-      }
-    },
-    "@react-types/overlays": {
-      "version": "3.8.14",
-      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.14.tgz",
-      "integrity": "sha512-XJS67KHYhdMvPNHXNGdmc85gE+29QT5TwC58V4kxxHVtQh9fYzEEPzIV8K84XWSz04rRGe3fjDgRNbcqBektWQ==",
-      "requires": {
-        "@react-types/shared": "^3.29.0"
-      }
-    },
-    "@react-types/shared": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
-      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
-      "requires": {}
     },
     "@rollup/rollup-android-arm-eabi": {
       "version": "4.40.2",
@@ -9144,6 +8688,9 @@
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
       "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.8.0"
       }
@@ -10069,7 +9616,8 @@
     "decimal.js": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "dev": true
     },
     "deep-eql": {
       "version": "5.0.2",
@@ -11170,17 +10718,6 @@
         "es-errors": "^1.3.0",
         "hasown": "^2.0.2",
         "side-channel": "^1.1.0"
-      }
-    },
-    "intl-messageformat": {
-      "version": "10.7.16",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
-      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
-      "requires": {
-        "@formatjs/ecma402-abstract": "2.3.4",
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/icu-messageformat-parser": "2.11.2",
-        "tslib": "^2.8.0"
       }
     },
     "ipaddr.js": {
@@ -12316,6 +11853,11 @@
         "set-function-name": "^2.0.2"
       }
     },
+    "reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
+    },
     "resolve": {
       "version": "2.0.0-next.5",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
@@ -12920,7 +12462,10 @@
     "tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://xivintheshell.com",
   "private": true,
   "dependencies": {
-    "@base-ui-components/react": "^1.0.0-alpha.8",
+    "@base-ui-components/react": "^1.0.0-beta.2",
     "@types/jquery": "^3.5.14",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.3",

--- a/src/Components/PlaybackControl.tsx
+++ b/src/Components/PlaybackControl.tsx
@@ -953,12 +953,12 @@ function getGcdTaxPreview(
 	levelStr: string,
 	speedModifier?: number,
 ): { gcdStr: string; taxedGcdStr: string } {
-	const level = parseFloat(levelStr);
-	const speed = parseFloat(speedStr);
+	const level = parseInt(levelStr);
+	const speed = parseInt(speedStr);
 	const fps = parseFloat(fpsStr);
 	let gcdStr: string;
 	let taxedGcdStr: string;
-	if (isNaN(level) || isNaN(speed) || isNaN(fps) || speed < 400) {
+	if (isNaN(level) || isNaN(speed) || isNaN(fps) || speed < XIVMath.getSubstatBase(level)) {
 		gcdStr = "n/a";
 		taxedGcdStr = "n/a";
 	} else {
@@ -1070,7 +1070,9 @@ export function Config() {
 			if (action.job !== undefined && action.job !== prevState.job) {
 				// If the job changed, update haste modifiers, clear resource overrides, and
 				// use whatever the last saved stats for that job was.
-				const dummyConfig: GameConfig = new GameConfig(makeDefaultConfig(action.job));
+				const dummyConfig: GameConfig = new GameConfig(
+					makeDefaultConfig(action.job, parseInt(action.level ?? prevState.level)),
+				);
 				const speedModifier = getGameState(dummyConfig).inherentSpeedModifier();
 				setjobSpeedMod(speedModifier);
 				// If we returned to the ORIGINAL job (still stored by the controller), revert
@@ -1087,6 +1089,13 @@ export function Config() {
 					// Update stats from last saved timeline of this job.
 					Object.assign(newState, getSavedConfigPart(action.job));
 				}
+			}
+			if (action.level !== undefined && action.level !== prevState.level) {
+				const dummyConfig: GameConfig = new GameConfig(
+					makeDefaultConfig(prevState.job, parseInt(action.level)),
+				);
+				const speedModifier = getGameState(dummyConfig).inherentSpeedModifier();
+				setjobSpeedMod(speedModifier);
 			}
 		}
 		return newState;

--- a/src/Components/PlaybackControl.tsx
+++ b/src/Components/PlaybackControl.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler, useEffect, useReducer, useState } from "react";
+import React, { useEffect, useReducer, useContext, useState, Dispatch } from "react";
 import { controller } from "../Controller/Controller";
 import {
 	ButtonIndicator,
@@ -9,35 +9,27 @@ import {
 	Input,
 	ValueChangeEvent,
 } from "./Common";
-import {
-	getCachedValue,
-	setCachedValue,
-	ShellInfo,
-	ShellVersion,
-	TickMode,
-} from "../Controller/Common";
+import { getCachedValue, setCachedValue, ShellVersion, TickMode } from "../Controller/Common";
 import { LevelSync, ProcMode } from "../Game/Common";
 import { getAllResources, getResourceInfo, ResourceOverrideData } from "../Game/Resources";
 import { localize, localizeResourceType } from "./Localization";
 import {
-	getThemeField,
 	getThemeColors,
 	getCurrentThemeColors,
 	ColorThemeContext,
+	getThemeField,
 } from "./ColorTheme";
-import { SerializedConfig, GameConfig, DEFAULT_CONFIG } from "../Game/GameConfig";
+import { SerializedConfig, GameConfig, makeDefaultConfig } from "../Game/GameConfig";
 import { XIVMath } from "../Game/XIVMath";
 import { FaCheck } from "react-icons/fa6";
 import {
 	ShellJob,
 	JOBS,
 	ImplementationKey,
-	CASTER_JOBS,
-	HEALER_JOBS,
 	ALL_JOBS,
 	IMPLEMENTATION_LEVELS,
 } from "../Game/Data/Jobs";
-import { ResourceKey, CooldownKey } from "../Game/Data";
+import { ResourceKey, CooldownKey, RESOURCES } from "../Game/Data";
 import { getGameState } from "../Game/Jobs";
 
 export let updateConfigDisplay = (config: SerializedConfig) => {};
@@ -76,7 +68,7 @@ export function ResourceOverrideDisplay(props: {
 		const lparen = localize({ en: " (", zh: "（" }) as string;
 		const rparen = localize({ en: ") ", zh: "）" }) as string;
 		//const colon = localize({en: ": ", zh: "："}) as string;
-		if (props.override.type === "LEY_LINES") {
+		if (RESOURCES[props.override.type as ResourceKey].mayBeToggled ?? false) {
 			str +=
 				lparen +
 				(props.override.effectOrTimerEnabled
@@ -125,16 +117,290 @@ export function ResourceOverrideDisplay(props: {
 	</div>;
 }
 
-let refreshConfigSummary = () => {};
-export function ConfigSummary(props: { job: ShellJob; dirty: boolean }) {
-	const [, forceUpdate] = useReducer((x) => x + 1, 0);
-	useEffect(() => {
-		refreshConfigSummary = forceUpdate;
-		return () => {
-			refreshConfigSummary = () => {};
-		};
-	}, []);
+function ResourceOverrideSection(props: {
+	job: ShellJob;
+	initialResourceOverrides: ResourceOverrideData[];
+	selectedOverrideResource: ResourceKey | CooldownKey;
+	overrideTimer: string;
+	overrideStacks: string;
+	overrideEnabled: boolean;
+	setInitialResourceOverrides: (data: ResourceOverrideData[]) => void;
+	setSelectedOverrideResource: (key: ResourceKey | CooldownKey) => void;
+	setOverrideTimer: (value: string) => void;
+	setOverrideStacks: (value: string) => void;
+	setOverrideEnabled: (value: boolean) => void;
+}) {
+	const deleteResourceOverride = (rscType: ResourceKey | CooldownKey) => {
+		const spliceIdx = props.initialResourceOverrides.findIndex((data) => data.type === rscType);
+		if (spliceIdx !== -1) {
+			props.initialResourceOverrides.splice(spliceIdx, 1);
+			props.setInitialResourceOverrides(props.initialResourceOverrides);
+		}
+	};
+	// list of selected overrides
+	const resourceOverridesDisplayNodes = props.initialResourceOverrides.map(
+		(override, i) => <ResourceOverrideDisplay
+			job={props.job}
+			key={i}
+			override={override}
+			deleteFn={deleteResourceOverride}
+		/>,
+	);
+	// TODO pass from parent as optimization
+	const S = new Set(props.initialResourceOverrides.map((rsc) => rsc.type));
+	const resourceInfos = getAllResources(props.job);
+	// <option> elements for resources that can be overridden
+	const optionEntries: { rsc: ResourceKey | CooldownKey; isCoolDown: number }[] = resourceInfos
+		.entries()
+		.flatMap(([k, info]) => (S.has(k) ? [] : [{ rsc: k, isCoolDown: info.isCoolDown ? 1 : 0 }]))
+		.toArray();
+	const resourceOptions = optionEntries
+		.sort((a, b) => a.isCoolDown - b.isCoolDown)
+		.map((opt, i) => <option key={i} value={opt.rsc}>
+			{localizeResourceType(opt.rsc)}
+		</option>);
 
+	const rscType = props.selectedOverrideResource;
+	const info = resourceInfos.get(rscType);
+	let inputSection = undefined;
+	let showEnabled = true;
+	if (info !== undefined) {
+		let showTimer, showAmount;
+		let timerDefaultValue = "-1",
+			timerOnChange = undefined,
+			amountDefaultValue = "0",
+			amountOnChange = undefined;
+
+		if (info.isCoolDown) {
+			showTimer = true;
+			showAmount = false;
+			showEnabled = false;
+			timerDefaultValue = props.overrideTimer;
+			timerOnChange = props.setOverrideTimer;
+		} else {
+			// timer
+			if (info.maxTimeout >= 0) {
+				showTimer = true;
+				timerDefaultValue = props.overrideTimer;
+				timerOnChange = props.setOverrideTimer;
+			} else {
+				showTimer = false;
+			}
+
+			// amount
+			// hide the amount display if the resource has only one stack
+			// unless that stack is set by default
+			if (info.maxValue > 1 || info.maxValue === info.defaultValue) {
+				showAmount = true;
+				amountDefaultValue = props.overrideStacks;
+				amountOnChange = props.setOverrideStacks;
+			} else {
+				showAmount = false;
+			}
+
+			showEnabled = RESOURCES[rscType as ResourceKey].mayBeToggled ?? false;
+		}
+
+		const timerDesc = info.isCoolDown
+			? localize({ en: "Time till full: ", zh: "距CD转好时间：" })
+			: rscType === "POLYGLOT"
+				? localize({ en: "Time till next stack: ", zh: "距下一层时间：" })
+				: localize({ en: "Time till drop: ", zh: " 距状态消失时间：" });
+
+		const enabledDesc = localize({ en: "enabled", zh: "生效中" });
+
+		inputSection = <div style={{ margin: "6px 0" }}>
+			{/*timer*/}
+			<div hidden={!showTimer}>
+				<Input
+					description={timerDesc}
+					defaultValue={timerDefaultValue}
+					onChange={timerOnChange}
+				/>
+			</div>
+
+			{/*stacks*/}
+			<div hidden={!showAmount}>
+				<Input
+					description={localize({ en: "Amount: ", zh: "数量：" })}
+					defaultValue={amountDefaultValue}
+					onChange={amountOnChange}
+				/>
+			</div>
+
+			{/*enabled*/}
+			<div hidden={!showEnabled}>
+				<input
+					style={{ position: "relative", top: 3, marginRight: 5 }}
+					type="checkbox"
+					checked={props.overrideEnabled}
+					onChange={(e) => props.setOverrideEnabled(e.target.checked)}
+				/>
+				<span>{enabledDesc}</span>
+			</div>
+		</div>;
+	}
+
+	const colors = useContext(ColorThemeContext);
+	const bg = getThemeField(colors, "bgMediumContrast");
+
+	const addResourceOverride = (e: React.FormEvent) => {
+		e.preventDefault();
+		const rscType = props.selectedOverrideResource;
+		const info = getAllResources(props.job).get(rscType)!;
+
+		let inputOverrideTimer = parseFloat(props.overrideTimer);
+		const inputOverrideStacks = parseInt(props.overrideStacks);
+		const inputOverrideEnabled = props.overrideEnabled;
+
+		// an exception for polyglot: leave empty := no timer set
+		// TODO do this for other jobs' timed resources
+		if (rscType === "POLYGLOT" && props.overrideTimer === "") {
+			inputOverrideTimer = 0;
+		}
+
+		if (isNaN(inputOverrideStacks) || isNaN(inputOverrideTimer)) {
+			window.alert("some inputs are not numbers!");
+			return;
+		}
+		let newRscProps: ResourceOverrideData;
+		if (info.isCoolDown) {
+			const maxTimer = info.maxStacks * info.cdPerStack;
+			if (inputOverrideTimer < 0 || inputOverrideTimer > maxTimer) {
+				window.alert("invalid input timeout (must be in range [0, " + maxTimer + "])");
+				return;
+			}
+
+			newRscProps = {
+				type: rscType,
+				timeTillFullOrDrop: inputOverrideTimer,
+				stacks: info.maxStacks > 1 ? inputOverrideStacks : 1,
+				effectOrTimerEnabled: true,
+			};
+		} else {
+			if (
+				(info.maxValue > 1 || info.maxValue === info.defaultValue) &&
+				(inputOverrideStacks < 0 || inputOverrideStacks > info.maxValue)
+			) {
+				window.alert("invalid input amount (must be in range [0, " + info.maxValue + "])");
+				return;
+			}
+			if (
+				info.maxTimeout >= 0 &&
+				(inputOverrideTimer < 0 || inputOverrideTimer > info.maxTimeout)
+			) {
+				window.alert(
+					"invalid input timeout (must be in range [0, " + info.maxTimeout + "])",
+				);
+				return;
+			}
+
+			newRscProps = {
+				type: rscType,
+				timeTillFullOrDrop: info.maxTimeout >= 0 ? inputOverrideTimer : -1,
+				stacks:
+					info.maxValue > 1 || info.maxValue === info.defaultValue
+						? inputOverrideStacks
+						: 1,
+				effectOrTimerEnabled: showEnabled || inputOverrideEnabled,
+			};
+		}
+		// end validation
+		props.setInitialResourceOverrides([...props.initialResourceOverrides, newRscProps]);
+	};
+	const addResourceOverrideNode = <div>
+		<form
+			onSubmit={(evt) => addResourceOverride(evt)}
+			style={{
+				marginTop: 16,
+				outline: "1px solid " + bg,
+				outlineOffset: 6,
+			}}
+		>
+			<select
+				value={props.selectedOverrideResource}
+				onChange={(evt) => {
+					if (evt.target) {
+						props.setSelectedOverrideResource(
+							evt.target.value as ResourceKey | CooldownKey,
+						);
+					}
+				}}
+			>
+				{resourceOptions}
+			</select>
+			{inputSection}
+			<input
+				type="submit"
+				value={localize({ en: "add override", zh: "应用此状态" }) as string}
+			/>
+		</form>
+	</div>;
+	return <div style={{ marginTop: 10 }}>
+		<Expandable
+			title="overrideInitialResources"
+			titleNode={
+				<span>
+					{localize({ en: "Override initial resources", zh: "指定初始资源" })}{" "}
+					<Help
+						topic="overrideInitialResources"
+						content={localize({
+							en: <div>
+								<div className={"paragraph"} style={{ color: "orangered" }}>
+									<b>
+										Can create invalid game states. Go over
+										Instructions/Troubleshoot first and use carefully at your
+										own risk!
+									</b>
+								</div>
+								<div className={"paragraph"}>
+									Also, currently thunder dot buff created this way doesn't
+									actually tick. It just shows the remaining buff timer.
+								</div>
+								<div className={"paragraph"}>
+									I would recommend saving settings (stats, lines presets,
+									timeline markers etc.) to files first, in case invalid game
+									states really mess up the tool and a complete reset is required.
+								</div>
+							</div>,
+							zh: <div>
+								<div className={"paragraph"} style={{ color: "orangered" }}>
+									<b>
+										错误的初始资源可能会导致非法游戏状态。请在阅读工具顶部的使用说明/常见问题后慎重使用，并优先自行排查问题！
+									</b>
+								</div>
+								<div className={"paragraph"}>
+									另：当前靠初始资源覆盖添加的雷dot只显示剩余时间，不会结算伤害。
+								</div>
+								<div className={"paragraph"}>
+									使用此功能时，请最好先下载保存各项数据（面板数值，技能轴，时间轴预设等），以防造成未知错误后排轴器重置导致的数据丢失。
+								</div>
+							</div>,
+						})}
+					/>
+				</span>
+			}
+			content={
+				<div>
+					<button
+						onClick={(evt) => {
+							if (props.initialResourceOverrides.length > 0) {
+								props.setInitialResourceOverrides([]);
+							}
+							evt.preventDefault();
+						}}
+					>
+						{localize({ en: "clear all overrides", zh: "清除所有指定初始资源" })}
+					</button>
+					{resourceOverridesDisplayNodes}
+					{addResourceOverrideNode}
+				</div>
+			}
+		/>
+	</div>;
+}
+
+export function ConfigSummary(props: { job: ShellJob; dirty: boolean }) {
 	const lucidTickOffset = controller.game.lucidTickOffset.toFixed(3);
 	const lucidOffsetDesc = localize({
 		en: "the random time offset of lucid dreaming ticks relative to mp ticks",
@@ -147,6 +413,7 @@ export function ConfigSummary(props: { job: ShellJob; dirty: boolean }) {
 		en: "the random time offset of DoT ticks relative to mp ticks",
 		zh: "雷DoT期间，每次跳蓝后多久跳雷（由随机种子决定）", // Akairyu's Note - Needs retranslating after removing the reference to thunder
 	});
+	// These fields are deliberately updated only when `dirty` is updated and a re-render of this component is forced.
 	const procMode = controller.gameConfig.procMode;
 	const numOverrides = controller.gameConfig.initialResourceOverrides.length;
 	const legacyCasterTax = controller.gameConfig.legacy_casterTax;
@@ -210,8 +477,7 @@ export function ConfigSummary(props: { job: ShellJob; dirty: boolean }) {
 
 		{tryGetImplementationWarning(JOBS[props.job].implementationLevel, warningColor)}
 
-		{/* TODO: refactor these out to job props classes */}
-		{[...CASTER_JOBS, ...HEALER_JOBS].includes(props.job) && <div>
+		{["CASTER", "HEALER"].includes(JOBS[props.job].role) && <div>
 			{localize({ en: "Lucid tick offset ", zh: "醒梦&跳蓝时间差 " })}
 			<Help topic={"lucidTickOffset"} content={lucidOffsetDesc} />: {lucidTickOffset}
 		</div>}
@@ -407,15 +673,10 @@ export function TimeControl() {
 	</div>;
 }
 
-// states are mostly strings here because those inputs are controlled by <Input ... />
-type ConfigState = {
+// State tracking all fields that can be directly set by text input or gearset link import.
+// These are strings or string enums because their values are controlled by an <Input> field
+type ConfigFields = {
 	job: ShellJob;
-	shellVersion: ShellVersion;
-
-	gearImportLink: string;
-	imported: boolean;
-	importedFields: string[];
-
 	level: string;
 	spellSpeed: string;
 	skillSpeed: string;
@@ -430,1283 +691,853 @@ type ConfigState = {
 	countdown: string;
 	randomSeed: string;
 	procMode: ProcMode;
-	initialResourceOverrides: ResourceOverrideData[];
-
 	// set only by xivgear/etro import
+	// for use with ama's combat sim
 	tenacity: string;
 	wd: string;
 	main: string;
-
-	selectedOverrideResource: ResourceKey | CooldownKey;
-	overrideTimer: string;
-	overrideStacks: string;
-	overrideEnabled: boolean;
-
+	// not actually serialized state, but makes the reducer easier to manage
 	dirty: boolean;
-	gcdPreview: string;
-	taxedGcdPreview: string;
-	sksGcdPreview: string;
-	taxedSksGcdPreview: string;
 };
 
-export class Config extends React.Component {
-	state: ConfigState;
-	updateTaxPreview: (spsStr: string, fpsStr: string, levelStr: string) => void;
-	updateSksTaxPreview: (sksStr: string, fpsStr: string, levelStr: string) => void;
-	handleSubmit: MouseEventHandler;
+function ConfigInputField(props: {
+	key: keyof ConfigFields;
+	description: ContentNode;
+	initial: string;
+	dispatch: Dispatch<Partial<ConfigFields>>;
+	removeImportedField: (key: keyof ConfigFields) => void;
+	imported: boolean;
+}) {
+	const colors = useContext(ColorThemeContext);
+	const color = (
+		props.imported ? getThemeField(colors, "success") : getThemeField(colors, "text")
+	) as string;
+	return <Input
+		style={{ color }}
+		defaultValue={props.initial}
+		description={props.description}
+		onChange={(val: string) => {
+			props.dispatch({ [props.key]: val });
+			props.removeImportedField(props.key);
+		}}
+	/>;
+}
 
-	setJob: (evt: React.ChangeEvent<HTMLSelectElement>) => void;
-	importGear: (evt: React.SyntheticEvent) => void;
-	setGearImportLink: (evt: React.ChangeEvent<HTMLInputElement>) => void;
-	setSpellSpeed: (val: string) => void;
-	setSkillSpeed: (val: string) => void;
-	setLevel: (evt: React.ChangeEvent<HTMLSelectElement>) => void;
-	setCriticalHit: (val: string) => void;
-	setDirectHit: (val: string) => void;
-	setDetermination: (val: string) => void;
-	setPiety: (val: string) => void;
-	setAnimationLock: (val: string) => void;
-	setFps: (val: string) => void;
-	setGcdSkillCorrection: (val: string) => void;
-	setTimeTillFirstManaTick: (val: string) => void;
-	setCountdown: (val: string) => void;
-	setRandomSeed: (val: string) => void;
-	setProcMode: (evt: React.ChangeEvent<HTMLSelectElement>) => void;
-	setOverrideTimer: (val: string) => void;
-	setOverrideStacks: (val: string) => void;
-	setOverrideEnabled: (evt: React.ChangeEvent<{ checked: boolean }>) => void;
-	deleteResourceOverride: (rsc: ResourceKey | CooldownKey) => void;
-	removeImportedField: (field: string) => void;
-
-	static contextType = ColorThemeContext;
-
-	constructor(props: {}) {
-		super(props);
-		this.state = {
-			// NOT DEFAULTS
-			job: "BLM",
-			shellVersion: ShellInfo.version,
-			gearImportLink: "",
-			imported: false,
-			importedFields: [],
-			/////////
-			level: `${LevelSync.lvl100}`,
-			spellSpeed: "0",
-			skillSpeed: "0",
-			criticalHit: "0",
-			directHit: "0",
-			determination: "0",
-			piety: "0",
-			animationLock: "0",
-			fps: "0",
-			gcdSkillCorrection: "0",
-			timeTillFirstManaTick: "0",
-			countdown: "0",
-			randomSeed: "",
-			procMode: ProcMode.RNG,
-			initialResourceOverrides: [],
-			/////////
-			tenacity: "0",
-			wd: "0",
-			main: "0",
-			/////////
-			selectedOverrideResource: "MANA",
-			overrideTimer: "0",
-			overrideStacks: "0",
-			overrideEnabled: true,
-			/////////
-			dirty: false,
-			gcdPreview: "n/a",
-			taxedGcdPreview: "n/a",
-			sksGcdPreview: "n/a",
-			taxedSksGcdPreview: "n/a",
-		};
-
-		this.updateTaxPreview = (spsStr: string, fpsStr: string, levelStr: string) => {
-			const { gcdStr, taxedGcdStr } = this.getGcdTaxPreview(spsStr, fpsStr, levelStr);
-
-			this.setState({
-				gcdPreview: gcdStr,
-				taxedGcdPreview: taxedGcdStr,
-			});
-		};
-
-		this.updateSksTaxPreview = (sksStr: string, fpsStr: string, levelStr: string) => {
-			// TODO: This code does not correctly apply new haste modifiers if the job is changed.
-			const { gcdStr, taxedGcdStr } = this.getGcdTaxPreview(
-				sksStr,
-				fpsStr,
-				levelStr,
-				this.getSpeedModifier(),
-			);
-
-			this.setState({
-				sksGcdPreview: gcdStr,
-				taxedSksGcdPreview: taxedGcdStr,
-			});
-		};
-
-		this.handleSubmit = (event: React.SyntheticEvent) => {
-			if (this.#resourceOverridesAreValid()) {
-				let seed = this.state.randomSeed;
-				if (seed.length === 0) {
-					for (let i = 0; i < 4; i++) {
-						seed += Math.floor(Math.random() * 10).toString();
-					}
-					this.setState({ randomSeed: seed });
+function GearImport(props: {
+	imported: boolean;
+	setImported: (value: boolean) => void;
+	setImportedFields: (fields: (keyof ConfigFields)[]) => void;
+	dispatch: Dispatch<Partial<ConfigFields>>;
+}) {
+	const colors = getThemeColors(useContext(ColorThemeContext));
+	const [gearImportLink, setGearImportLink] = useState("");
+	const { imported, setImported } = props;
+	const importGear = async (event: React.SyntheticEvent) => {
+		event.preventDefault();
+		const url = URL.parse(gearImportLink);
+		const headers = new Headers();
+		try {
+			if (url && url.hostname === "etro.gg") {
+				const tokens = url.pathname.split("/");
+				if (tokens[1] !== "gearset" && tokens.length !== 3) {
+					throw new Error(
+						"Invalid etro gearset link (hover ? in URL input box for details)",
+					);
 				}
-				const config = { ...this.state, ...{ randomSeed: seed } };
-				this.setConfigAndRestart(config);
-				this.setState({ dirty: false, imported: false, importedFields: [] });
-				controller.scrollToTime();
-			}
-			event.preventDefault();
-		};
-
-		this.setJob = (evt) => {
-			// Reset all resource overrides
-			if (evt.target.value !== this.state.job) {
-				this.setState({ initialResourceOverrides: [], dirty: true });
-			}
-			this.setState({ job: evt.target.value, dirty: true });
-			this.removeImportedField("job");
-			this.updateTaxPreview(this.state.spellSpeed, this.state.fps, this.state.level);
-			this.updateSksTaxPreview(this.state.skillSpeed, this.state.fps, this.state.level);
-		};
-
-		this.setGearImportLink = (evt: React.ChangeEvent<HTMLInputElement>) => {
-			this.setState({ gearImportLink: evt.target.value });
-		};
-
-		this.importGear = async (event: React.SyntheticEvent) => {
-			event.preventDefault();
-			const url = URL.parse(this.state.gearImportLink);
-			const headers = new Headers();
-			try {
-				if (url && url.hostname === "etro.gg") {
-					const tokens = url.pathname.split("/");
-					if (tokens[1] !== "gearset" && tokens.length !== 3) {
-						throw new Error(
-							"Invalid etro gearset link (hover ? in URL input box for details)",
-						);
-					}
-					headers.append("Content-Type", "application/json");
-					const response = await fetch("https://etro.gg/api/gearsets/" + tokens[2], {
-						method: "GET",
-						headers: headers,
-					});
-					if (response.ok) {
-						const body: any = await response.json();
-						const stats = new Map<string, string>(
-							body["totalParams"].map((obj: any) => [obj["name"], obj["value"]]),
-						);
-						// The main stat should always be the first returned field.
-						const mainStat =
-							body["totalParams"].length > 0 ? body["totalParams"][0]["value"] : 0;
-						if (!(body["jobAbbrev"] in JOBS)) {
-							throw new Error(
-								"Imported gearset was for a job (" +
-									body["jobAbbrev"] +
-									") that XIV in the Shell doesn't support",
-							);
-						}
-						// TODO should probably validate each of these fields
-						const baseSpeed = XIVMath.getSubstatBase(
-							parseFloat(body["level"]) as LevelSync,
-						).toString();
-						const spellSpeed = stats.get("SPS") ?? baseSpeed;
-						const skillSpeed = stats.get("SKS") ?? baseSpeed;
-						const importedFields = [
-							"job",
-							"level",
-							"criticalHit",
-							"directHit",
-							"determination",
-							"main",
-						];
-						if (stats.has("SPS")) importedFields.push("spellSpeed");
-						if (stats.has("SKS")) importedFields.push("skillSpeed");
-						if (stats.has("PIE")) importedFields.push("piety");
-						if (stats.has("TEN")) importedFields.push("tenacity");
-						if (stats.has("Weapon Damage")) importedFields.push("wd");
-						this.setState({
-							job: body["jobAbbrev"],
-							level: body["level"],
-							spellSpeed,
-							skillSpeed,
-							wd: stats.get("Weapon Damage"),
-							criticalHit: stats.get("CRT"),
-							directHit: stats.get("DH"),
-							determination: stats.get("DET"),
-							piety: stats.get("PIE"),
-							tenacity: stats.get("TEN"),
-							main: mainStat,
-							imported: true,
-							importedFields: importedFields,
-							dirty: true,
-						});
-						this.updateTaxPreview(spellSpeed, this.state.fps, body["level"]);
-						this.updateSksTaxPreview(skillSpeed, this.state.fps, body["level"]);
-					} else {
-						console.error(response);
-						throw new Error("etro load failed (please check your link)");
-					}
-				} else if (url && url.hostname === "xivgear.app") {
-					const pageParam = url.searchParams.get("page");
-					if (!pageParam) {
-						throw new Error(
-							"xivgear link must be to a specific set (hover ? in URL input box for details)",
-						);
-					}
-					// strip the "sl|" url-encoded characters at the start of the link
-					const setId = pageParam.startsWith("sl|") ? pageParam.substr(3) : pageParam;
-					headers.append("Content-Type", "application/json");
-					const response = await fetch("https://api.xivgear.app/fulldata/" + setId, {
-						method: "GET",
-						headers: headers,
-					});
-					if (response.ok) {
-						const body: any = await response.json();
-						// TODO should probably validate each of these fields
-						if (!(body["job"] in JOBS)) {
-							throw new Error(
-								"Imported gearset was for a job (" +
-									body["job"] +
-									") that XIV in the Shell doesn't support",
-							);
-						}
-						const stats = body["sets"][0]["computedStats"];
-						// just assume the highest main stat/wd field is the correct one
-						const mainStat = Math.max(
-							...["strength", "dexterity", "intelligence", "mind"].map(
-								(field) => stats[field] ?? 0,
-							),
-						);
-						const wd = Math.max(stats["wdPhys"] ?? 0, stats["wdMag"] ?? 0);
-						this.setState({
-							job: body["job"],
-							level: body["level"],
-							spellSpeed: stats["spellspeed"],
-							skillSpeed: stats["skillspeed"],
-							criticalHit: stats["crit"],
-							directHit: stats["dhit"],
-							determination: stats["determination"],
-							piety: stats["piety"],
-							tenacity: stats["tenacity"],
-							wd,
-							main: mainStat,
-							imported: true,
-							importedFields: [
-								"job",
-								"level",
-								"spellSpeed",
-								"skillSpeed",
-								"criticalHit",
-								"directHit",
-								"determination",
-								"piety",
-								"tenacity",
-								"wd",
-								"main",
-							],
-							dirty: true,
-						});
-						this.updateTaxPreview(
-							stats["spellspeed"]!.toString(),
-							this.state.fps,
-							body["level"],
-						);
-					} else {
-						console.error("xivgear load failed: " + response);
-						throw new Error("xivgear load failed (please check your link)");
-					}
-				} else {
-					throw new Error("Invalid gearset link (must be from etro.gg or xivgear.app)");
-				}
-			} catch (e: any) {
-				console.error(e);
-				window.alert(e.message);
-			}
-		};
-
-		this.setSpellSpeed = (val: string) => {
-			this.setState({ spellSpeed: val, dirty: true });
-			this.removeImportedField("spellSpeed");
-			this.updateTaxPreview(val, this.state.fps, this.state.level);
-		};
-
-		this.setSkillSpeed = (val: string) => {
-			this.setState({ skillSpeed: val, dirty: true });
-			this.removeImportedField("skillSpeed");
-			this.updateSksTaxPreview(val, this.state.fps, this.state.level);
-		};
-
-		this.setLevel = (evt) => {
-			this.setState({ level: evt.target.value, dirty: true });
-			this.removeImportedField("level");
-			this.updateTaxPreview(this.state.spellSpeed, this.state.fps, evt.target.value);
-			this.updateSksTaxPreview(this.state.skillSpeed, this.state.fps, this.state.level);
-		};
-
-		this.setCriticalHit = (val: string) => {
-			this.setState({ criticalHit: val, dirty: true });
-			this.removeImportedField("criticalHit");
-		};
-
-		this.setDirectHit = (val: string) => {
-			this.setState({ directHit: val, dirty: true });
-			this.removeImportedField("directHit");
-		};
-
-		this.setDetermination = (val: string) => {
-			this.setState({ determination: val, dirty: true });
-			this.removeImportedField("determination");
-		};
-
-		this.setPiety = (val: string) => {
-			this.setState({ piety: val, dirty: true });
-			this.removeImportedField("piety");
-		};
-
-		this.setAnimationLock = (val: string) => {
-			this.setState({ animationLock: val, dirty: true });
-		};
-
-		this.setFps = (val: string) => {
-			this.setState({ fps: val, dirty: true });
-			this.updateTaxPreview(this.state.spellSpeed, val, this.state.level);
-		};
-
-		this.setGcdSkillCorrection = (val: string) => {
-			this.setState({ gcdSkillCorrection: val, dirty: true });
-		};
-
-		this.setTimeTillFirstManaTick = (val: string) => {
-			this.setState({ timeTillFirstManaTick: val, dirty: true });
-		};
-
-		this.setCountdown = (val: string) => {
-			this.setState({ countdown: val, dirty: true });
-		};
-
-		this.setRandomSeed = (val: string) => {
-			this.setState({ randomSeed: val, dirty: true });
-		};
-
-		this.setProcMode = (evt) => {
-			this.setState({ procMode: evt.target.value, dirty: true });
-		};
-
-		this.setOverrideTimer = (val: string) => {
-			this.setState({ overrideTimer: val });
-		};
-		this.setOverrideStacks = (val: string) => {
-			this.setState({ overrideStacks: val });
-		};
-		this.setOverrideEnabled = (evt: React.ChangeEvent<{ checked: boolean }>) => {
-			this.setState({ overrideEnabled: evt.target.checked });
-		};
-		this.deleteResourceOverride = (rscType: ResourceKey | CooldownKey) => {
-			const overrides = this.state.initialResourceOverrides;
-			for (let i = 0; i < overrides.length; i++) {
-				if (overrides[i].type === rscType) {
-					overrides.splice(i, 1);
-					break;
-				}
-			}
-			this.setState({ initialResourceOverrides: overrides, dirty: true });
-		};
-		this.removeImportedField = (field: string) => {
-			const idx = this.state.importedFields.indexOf(field);
-			if (idx >= 0) {
-				const newFieldsArray = this.state.importedFields;
-				newFieldsArray.splice(idx, 1);
-				this.setState({ importedFields: newFieldsArray });
-			}
-		};
-	}
-
-	private getSpeedModifier(): number | undefined {
-		const dummyConfig: GameConfig = new GameConfig({ ...DEFAULT_CONFIG, job: this.state.job });
-		return getGameState(dummyConfig).inherentSpeedModifier();
-	}
-
-	private getDefaultGcd(base: number): number {
-		const isSps =
-			JOBS[this.state.job].role === "CASTER" || JOBS[this.state.job].role === "HEALER";
-		return XIVMath.preTaxGcd(
-			parseFloat(this.state.level) as LevelSync,
-			isSps ? parseFloat(this.state.spellSpeed) : parseFloat(this.state.skillSpeed),
-			base,
-			this.getSpeedModifier(),
-		);
-	}
-
-	private getDefaultGcdTax(base: number): number {
-		// Returns the approxmiate duration of the GCD after applying innate haste buffs
-		// and FPS adjustments.
-		return XIVMath.afterFpsTax(parseFloat(this.state.fps), this.getDefaultGcd(base));
-	}
-
-	private getGcdTaxPreview(
-		speedStr: string,
-		fpsStr: string,
-		levelStr: string,
-		speedModifier?: number,
-	): { gcdStr: string; taxedGcdStr: string } {
-		const level = parseFloat(levelStr);
-		const speed = parseFloat(speedStr);
-		const fps = parseFloat(fpsStr);
-
-		let gcdStr: string;
-		let taxedGcdStr: string;
-		if (isNaN(level) || isNaN(speed) || isNaN(fps) || speed < 400) {
-			gcdStr = "n/a";
-			taxedGcdStr = "n/a";
-		} else {
-			const gcd = XIVMath.preTaxGcd(level as LevelSync, speed, 2.5, speedModifier);
-			gcdStr = gcd.toFixed(2);
-			taxedGcdStr = XIVMath.afterFpsTax(fps, gcd).toFixed(3);
-		}
-
-		return {
-			gcdStr,
-			taxedGcdStr,
-		};
-	}
-
-	// call this whenever the list of options has potentially changed
-	#getFirstAddable(overridesList: ResourceOverrideData[]) {
-		let firstAddableRsc = "aba aba";
-		const S = new Set<ResourceKey | CooldownKey>();
-		overridesList.forEach((ov) => {
-			S.add(ov.type);
-		});
-		for (const k of getAllResources(this.state.job).keys()) {
-			if (!S.has(k)) {
-				firstAddableRsc = k;
-				break;
-			}
-		}
-		return firstAddableRsc;
-	}
-
-	componentDidMount() {
-		updateConfigDisplay = (config) => {
-			this.setState(config);
-			const spsGcd = XIVMath.preTaxGcd(config.level, config.spellSpeed, 2.5);
-			const { gcdStr: sksGcdPreview, taxedGcdStr: taxedSksGcdPreview } =
-				this.getGcdTaxPreview(
-					config.skillSpeed.toString(),
-					config.fps.toString(),
-					config.level.toString(),
-					this.getSpeedModifier(),
-				);
-			this.setState({
-				dirty: false,
-				imported: false,
-				importedFields: [],
-				gcdPreview: spsGcd.toFixed(2),
-				taxedGcdPreview: XIVMath.afterFpsTax(config.fps, spsGcd).toFixed(3),
-				sksGcdPreview,
-				taxedSksGcdPreview,
-				selectedOverrideResource: this.#getFirstAddable(config.initialResourceOverrides),
-			});
-			refreshConfigSummary();
-		};
-	}
-
-	#resourceOverridesAreValid() {
-		// gather resources for quick access
-		const M = new Map<ResourceKey | CooldownKey, ResourceOverrideData>();
-		this.state.initialResourceOverrides.forEach((ov) => {
-			M.set(ov.type, ov);
-		});
-
-		// shouldn't have AF and UI at the same time
-		if (M.has("ASTRAL_FIRE") && M.has("UMBRAL_ICE")) {
-			const af = M.get("ASTRAL_FIRE")!.stacks;
-			const ui = M.get("UMBRAL_ICE")!.stacks;
-			if (af > 0 && ui > 0) {
-				window.alert("shouldn't have both AF and UI stacks");
-				return false;
-			}
-		}
-
-		let af = 0;
-		let ui = 0;
-		let uh = 0;
-		if (M.has("ASTRAL_FIRE")) af = M.get("ASTRAL_FIRE")!.stacks;
-		if (M.has("UMBRAL_ICE")) ui = M.get("UMBRAL_ICE")!.stacks;
-		if (M.has("UMBRAL_HEART")) uh = M.get("UMBRAL_HEART")!.stacks;
-
-		// if there's uh, must have AF/UI
-		if (uh > 0) {
-			if (af === 0 && ui === 0) {
-				window.alert(
-					"since there's at least one UH stack, there should also be Enochian and AF or UI",
-				);
-				return false;
-			}
-		}
-
-		// if there are AF/UI stacks, implicitly grant enochian
-		let hasEno = false;
-		if (af > 0 || ui > 0 || uh > 0) {
-			hasEno = true;
-		}
-		// if polyglot timer is set (>0), must have enochian
-		if (M.has("POLYGLOT")) {
-			const polyTimer = M.get("POLYGLOT")!.timeTillFullOrDrop;
-			if (polyTimer > 0 && !hasEno) {
-				window.alert(
-					"since a timer for polyglot is set (time till next stack > 0), there must also be AF/UI",
-				);
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	#addResourceOverride() {
-		const rscType = this.state.selectedOverrideResource;
-		const info = getAllResources(this.state.job).get(rscType)!;
-
-		let inputOverrideTimer = parseFloat(this.state.overrideTimer);
-		const inputOverrideStacks = parseInt(this.state.overrideStacks);
-		const inputOverrideEnabled = this.state.overrideEnabled;
-
-		// an exception for polyglot: leave empty := no timer set
-		if (rscType === "POLYGLOT" && this.state.overrideTimer === "") {
-			inputOverrideTimer = 0;
-		}
-
-		if (isNaN(inputOverrideStacks) || isNaN(inputOverrideTimer)) {
-			window.alert("some inputs are not numbers!");
-			return;
-		}
-
-		let props: ResourceOverrideData;
-
-		if (info.isCoolDown) {
-			const maxTimer = info.maxStacks * info.cdPerStack;
-			if (inputOverrideTimer < 0 || inputOverrideTimer > maxTimer) {
-				window.alert("invalid input timeout (must be in range [0, " + maxTimer + "])");
-				return;
-			}
-
-			props = {
-				type: rscType,
-				timeTillFullOrDrop: inputOverrideTimer,
-				stacks: info.maxStacks > 1 ? inputOverrideStacks : 1,
-				effectOrTimerEnabled: true,
-			};
-		} else {
-			if (
-				(info.maxValue > 1 || info.maxValue === info.defaultValue) &&
-				rscType !== "PARADOX" &&
-				(inputOverrideStacks < 0 || inputOverrideStacks > info.maxValue)
-			) {
-				window.alert("invalid input amount (must be in range [0, " + info.maxValue + "])");
-				return;
-			}
-			if (
-				info.maxTimeout >= 0 &&
-				(inputOverrideTimer < 0 || inputOverrideTimer > info.maxTimeout)
-			) {
-				window.alert(
-					"invalid input timeout (must be in range [0, " + info.maxTimeout + "])",
-				);
-				return;
-			}
-
-			props = {
-				type: rscType,
-				timeTillFullOrDrop: info.maxTimeout >= 0 ? inputOverrideTimer : -1,
-				stacks:
-					info.maxValue > 1 || info.maxValue === info.defaultValue
-						? inputOverrideStacks
-						: 1,
-				effectOrTimerEnabled: rscType === "LEY_LINES" ? inputOverrideEnabled : true,
-			};
-		}
-		// end validation
-
-		const overrides = this.state.initialResourceOverrides;
-		overrides.push(props);
-		this.setState({ initialResourceOverrides: overrides, dirty: true });
-	}
-
-	#addResourceOverrideNode() {
-		const resourceInfos = getAllResources(this.state.job);
-		const S = new Set();
-		this.state.initialResourceOverrides.forEach((override) => {
-			S.add(override.type);
-		});
-
-		const optionEntries: { rsc: ResourceKey | CooldownKey; isCoolDown: number }[] = [];
-		for (const k of resourceInfos.keys()) {
-			if (!S.has(k)) {
-				optionEntries.push({
-					rsc: k,
-					isCoolDown: resourceInfos.get(k)!.isCoolDown ? 1 : 0,
+				headers.append("Content-Type", "application/json");
+				const response = await fetch("https://etro.gg/api/gearsets/" + tokens[2], {
+					method: "GET",
+					headers: headers,
 				});
+				if (response.ok) {
+					const body: any = await response.json();
+					const stats = new Map<string, string>(
+						body["totalParams"].map((obj: any) => [obj["name"], obj["value"]]),
+					);
+					// The main stat should always be the first returned field.
+					const mainStat =
+						body["totalParams"].length > 0 ? body["totalParams"][0]["value"] : 0;
+					if (!(body["jobAbbrev"] in JOBS)) {
+						throw new Error(
+							"Imported gearset was for a job (" +
+								body["jobAbbrev"] +
+								") that XIV in the Shell doesn't support",
+						);
+					}
+					// TODO should probably validate each of these fields
+					const baseSpeed = XIVMath.getSubstatBase(
+						parseFloat(body["level"]) as LevelSync,
+					).toString();
+					const spellSpeed = stats.get("SPS") ?? baseSpeed;
+					const skillSpeed = stats.get("SKS") ?? baseSpeed;
+					const importedFields: (keyof ConfigFields)[] = [
+						"job",
+						"level",
+						"criticalHit",
+						"directHit",
+						"determination",
+						"main",
+					];
+					if (stats.has("SPS")) importedFields.push("spellSpeed");
+					if (stats.has("SKS")) importedFields.push("skillSpeed");
+					if (stats.has("PIE")) importedFields.push("piety");
+					if (stats.has("TEN")) importedFields.push("tenacity");
+					if (stats.has("Weapon Damage")) importedFields.push("wd");
+					props.dispatch({
+						job: body["jobAbbrev"],
+						level: body["level"],
+						spellSpeed,
+						skillSpeed,
+						wd: stats.get("Weapon Damage"),
+						criticalHit: stats.get("CRT"),
+						directHit: stats.get("DH"),
+						determination: stats.get("DET"),
+						piety: stats.get("PIE"),
+						tenacity: stats.get("TEN"),
+						main: mainStat,
+					});
+					props.setImportedFields(importedFields);
+					setImported(true);
+				} else {
+					console.error(response);
+					throw new Error("etro load failed (please check your link)");
+				}
+			} else if (url && url.hostname === "xivgear.app") {
+				const pageParam = url.searchParams.get("page");
+				if (!pageParam) {
+					throw new Error(
+						"xivgear link must be to a specific set (hover ? in URL input box for details)",
+					);
+				}
+				// strip the "sl|" url-encoded characters at the start of the link
+				const setId = pageParam.startsWith("sl|") ? pageParam.substr(3) : pageParam;
+				headers.append("Content-Type", "application/json");
+				const response = await fetch("https://api.xivgear.app/fulldata/" + setId, {
+					method: "GET",
+					headers: headers,
+				});
+				if (response.ok) {
+					const body: any = await response.json();
+					// TODO should probably validate each of these fields
+					if (!(body["job"] in JOBS)) {
+						throw new Error(
+							"Imported gearset was for a job (" +
+								body["job"] +
+								") that XIV in the Shell doesn't support",
+						);
+					}
+					const stats = body["sets"][0]["computedStats"];
+					// just assume the highest main stat/wd field is the correct one
+					const mainStat = Math.max(
+						...["strength", "dexterity", "intelligence", "mind"].map(
+							(field) => stats[field] ?? 0,
+						),
+					).toString();
+					const wd = Math.max(stats["wdPhys"] ?? 0, stats["wdMag"] ?? 0).toString();
+					const fields: Partial<ConfigFields> = {
+						job: body["job"],
+						level: body["level"],
+						spellSpeed: stats["spellspeed"],
+						skillSpeed: stats["skillspeed"],
+						criticalHit: stats["crit"],
+						directHit: stats["dhit"],
+						determination: stats["determination"],
+						piety: stats["piety"],
+						tenacity: stats["tenacity"],
+						wd,
+						main: mainStat,
+					};
+					props.dispatch(fields);
+					// @ts-expect-error compiler can't be sure that Object.keys matches ConfigFields
+					props.setImportedFields(Object.keys(fields));
+					setImported(true);
+				} else {
+					console.error("xivgear load failed: " + response);
+					throw new Error("xivgear load failed (please check your link)");
+				}
+			} else {
+				throw new Error("Invalid gearset link (must be from etro.gg or xivgear.app)");
+			}
+		} catch (e: any) {
+			console.error(e);
+			window.alert(e.message);
+		}
+	};
+	const etroLink = <a href="https://etro.gg" target="_blank" rel="noreferrer">
+		etro
+	</a>;
+	const xivgearLink = <a href="https://xivgear.app" target="_blank" rel="noreferrer">
+		xivgear
+	</a>;
+	return <form onSubmit={importGear}>
+		{localize({
+			en: <span>
+				Load stats from {etroLink}/{xivgearLink}:{" "}
+			</span>,
+			zh: <span>
+				从{etroLink}或{xivgearLink}导入套装：
+			</span>,
+		})}
+		<Help
+			topic={"gearImport"}
+			content={
+				<>
+					<p>
+						{localize({
+							en: <span>
+								Enter and <ButtonIndicator text={"Load"} /> a link to a gearset from
+								xivgear.app or etro.gg, edit the rest of config, then{" "}
+								<ButtonIndicator text={"apply and reset"} />.
+							</span>,
+							zh: <span>
+								输入xivgear.app或etro.gg的套装链接并
+								<ButtonIndicator text={"加载"} />
+								，调整其余角色属性，然后
+								<ButtonIndicator text={"应用并重置时间轴"} />。
+							</span>,
+						})}
+					</p>
+					<p>
+						{localize({
+							en: "etro: Copy/paste the link to the set (example: https://etro.gg/gearset/e13d5960-4794-4dc4-b273-24ecfed6745e)",
+							zh: "etro：复制粘贴套装链接（例：https://etro.gg/gearset/e13d5960-4794-4dc4-b273-24ecfed6745e）",
+						})}
+					</p>
+					<p>
+						{localize({
+							en:
+								'xivgear: At the top of the page, click "Export" -> "Selected Set" -> "Link to This Set" -> "Generate"' +
+								" (example: https://xivgear.app/?page=sl%7C143f3245-c35b-4391-8b2b-db5cc1a8de9a)",
+							zh: 'xivgear：从页面顶端点击 "Export" -> "Selected Set" -> "Link to This Set" -> "Generate"（例：https://xivgear.app/?page=sl%7C143f3245-c35b-4391-8b2b-db5cc1a8de9a）',
+						})}
+					</p>
+				</>
+			}
+		/>
+		<div style={{ position: "relative", marginTop: 5 }}>
+			<Input
+				style={{ display: "inline-block" }}
+				width={25}
+				description={""}
+				onChange={(s) => setGearImportLink(s)}
+			/>
+			<span> </span>
+			<input
+				style={{ display: "inline-block" }}
+				type="submit"
+				value={localize({ en: "Load", zh: "加载" }) as string}
+			/>
+			{
+				<FaCheck
+					style={{
+						display: imported ? "inline" : "none",
+						color: colors.success,
+						position: "relative",
+						top: 4,
+						marginLeft: 8,
+					}}
+				/>
+			}
+		</div>
+	</form>;
+}
+
+function getGcdTaxPreview(
+	speedStr: string,
+	fpsStr: string,
+	levelStr: string,
+	speedModifier?: number,
+): { gcdStr: string; taxedGcdStr: string } {
+	const level = parseFloat(levelStr);
+	const speed = parseFloat(speedStr);
+	const fps = parseFloat(fpsStr);
+	let gcdStr: string;
+	let taxedGcdStr: string;
+	if (isNaN(level) || isNaN(speed) || isNaN(fps) || speed < 400) {
+		gcdStr = "n/a";
+		taxedGcdStr = "n/a";
+	} else {
+		const gcd = XIVMath.preTaxGcd(level as LevelSync, speed, 2.5, speedModifier);
+		gcdStr = gcd.toFixed(2);
+		taxedGcdStr = XIVMath.afterFpsTax(fps, gcd).toFixed(3);
+	}
+	return {
+		gcdStr,
+		taxedGcdStr,
+	};
+}
+
+// TODO this function currently only validates BLM's ice/fire state overrides, but other jobs
+// have invalid combinations that need validation too
+function validateResourceOverrides(initialResourceOverrides: ResourceOverrideData[]): boolean {
+	// gather resources for quick access
+	const M = new Map<ResourceKey | CooldownKey, ResourceOverrideData>(
+		initialResourceOverrides.map((rsc) => [rsc.type, rsc]),
+	);
+
+	// shouldn't have AF and UI at the same time
+	if (M.has("ASTRAL_FIRE") && M.has("UMBRAL_ICE")) {
+		const af = M.get("ASTRAL_FIRE")!.stacks;
+		const ui = M.get("UMBRAL_ICE")!.stacks;
+		if (af > 0 && ui > 0) {
+			window.alert("shouldn't have both AF and UI stacks");
+			return false;
+		}
+	}
+
+	let af = 0;
+	let ui = 0;
+	let uh = 0;
+	if (M.has("ASTRAL_FIRE")) af = M.get("ASTRAL_FIRE")!.stacks;
+	if (M.has("UMBRAL_ICE")) ui = M.get("UMBRAL_ICE")!.stacks;
+	if (M.has("UMBRAL_HEART")) uh = M.get("UMBRAL_HEART")!.stacks;
+
+	// if there's uh, must have AF/UI
+	if (uh > 0) {
+		if (af === 0 && ui === 0) {
+			window.alert(
+				"since there's at least one UH stack, there should also be Enochian and AF or UI",
+			);
+			return false;
+		}
+	}
+
+	// if there are AF/UI stacks, implicitly grant enochian
+	let hasEno = false;
+	if (af > 0 || ui > 0 || uh > 0) {
+		hasEno = true;
+	}
+	// if polyglot timer is set (>0), must have enochian
+	if (M.has("POLYGLOT")) {
+		const polyTimer = M.get("POLYGLOT")!.timeTillFullOrDrop;
+		if (polyTimer > 0 && !hasEno) {
+			window.alert(
+				"since a timer for polyglot is set (time till next stack > 0), there must also be AF/UI",
+			);
+			return false;
+		}
+	}
+
+	return true;
+}
+
+export function Config() {
+	const colors = getThemeColors(useContext(ColorThemeContext));
+	const [jobSpeedMod, setjobSpeedMod] = useState<number | undefined>(undefined);
+	const [shellVersion, setShellVersion] = useState<ShellVersion>(ShellVersion.AllaganGcdFormula);
+	// resource override management
+	const [initialResourceOverrides, _setInitialResourceOverrides] = useState<
+		ResourceOverrideData[]
+	>([]);
+	const [overrideTimer, setOverrideTimer] = useState("0");
+	const [overrideStacks, setOverrideStacks] = useState("0");
+	const [overrideEnabled, setOverrideEnabled] = useState(true);
+	const setInitialResourceOverrides = (data: ResourceOverrideData[]) => {
+		setDirty(true);
+		_setInitialResourceOverrides(data);
+		setFirstSelectedOverride(data);
+	};
+	const [selectedOverrideResource, setSelectedOverrideResource] = useState<
+		ResourceKey | CooldownKey
+	>("NEVER");
+	const setFirstSelectedOverride = (overrides: ResourceOverrideData[]) => {
+		const S = new Set<ResourceKey | CooldownKey>(overrides.map((ov) => ov.type));
+		// TODO update ordering to something that's more intuitive?
+		const firstAddableRsc: ResourceKey | CooldownKey =
+			getAllResources(configFields.job)
+				.keys()
+				.find((rsc) => !S.has(rsc)) ?? "NEVER";
+		setSelectedOverrideResource(firstAddableRsc);
+	};
+	// config field management
+	function configFieldReducer(
+		prevState: ConfigFields,
+		action: Partial<ConfigFields>,
+	): ConfigFields {
+		const newState: ConfigFields = {
+			...prevState,
+			...action,
+		};
+		if (!Object.is(newState, prevState)) {
+			// The reducer runs on component render and registers a change from the initial state,
+			// so the initializing action must explicitly set dirty to false.
+			newState.dirty = action.dirty ?? true;
+			if (action.job !== undefined && action.job !== prevState.job) {
+				// If the job changed, update haste modifiers and clear resource overrides.
+				const dummyConfig: GameConfig = new GameConfig(makeDefaultConfig(action.job));
+				const speedModifier = getGameState(dummyConfig).inherentSpeedModifier();
+				setjobSpeedMod(speedModifier);
+				_setInitialResourceOverrides([]);
+				// need to duplicate some code to prevent a bootstrapping error
+				const firstAddableRsc: ResourceKey | CooldownKey =
+					getAllResources(action.job).keys().toArray()?.[0] ?? "NEVER";
+				setSelectedOverrideResource(firstAddableRsc);
 			}
 		}
-		const resourceOptions = optionEntries
-			.sort((a, b) => {
-				return a.isCoolDown - b.isCoolDown;
-			})
-			.map((opt, i) => {
-				return <option key={i} value={opt.rsc}>
-					{localizeResourceType(opt.rsc)}
-				</option>;
+		return newState;
+	}
+	const [configFields, configFieldDispatch] = useReducer(configFieldReducer, {
+		job: "BLM" as ShellJob,
+		level: `${LevelSync.lvl100}`,
+		spellSpeed: "0",
+		skillSpeed: "0",
+		criticalHit: "0",
+		directHit: "0",
+		determination: "0",
+		piety: "0",
+		animationLock: "0",
+		fps: "0",
+		gcdSkillCorrection: "0",
+		timeTillFirstManaTick: "0",
+		countdown: "0",
+		randomSeed: "",
+		procMode: ProcMode.RNG,
+		tenacity: "0",
+		wd: "0",
+		main: "0",
+		dirty: false,
+	});
+	const setDirty = (b: boolean) => configFieldDispatch({ dirty: b });
+	const singleDispatch = (key: keyof ConfigFields) => (v: string) =>
+		configFieldDispatch({ [key]: v });
+	// gearset import state
+	const [imported, setImported] = useState(false);
+	// @ts-expect-error compiler doesn't know this iteration is exhaustive over configFields keys
+	const emptyImportedFields: { [Property in keyof ConfigFields]: boolean } = Object.fromEntries(
+		Object.keys(configFields).map((key) => [key, false]),
+	);
+	const [importedFields, _setImportedFields] = useState(emptyImportedFields);
+	const addImportedFields = (keys: (keyof ConfigFields)[]) => {
+		_setImportedFields({
+			...importedFields,
+			...Object.fromEntries(keys.map((key) => [key, true])),
+		});
+	};
+	const removeImportedField = (key: keyof ConfigFields) => {
+		_setImportedFields({
+			...importedFields,
+			[key]: false,
+		});
+	};
+	const clearImportedFields = () => {
+		_setImportedFields(emptyImportedFields);
+		setImported(false);
+	};
+
+	// DANGER!! CONTROLLER STATE HACK
+	useEffect(() => {
+		updateConfigDisplay = (config: SerializedConfig) => {
+			setShellVersion(config.shellVersion);
+			setInitialResourceOverrides(config.initialResourceOverrides);
+			configFieldDispatch({
+				...Object.fromEntries(
+					Object.entries(config).flatMap(([key, value]) =>
+						key !== "initialResourceOverrides" ? [[key, value.toString()]] : [],
+					),
+				),
+			});
+			setDirty(false);
+			clearImportedFields();
+			// Update resource override module
+			setFirstSelectedOverride(config.initialResourceOverrides);
+		};
+	});
+
+	const fieldColor = (field: keyof ConfigFields) =>
+		importedFields[field] ? colors.success : colors.text;
+
+	const editJobSection = <div style={{ marginBottom: 10 }}>
+		<span>{localize({ en: "job: ", zh: "职业：" })}</span>
+		<select
+			style={{ outline: "none", color: fieldColor("job") }}
+			value={configFields.job}
+			onChange={(s) => {
+				removeImportedField("job");
+				configFieldDispatch({ job: s.target.value as ShellJob });
+			}}
+		>
+			{ALL_JOBS.filter((job) => JOBS[job].implementationLevel !== "UNIMPLEMENTED").map(
+				(job) => {
+					const impl = JOBS[job].implementationLevel as ImplementationKey;
+					if (impl !== "LIVE") {
+						return <option key={job} value={job}>
+							{job +
+								` (${localize(IMPLEMENTATION_LEVELS[impl].label ?? { en: "" })})`}
+						</option>;
+					} else {
+						return <option key={job} value={job}>
+							{job}
+						</option>;
+					}
+				},
+			)}
+		</select>
+	</div>;
+
+	const { gcdStr: spsGcdPreview, taxedGcdStr: taxedSpsGcdPreview } = getGcdTaxPreview(
+		configFields.spellSpeed,
+		configFields.fps,
+		configFields.level,
+		jobSpeedMod,
+	);
+	const { gcdStr: sksGcdPreview, taxedGcdStr: taxedSksGcdPreview } = getGcdTaxPreview(
+		configFields.skillSpeed,
+		configFields.fps,
+		configFields.level,
+		jobSpeedMod,
+	);
+	const fpsAndCorrectionColor =
+		shellVersion >= ShellVersion.FpsTax ? colors.text : colors.warning;
+	const job: ShellJob = configFields.job;
+	const isSps = JOBS[job].role === "CASTER" || JOBS[job].role === "HEALER";
+	const speedStr = {
+		en: isSps ? "spell" : "skill",
+		zh: isSps ? "咏" : "技",
+	};
+	const getDefaultGcd = (base: number) =>
+		XIVMath.preTaxGcd(
+			parseFloat(configFields.level) as LevelSync,
+			isSps ? parseFloat(configFields.spellSpeed) : parseFloat(configFields.skillSpeed),
+			base,
+			jobSpeedMod,
+		);
+	// Approxmiate duration of the GCD after applying innate haste buffs and FPS adjustments.
+	const getDefaultGcdTax = (base: number) =>
+		XIVMath.afterFpsTax(parseFloat(configFields.fps), getDefaultGcd(base));
+
+	const gcdTaxDesc = <div>
+		<style>{getTableStyle(colors.bgHighContrast)}</style>
+		<div style={{ marginBottom: 10 }}>
+			{localize({
+				en: `Preview numbers based on your current ${speedStr.en} speed and FPS input:`,
+				zh: `根据当前输入的${speedStr.zh}速和帧率，你将得到如下帧率税：`,
+			})}
+		</div>
+		<table className="castTimeTable">
+			<tbody>
+				<tr>
+					<th>{localize({ en: "GCD time", zh: "GCD时间" })}</th>
+					<th>{localize({ en: "After FPS tax", zh: "帧率税后" })}</th>
+				</tr>
+				{[2.5, 3.0, 3.5, 4.0].map((recast, i) => <tr key={"gcdPreview" + i.toString()}>
+					<td>
+						{getDefaultGcd(recast).toFixed(2)} ({recast.toFixed(2)}{" "}
+						{localize({ en: "base", zh: "原始" })})
+					</td>
+					<td>{getDefaultGcdTax(recast).toFixed(3)}</td>
+				</tr>)}
+			</tbody>
+		</table>
+	</div>;
+
+	const handleSubmit = (event: React.SyntheticEvent) => {
+		if (validateResourceOverrides(initialResourceOverrides)) {
+			let seed = configFields.randomSeed;
+			if (seed.length === 0) {
+				for (let i = 0; i < 4; i++) {
+					seed += Math.floor(Math.random() * 10).toString();
+				}
+				configFieldDispatch({ randomSeed: seed });
+			}
+			// Confirm config and restart sim
+			const numericFields: (keyof ConfigFields)[] = [
+				"spellSpeed",
+				"skillSpeed",
+				"criticalHit",
+				"directHit",
+				"determination",
+				"animationLock",
+				"fps",
+				"gcdSkillCorrection",
+				"timeTillFirstManaTick",
+				"countdown",
+				"level",
+				"wd",
+				"main",
+				"tenacity",
+			];
+			if (
+				numericFields
+					.map((field) => isNaN(parseFloat(configFields[field].toString())))
+					.some((x) => x)
+			) {
+				window.alert("Some config fields are not numbers!");
+				return;
+			}
+			if (!(configFields.job in JOBS)) {
+				window.alert("Invalid job: " + configFields.job);
+				return;
+			}
+			// @ts-expect-error too onerous to manually specify every field in a way that type-checks with fromEntries
+			controller.setConfigAndRestart({
+				job: configFields.job,
+				randomSeed: seed.trim(),
+				procMode: configFields.procMode,
+				initialResourceOverrides, // info only
+				...Object.fromEntries(
+					numericFields.map((field) => [
+						field,
+						parseFloat(configFields[field].toString()),
+					]),
+				),
 			});
 
-		const rscType = this.state.selectedOverrideResource;
-		const info = resourceInfos.get(rscType);
-		let inputSection = undefined;
-		if (info !== undefined) {
-			let showTimer, showAmount, showEnabled;
-			let timerDefaultValue = "-1",
-				timerOnChange = undefined;
-			let amountDefaultValue = "0",
-				amountOnChange = undefined;
-
-			if (info.isCoolDown) {
-				showTimer = true;
-				showAmount = false;
-				showEnabled = false;
-				timerDefaultValue = this.state.overrideTimer;
-				timerOnChange = this.setOverrideTimer;
-			} else {
-				// timer
-				if (info.maxTimeout >= 0) {
-					showTimer = true;
-					timerDefaultValue = this.state.overrideTimer;
-					timerOnChange = this.setOverrideTimer;
-				} else {
-					showTimer = false;
-				}
-
-				// amount
-				// hide the amount display if the resource has only one stack
-				// unless that stack is set by default
-				if (info.maxValue > 1 || info.maxValue === info.defaultValue) {
-					showAmount = true;
-					amountDefaultValue = this.state.overrideStacks;
-					amountOnChange = this.setOverrideStacks;
-				} else {
-					showAmount = false;
-				}
-
-				// enabled
-				showEnabled = rscType === "LEY_LINES";
-			}
-
-			let timerDesc;
-			if (info.isCoolDown) {
-				timerDesc = localize({ en: "Time till full: ", zh: "距CD转好时间：" }) as string;
-			} else if (rscType === "POLYGLOT") {
-				timerDesc = localize({
-					en: "Time till next stack: ",
-					zh: "距下一层时间：",
-				}) as string;
-			} else {
-				timerDesc = localize({ en: "Time till drop: ", zh: " 距状态消失时间：" }) as string;
-			}
-
-			const enabledDesc = localize({ en: "enabled", zh: "生效中" });
-
-			inputSection = <div style={{ margin: "6px 0" }}>
-				{/*timer*/}
-				<div hidden={!showTimer}>
-					<Input
-						description={timerDesc}
-						defaultValue={timerDefaultValue}
-						onChange={timerOnChange}
-					/>
-				</div>
-
-				{/*stacks*/}
-				<div hidden={!showAmount}>
-					<Input
-						description={localize({ en: "Amount: ", zh: "数量：" })}
-						defaultValue={amountDefaultValue}
-						onChange={amountOnChange}
-					/>
-				</div>
-
-				{/*enabled*/}
-				<div hidden={!showEnabled}>
-					<input
-						style={{ position: "relative", top: 3, marginRight: 5 }}
-						type="checkbox"
-						checked={this.state.overrideEnabled}
-						onChange={this.setOverrideEnabled}
-					/>
-					<span>{enabledDesc}</span>
-				</div>
-			</div>;
+			setDirty(false);
+			clearImportedFields();
+			controller.updateAllDisplay();
+			controller.scrollToTime();
 		}
+		event.preventDefault();
+	};
 
-		// @ts-expect-error: this.context is untyped, and we need this to access the ColorTheme context
-		const bg = getThemeField(this.context, "bgMediumContrast");
+	// Stats that use ConfigInputField directly, without any bells and whistles
+	const genericInputStats: Array<[keyof ConfigFields, ContentNode]> = [
+		["criticalHit", localize({ en: "crit: ", zh: "暴击：" })],
+		["directHit", localize({ en: "direct hit: ", zh: "直击：" })],
+		["determination", localize({ en: "determination: ", zh: "信念：" })],
+		["piety", localize({ en: "piety: ", zh: "信仰：" })],
+		["animationLock", localize({ en: "animation lock: ", zh: "能力技后摇：" })],
+	];
 
-		return <div>
-			<form
-				onSubmit={(evt) => {
-					this.#addResourceOverride();
-					this.setState({
-						selectedOverrideResource: this.#getFirstAddable(
-							this.state.initialResourceOverrides,
-						),
-					});
-					evt.preventDefault();
-				}}
-				style={{
-					marginTop: 16,
-					outline: "1px solid " + bg,
-					outlineOffset: 6,
-				}}
-			>
-				<select
-					value={this.state.selectedOverrideResource}
-					onChange={(evt) => {
-						if (evt.target) {
-							this.setState({
-								selectedOverrideResource: evt.target.value,
-								overrideEnabled:
-									evt.target.value === "LEY_LINES"
-										? this.state.overrideEnabled
-										: true,
-							});
-						}
-					}}
-				>
-					{resourceOptions}
-				</select>
-				{inputSection}
-				<input
-					type="submit"
-					value={localize({ en: "add override", zh: "应用此状态" }) as string}
-				/>
-			</form>
-		</div>;
-	}
+	const genericInputStatWidgets = genericInputStats.map(([key, description]) => <ConfigInputField
+		key={key}
+		description={description}
+		initial={configFields[key].toString()}
+		dispatch={configFieldDispatch}
+		imported={importedFields[key]}
+		removeImportedField={(key) => removeImportedField(key)}
+	/>);
 
-	#resourceOverridesSection() {
-		const resourceOverridesDisplayNodes = [];
-		for (let i = 0; i < this.state.initialResourceOverrides.length; i++) {
-			const override = this.state.initialResourceOverrides[i];
-			resourceOverridesDisplayNodes.push(
-				<ResourceOverrideDisplay
-					job={this.state.job}
-					key={i}
-					override={override}
-					deleteFn={this.deleteResourceOverride}
-				/>,
-			);
-		}
-		return <div style={{ marginTop: 10 }}>
-			<Expandable
-				title="overrideInitialResources"
-				titleNode={
-					<span>
-						{localize({ en: "Override initial resources", zh: "指定初始资源" })}{" "}
-						<Help
-							topic="overrideInitialResources"
-							content={localize({
-								en: <div>
-									<div className={"paragraph"} style={{ color: "orangered" }}>
-										<b>
-											Can create invalid game states. Go over
-											Instructions/Troubleshoot first and use carefully at
-											your own risk!
-										</b>
-									</div>
-									<div className={"paragraph"}>
-										Also, currently thunder dot buff created this way doesn't
-										actually tick. It just shows the remaining buff timer.
-									</div>
-									<div className={"paragraph"}>
-										I would recommend saving settings (stats, lines presets,
-										timeline markers etc.) to files first, in case invalid game
-										states really mess up the tool and a complete reset is
-										required.
-									</div>
-								</div>,
-								zh: <div>
-									<div className={"paragraph"} style={{ color: "orangered" }}>
-										<b>
-											错误的初始资源可能会导致非法游戏状态。请在阅读工具顶部的使用说明/常见问题后慎重使用，并优先自行排查问题！
-										</b>
-									</div>
-									<div className={"paragraph"}>
-										另：当前靠初始资源覆盖添加的雷dot只显示剩余时间，不会结算伤害。
-									</div>
-									<div className={"paragraph"}>
-										使用此功能时，请最好先下载保存各项数据（面板数值，技能轴，时间轴预设等），以防造成未知错误后排轴器重置导致的数据丢失。
-									</div>
-								</div>,
-							})}
-						/>
-					</span>
-				}
-				content={
-					<div>
-						<button
-							onClick={(evt) => {
-								this.setState({ initialResourceOverrides: [], dirty: true });
-								evt.preventDefault();
-							}}
-						>
-							{localize({ en: "clear all overrides", zh: "清除所有指定初始资源" })}
-						</button>
-						{resourceOverridesDisplayNodes}
-						{this.#addResourceOverrideNode()}
-					</div>
-				}
-			/>
-		</div>;
-	}
-
-	setConfigAndRestart(config: ConfigState) {
-		const numericFields: (keyof ConfigState)[] = [
-			"spellSpeed",
-			"skillSpeed",
-			"criticalHit",
-			"directHit",
-			"determination",
-			"animationLock",
-			"fps",
-			"gcdSkillCorrection",
-			"timeTillFirstManaTick",
-			"countdown",
-			"level",
-			"wd",
-			"main",
-			"tenacity",
-		];
-		if (
-			// @ts-expect-error we know that all the fields correspond to number values here
-			// (should split up state later)
-			numericFields.map((field) => isNaN(parseFloat(config[field]))).some((x) => x)
-		) {
-			window.alert("Some config fields are not numbers!");
-			return;
-		}
-		if (config.initialResourceOverrides === undefined) {
-			config.initialResourceOverrides = [];
-		}
-		if (!(config.job in JOBS)) {
-			window.alert("Invalid job: " + config.job);
-			return;
-		}
-		// @ts-expect-error too hard to manually specify every field, should refactor
-		controller.setConfigAndRestart({
-			job: config.job,
-			randomSeed: config.randomSeed.trim(),
-			procMode: config.procMode,
-			initialResourceOverrides: config.initialResourceOverrides, // info only
-			...Object.fromEntries(
-				// @ts-expect-error we know that all fields correspond to number values here
-				numericFields.map((field) => [field, parseFloat(config[field])]),
-			),
-		});
-		controller.updateAllDisplay();
-	}
-
-	componentWillUnmount() {
-		updateConfigDisplay = (config) => {};
-	}
-
-	render() {
-		// @ts-expect-error: this.context is untyped, and we need this to access the ColorTheme context
-		const colors = getThemeColors(this.context);
-		const fpsAndCorrectionColor =
-			this.state.shellVersion >= ShellVersion.FpsTax ? colors.text : colors.warning;
-		const isSps =
-			JOBS[this.state.job].role === "CASTER" || JOBS[this.state.job].role === "HEALER";
-		const speedStr = {
-			en: isSps ? "spell" : "skill",
-			zh: isSps ? "咏" : "技",
-		};
-		const gcdTaxDesc = <div>
-			<style>{getTableStyle(colors.bgHighContrast)}</style>
-			<div style={{ marginBottom: 10 }}>
-				{localize({
-					en: `Preview numbers based on your current ${speedStr.en} speed and FPS input:`,
-					zh: `根据当前输入的${speedStr.zh}速和帧率，你将得到如下帧率税：`,
-				})}
-			</div>
-			<table className="castTimeTable">
-				<tbody>
-					<tr>
-						<th>{localize({ en: "GCD time", zh: "GCD时间" })}</th>
-						<th>{localize({ en: "After FPS tax", zh: "帧率税后" })}</th>
-					</tr>
-					{[2.5, 3.0, 3.5, 4.0].map((recast, i) => <tr key={"gcdPreview" + i.toString()}>
-						<td>
-							{this.getDefaultGcd(recast).toFixed(2)} ({recast.toFixed(2)}{" "}
-							{localize({ en: "base", zh: "原始" })})
-						</td>
-						<td>{this.getDefaultGcdTax(recast).toFixed(3)}</td>
-					</tr>)}
-				</tbody>
-			</table>
-		</div>;
-		const etroLink = <a href="https://etro.gg" target="_blank" rel="noreferrer">
-			etro
-		</a>;
-		const xivgearLink = <a href="https://xivgear.app" target="_blank" rel="noreferrer">
-			xivgear
-		</a>;
-		const gearImportSection = <form onSubmit={this.importGear}>
-			{localize({
-				en: <span>
-					Load stats from {etroLink}/{xivgearLink}:{" "}
-				</span>,
-				zh: <span>
-					从{etroLink}或{xivgearLink}导入套装：
-				</span>,
-			})}
-			<Help
-				topic={"gearImport"}
-				content={
-					<>
-						<p>
-							{localize({
-								en: <span>
-									Enter and <ButtonIndicator text={"Load"} /> a link to a gearset
-									from xivgear.app or etro.gg, edit the rest of config, then{" "}
-									<ButtonIndicator text={"apply and reset"} />.
-								</span>,
-								zh: <span>
-									输入xivgear.app或etro.gg的套装链接并
-									<ButtonIndicator text={"加载"} />
-									，调整其余角色属性，然后
-									<ButtonIndicator text={"应用并重置时间轴"} />。
-								</span>,
-							})}
-						</p>
-						<p>
-							{localize({
-								en: "etro: Copy/paste the link to the set (example: https://etro.gg/gearset/e13d5960-4794-4dc4-b273-24ecfed6745e)",
-								zh: "etro：复制粘贴套装链接（例：https://etro.gg/gearset/e13d5960-4794-4dc4-b273-24ecfed6745e）",
-							})}
-						</p>
-						<p>
-							{localize({
-								en:
-									'xivgear: At the top of the page, click "Export" -> "Selected Set" -> "Link to This Set" -> "Generate"' +
-									" (example: https://xivgear.app/?page=sl%7C143f3245-c35b-4391-8b2b-db5cc1a8de9a)",
-								zh: 'xivgear：从页面顶端点击 "Export" -> "Selected Set" -> "Link to This Set" -> "Generate"（例：https://xivgear.app/?page=sl%7C143f3245-c35b-4391-8b2b-db5cc1a8de9a）',
-							})}
-						</p>
-					</>
-				}
-			/>
-			<div style={{ position: "relative", marginTop: 5 }}>
-				<Input
-					style={{ display: "inline-block" }}
-					width={25}
-					description={""}
-					onChange={(s) => {
-						this.setState({ gearImportLink: s });
-					}}
-				/>
-				<span> </span>
-				<input
-					style={{ display: "inline-block" }}
-					type="submit"
-					value={localize({ en: "Load", zh: "加载" }) as string}
-				/>
-				{
-					<FaCheck
-						style={{
-							display: this.state.imported ? "inline" : "none",
-							color: colors.success,
-							position: "relative",
-							top: 4,
-							marginLeft: 8,
-						}}
-					/>
-				}
-			</div>
-		</form>;
-		const fieldColor = (field: string) => {
-			if (this.state.importedFields.indexOf(field) > -1) {
-				return colors.success;
-			} else {
-				return colors.text;
-			}
-		};
-		const editJobSection = <div style={{ marginBottom: 10 }}>
-			<span>{localize({ en: "job: ", zh: "职业：" })}</span>
+	const editStatsSection = <div style={{ marginBottom: 16 }}>
+		<div>
+			<span>{localize({ en: "level: ", zh: "等级：" })}</span>
 			<select
-				style={{ outline: "none", color: fieldColor("job") }}
-				value={this.state.job}
-				onChange={this.setJob}
+				style={{ outline: "none", color: fieldColor("level") }}
+				value={configFields.level}
+				onChange={(e) => configFieldDispatch({ level: e.target.value })}
 			>
-				{ALL_JOBS.filter((job) => JOBS[job].implementationLevel !== "UNIMPLEMENTED").map(
-					(job) => {
-						const impl = JOBS[job].implementationLevel as ImplementationKey;
-						if (impl !== "LIVE") {
-							return <option key={job} value={job}>
-								{job +
-									` (${localize(IMPLEMENTATION_LEVELS[impl].label ?? { en: "" })})`}
-							</option>;
-						} else {
-							return <option key={job} value={job}>
-								{job}
-							</option>;
-						}
-					},
-				)}
+				<option key={LevelSync.lvl100} value={LevelSync.lvl100}>
+					100
+				</option>
+				<option key={LevelSync.lvl90} value={LevelSync.lvl90}>
+					90
+				</option>
+				<option key={LevelSync.lvl80} value={LevelSync.lvl80}>
+					80
+				</option>
+				<option key={LevelSync.lvl70} value={LevelSync.lvl70}>
+					70
+				</option>
 			</select>
-		</div>;
-		const editStatsSection = <div style={{ marginBottom: 16 }}>
-			<div>
-				<span>{localize({ en: "level: ", zh: "等级：" })}</span>
-				<select
-					style={{ outline: "none", color: fieldColor("level") }}
-					value={this.state.level}
-					onChange={this.setLevel}
-				>
-					<option key={LevelSync.lvl100} value={LevelSync.lvl100}>
-						100
-					</option>
-					<option key={LevelSync.lvl90} value={LevelSync.lvl90}>
-						90
-					</option>
-					<option key={LevelSync.lvl80} value={LevelSync.lvl80}>
-						80
-					</option>
-					<option key={LevelSync.lvl70} value={LevelSync.lvl70}>
-						70
-					</option>
-				</select>
-			</div>
-			<div>
-				<Input
-					style={{ display: "inline-block", color: fieldColor("spellSpeed") }}
-					defaultValue={this.state.spellSpeed}
-					description={localize({ en: "spell speed: ", zh: "咏速：" })}
-					onChange={this.setSpellSpeed}
+		</div>
+		<div>
+			<Input
+				style={{ display: "inline-block", color: fieldColor("spellSpeed") }}
+				defaultValue={configFields.spellSpeed}
+				description={localize({ en: "spell speed: ", zh: "咏速：" })}
+				onChange={singleDispatch("spellSpeed")}
+			/>
+			<span>
+				{" "}
+				(GCD: {spsGcdPreview}{" "}
+				<Help
+					topic={"gcdPreview"}
+					content={
+						<>
+							<p>
+								{localize({
+									en: "Preview of displayed GCD based on your spell speed.",
+									zh: "当前咏速对应的游戏内显示的GCD.",
+								})}
+							</p>
+							<p>
+								{localize({
+									en: `Measured average GCD should be ${taxedSpsGcdPreview} due to FPS tax.`,
+									zh: `由于帧率税的影响，测量得到的平均GCD为${taxedSpsGcdPreview}。`,
+								})}
+							</p>
+						</>
+					}
 				/>
-				<span>
-					{" "}
-					(GCD: {this.state.gcdPreview}{" "}
-					<Help
-						topic={"gcdPreview"}
-						content={
-							<>
-								<p>
-									{localize({
-										en: "Preview of displayed GCD based on your spell speed.",
-										zh: "当前咏速对应的游戏内显示的GCD.",
-									})}
-								</p>
-								<p>
-									{localize({
-										en: `Measured average GCD should be ${this.state.taxedGcdPreview} due to FPS tax.`,
-										zh: `由于帧率税的影响，测量得到的平均GCD为${this.state.taxedGcdPreview}。`,
-									})}
-								</p>
-							</>
-						}
-					/>
-					)
-				</span>
-			</div>
-			<div>
-				<Input
-					style={{ display: "inline-block", color: fieldColor("skillSpeed") }}
-					defaultValue={this.state.skillSpeed}
-					description={localize({ en: "skill speed: ", zh: "技速：" })}
-					onChange={this.setSkillSpeed}
+				)
+			</span>
+		</div>
+		<div>
+			<Input
+				style={{ display: "inline-block", color: fieldColor("skillSpeed") }}
+				defaultValue={configFields.skillSpeed}
+				description={localize({ en: "skill speed: ", zh: "技速：" })}
+				onChange={singleDispatch("skillSpeed")}
+			/>
+			<span>
+				{" "}
+				(GCD: {sksGcdPreview}{" "}
+				<Help
+					topic={"sksGcdPreview"}
+					content={
+						<>
+							<p>
+								{localize({
+									en: "Preview of displayed GCD based on your skill speed.",
+									zh: "当前技速对应的游戏内显示的GCD.",
+								})}
+							</p>
+							<p>
+								{localize({
+									en: `Measured average GCD should be ${taxedSksGcdPreview} due to FPS tax.`,
+									zh: `由于帧率税的影响，测量得到的平均GCD为${taxedSksGcdPreview}。`,
+								})}
+							</p>
+						</>
+					}
 				/>
-				<span>
-					{" "}
-					(GCD: {this.state.sksGcdPreview}{" "}
-					<Help
-						topic={"sksGcdPreview"}
-						content={
-							<>
-								<p>
-									{localize({
-										en: "Preview of displayed GCD based on your skill speed.",
-										zh: "当前技速对应的游戏内显示的GCD.",
-									})}
-								</p>
-								<p>
-									{localize({
-										en: `Measured average GCD should be ${this.state.taxedSksGcdPreview} due to FPS tax.`,
-										zh: `由于帧率税的影响，测量得到的平均GCD为${this.state.taxedSksGcdPreview}。`,
-									})}
-								</p>
-							</>
-						}
-					/>
-					)
-				</span>
-			</div>
-			<Input
-				style={{ color: fieldColor("criticalHit") }}
-				defaultValue={this.state.criticalHit}
-				description={localize({ en: "crit: ", zh: "暴击：" })}
-				onChange={this.setCriticalHit}
-			/>
-			<Input
-				style={{ color: fieldColor("directHit") }}
-				defaultValue={this.state.directHit}
-				description={localize({ en: "direct hit: ", zh: "直击：" })}
-				onChange={this.setDirectHit}
-			/>
-			<Input
-				style={{ color: fieldColor("determination") }}
-				defaultValue={this.state.determination}
-				description={localize({ en: "determination: ", zh: "信念：" })}
-				onChange={this.setDetermination}
-			/>
-			<Input
-				style={{ color: fieldColor("piety") }}
-				defaultValue={this.state.piety}
-				description={localize({ en: "piety: ", zh: "信仰：" })}
-				onChange={this.setPiety}
-			/>
-			<Input
-				defaultValue={this.state.animationLock}
-				description={localize({ en: "animation lock: ", zh: "能力技后摇：" })}
-				onChange={this.setAnimationLock}
-			/>
-			<div>
-				<Input
-					componentColor={fpsAndCorrectionColor}
-					style={{ display: "inline-block" }}
-					defaultValue={this.state.fps}
-					description={localize({ en: "FPS: ", zh: "帧率：" })}
-					onChange={this.setFps}
-				/>
-				<span>
-					{" "}
-					(
-					{localize({
-						en: `${this.getDefaultGcd(2.5).toFixed(2)}s w/ tax`,
-						zh: `${this.getDefaultGcd(2.5)}s+帧率税`,
-					})}
-					: {this.getDefaultGcdTax(2.5).toFixed(3)}{" "}
-					<Help topic={"gcdTaxPreview"} content={gcdTaxDesc} />)
-				</span>
-			</div>
+				)
+			</span>
+		</div>
+		{genericInputStatWidgets}
+		<div>
 			<Input
 				componentColor={fpsAndCorrectionColor}
-				defaultValue={this.state.gcdSkillCorrection}
-				description={
-					<span>
-						{localize({ en: "GCD correction", zh: "GCD时长修正" })}{" "}
-						<Help
-							topic={"cast-time-correction"}
-							content={localize({
-								en: "Leaving this at 0 will probably give you the most accurate simulation. But if you want to manually correct your GCD skill durations (including casts) for whatever reason, you can put a small number (can be negative)",
-								zh: "正常情况下填0即能得到最精确的模拟结果。如果实在需要修正的话，这里输入的时长会被加到你的每个GCD技能（包括读条）耗时里（可以为负）",
-							})}
-						/>
-						:{" "}
-					</span>
-				}
-				onChange={this.setGcdSkillCorrection}
+				style={{ display: "inline-block" }}
+				defaultValue={configFields.fps}
+				description={localize({ en: "FPS: ", zh: "帧率：" })}
+				onChange={singleDispatch("fps")}
 			/>
-			<Input
-				defaultValue={this.state.timeTillFirstManaTick}
-				description={localize({ en: "time till first MP tick: ", zh: "距首次跳蓝时间：" })}
-				onChange={this.setTimeTillFirstManaTick}
-			/>
-			<Input
-				defaultValue={this.state.countdown}
-				description={
-					<span>
-						{localize({ en: "countdown ", zh: "倒数时间 " })}
-						<Help
-							topic={"countdown"}
-							content={localize({
-								en: "can use a negative countdown to start from a specific time of fight",
-								zh: "可以是负数，时间轴会从战斗中途某个时间开始显示",
-							})}
-						/>
-						:{" "}
-					</span>
-				}
-				onChange={this.setCountdown}
-			/>
-			<Input
-				defaultValue={this.state.randomSeed}
-				description={
-					<span>
-						{localize({ en: "random seed ", zh: "随机种子 " })}
-						<Help
-							topic={"randomSeed"}
-							content={localize({
-								en: "can be anything, or leave empty to get 4 random digits.",
-								zh: "可以是任意字符串，或者留空，会获得4个随机数字",
-							})}
-						/>
-						:{" "}
-					</span>
-				}
-				onChange={this.setRandomSeed}
-			/>
-			<div>
+			<span>
+				{" "}
+				(
+				{localize({
+					en: `${getDefaultGcd(2.5).toFixed(2)}s w/ tax`,
+					zh: `${getDefaultGcd(2.5).toFixed(2)}s+帧率税`,
+				})}
+				: {getDefaultGcdTax(2.5).toFixed(3)}{" "}
+				<Help topic={"gcdTaxPreview"} content={gcdTaxDesc} />)
+			</span>
+		</div>
+		<Input
+			componentColor={fpsAndCorrectionColor}
+			defaultValue={configFields.gcdSkillCorrection}
+			description={
 				<span>
-					{localize({ en: "proc mode ", zh: "随机BUFF获取 " })}
+					{localize({ en: "GCD correction", zh: "GCD时长修正" })}{" "}
 					<Help
-						topic={"procMode"}
+						topic={"cast-time-correction"}
 						content={localize({
-							en: "Default RNG: 40% Firestarter",
-							zh: "RNG会像游戏内一样，相应技能40%概率获得火苗，Always则每次都会触发火苗，Never则从不触发。",
+							en: "Leaving this at 0 will probably give you the most accurate simulation. But if you want to manually correct your GCD skill durations (including casts) for whatever reason, you can put a small number (can be negative)",
+							zh: "正常情况下填0即能得到最精确的模拟结果。如果实在需要修正的话，这里输入的时长会被加到你的每个GCD技能（包括读条）耗时里（可以为负）",
 						})}
 					/>
 					:{" "}
 				</span>
-				<select
-					style={{ outline: "none" }}
-					value={this.state.procMode}
-					onChange={this.setProcMode}
-				>
-					<option key={ProcMode.RNG} value={ProcMode.RNG}>
-						RNG
-					</option>
-					<option key={ProcMode.Never} value={ProcMode.Never}>
-						Never
-					</option>
-					<option key={ProcMode.Always} value={ProcMode.Always}>
-						Always
-					</option>
-				</select>
-			</div>
-			{this.#resourceOverridesSection()}
-			<button
-				onClick={this.handleSubmit}
-				style={{ width: "100%", fontWeight: this.state.dirty ? "bold" : "normal" }}
+			}
+			onChange={singleDispatch("gcdSkillCorrection")}
+		/>
+		<Input
+			defaultValue={configFields.timeTillFirstManaTick}
+			description={localize({ en: "time till first MP tick: ", zh: "距首次跳蓝时间：" })}
+			onChange={singleDispatch("timeTillFirstManaTick")}
+		/>
+		<Input
+			defaultValue={configFields.countdown}
+			description={
+				<span>
+					{localize({ en: "countdown ", zh: "倒数时间 " })}
+					<Help
+						topic={"countdown"}
+						content={localize({
+							en: "can use a negative countdown to start from a specific time of fight",
+							zh: "可以是负数，时间轴会从战斗中途某个时间开始显示",
+						})}
+					/>
+					:{" "}
+				</span>
+			}
+			onChange={singleDispatch("countdown")}
+		/>
+		<Input
+			defaultValue={configFields.randomSeed}
+			description={
+				<span>
+					{localize({ en: "random seed ", zh: "随机种子 " })}
+					<Help
+						topic={"randomSeed"}
+						content={localize({
+							en: "can be anything, or leave empty to get 4 random digits.",
+							zh: "可以是任意字符串，或者留空，会获得4个随机数字",
+						})}
+					/>
+					:{" "}
+				</span>
+			}
+			onChange={singleDispatch("randomSeed")}
+		/>
+		<div>
+			<span>
+				{localize({ en: "proc mode ", zh: "随机BUFF获取 " })}
+				<Help
+					topic={"procMode"}
+					content={localize({
+						// TODO update to reflect for all jobs
+						en: "Default RNG: 40% Firestarter",
+						zh: "RNG会像游戏内一样，相应技能40%概率获得火苗，Always则每次都会触发火苗，Never则从不触发。",
+					})}
+				/>
+				:{" "}
+			</span>
+			<select
+				style={{ outline: "none" }}
+				value={configFields.procMode}
+				onChange={(e) => configFieldDispatch({ procMode: e.target.value as ProcMode })}
 			>
-				{localize({ en: "apply and reset", zh: "应用并重置时间轴" })}
-				{this.state.dirty ? "*" : ""}
-			</button>
-		</div>;
-		return <div style={{ marginBottom: 20 }}>
-			{gearImportSection}
-			<br />
-			{editJobSection}
-			<ConfigSummary job={controller.getActiveJob()} dirty={this.state.dirty} />
-			{editStatsSection}
-			<p>
-				{localize({
-					en: "You can also import/export fights from/to local files at the bottom of the page.",
-					zh: "页面底部有导入和导出战斗文件相关选项。",
-				})}
-			</p>
-		</div>;
-	}
+				<option key={ProcMode.RNG} value={ProcMode.RNG}>
+					RNG
+				</option>
+				<option key={ProcMode.Never} value={ProcMode.Never}>
+					Never
+				</option>
+				<option key={ProcMode.Always} value={ProcMode.Always}>
+					Always
+				</option>
+			</select>
+		</div>
+		<ResourceOverrideSection
+			job={configFields.job}
+			initialResourceOverrides={initialResourceOverrides}
+			overrideTimer={overrideTimer}
+			overrideStacks={overrideStacks}
+			overrideEnabled={overrideEnabled}
+			setInitialResourceOverrides={setInitialResourceOverrides}
+			selectedOverrideResource={selectedOverrideResource}
+			setSelectedOverrideResource={setSelectedOverrideResource}
+			setOverrideTimer={setOverrideTimer}
+			setOverrideStacks={setOverrideStacks}
+			setOverrideEnabled={setOverrideEnabled}
+		/>
+		<button
+			onClick={handleSubmit}
+			style={{ width: "100%", fontWeight: configFields.dirty ? "bold" : "normal" }}
+		>
+			{localize({ en: "apply and reset", zh: "应用并重置时间轴" })}
+			{configFields.dirty ? "*" : ""}
+		</button>
+	</div>;
+
+	return <div style={{ marginBottom: 20 }}>
+		<GearImport
+			imported={imported}
+			setImported={setImported}
+			setImportedFields={addImportedFields}
+			dispatch={configFieldDispatch}
+		/>
+		<br />
+		{editJobSection}
+		<ConfigSummary job={controller.getActiveJob()} dirty={configFields.dirty} />
+		{editStatsSection}
+		<p>
+			{localize({
+				en: "You can also import/export fights from/to local files at the bottom of the page.",
+				zh: "页面底部有导入和导出战斗文件相关选项。",
+			})}
+		</p>
+	</div>;
 }

--- a/src/Components/PlaybackControl.tsx
+++ b/src/Components/PlaybackControl.tsx
@@ -1535,13 +1535,6 @@ export function Config() {
 			setOverrideStacks={setOverrideStacks}
 			setOverrideEnabled={setOverrideEnabled}
 		/>
-		<button
-			onClick={handleSubmit}
-			style={{ width: "100%", fontWeight: configFields.dirty ? "bold" : "normal" }}
-		>
-			{localize({ en: "apply and reset", zh: "应用并重置时间轴" })}
-			{configFields.dirty ? "*" : ""}
-		</button>
 	</div>;
 
 	return <div style={{ marginBottom: 20 }}>
@@ -1555,11 +1548,47 @@ export function Config() {
 		{editJobSection}
 		<ConfigSummary job={controller.getActiveJob()} dirty={configFields.dirty} />
 		{editStatsSection}
-		<p>
+		<p style={{ paddingBottom: 5 }}>
 			{localize({
 				en: "You can also import/export fights from/to local files at the bottom of the page.",
 				zh: "页面底部有导入和导出战斗文件相关选项。",
 			})}
 		</p>
+		<div
+			className="invisibleScrollbar"
+			style={{
+				boxSizing: "border-box",
+				width: "100%",
+				position: "absolute",
+				paddingRight: 5,
+				paddingLeft: 5,
+				bottom: 0,
+				left: 0,
+				overflowY: "scroll",
+			}}
+		>
+			{/* intermediate child div needed to ensure background fill doesn't overlap scroll bar */}
+			<div
+				style={{
+					width: "100%",
+					boxSizing: "border-box",
+					backgroundColor: colors.background,
+					borderTop: "1px solid " + colors.bgMediumContrast,
+					paddingTop: 5,
+					paddingBottom: 5,
+				}}
+			>
+				<button
+					onClick={handleSubmit}
+					style={{
+						width: "100%",
+						fontWeight: configFields.dirty ? "bold" : "normal",
+					}}
+				>
+					{localize({ en: "apply and reset", zh: "应用并重置时间轴" })}
+					{configFields.dirty ? "*" : ""}
+				</button>
+			</div>
+		</div>
 	</div>;
 }

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -1548,7 +1548,10 @@ class Controller {
 			this.autoSave();
 
 			this.record.unselectAll();
-			console.assert(this.timeline.loadSlot(slot));
+			const loaded = this.timeline.loadSlot(slot);
+			if (!loaded) {
+				console.error(`failed to load timeline in cached active slot ${slot}`);
+			}
 		});
 		this.displayCurrentState();
 		setCachedValue("activeSlotIndex", slot.toString());

--- a/src/Controller/Timeline.ts
+++ b/src/Controller/Timeline.ts
@@ -371,6 +371,7 @@ export class Timeline {
 		if (this.activeSlotIndex >= idx)
 			this.activeSlotIndex = Math.max(0, this.activeSlotIndex - 1);
 		this.loadSlot(this.activeSlotIndex);
+		setCachedValue("activeSlotIndex", this.activeSlotIndex.toString());
 	}
 
 	saveCurrentSlot(serializedRecord: any, countdown: number, elapsedTime: number) {

--- a/src/Controller/Timeline.ts
+++ b/src/Controller/Timeline.ts
@@ -386,6 +386,7 @@ export class Timeline {
 				elapsedTime: elapsedTime,
 			}),
 		);
+		controller.gameConfig.savePartialConfig();
 	}
 
 	loadSlot(index: number): boolean {

--- a/src/Game/GameConfig.ts
+++ b/src/Game/GameConfig.ts
@@ -284,11 +284,11 @@ const JOB_DEFAULT_FIELDS: { [Property in ShellJob]: DynamicConfigPart } = {
 	},
 };
 
-export function makeDefaultConfig(job: ShellJob): ConfigData {
+export function makeDefaultConfig(job: ShellJob, level: LevelSync = LevelSync.lvl100): ConfigData {
 	return {
 		job,
 		shellVersion: ShellInfo.version,
-		level: job === "BLU" ? LevelSync.lvl80 : LevelSync.lvl100,
+		level: level ?? (job === "BLU" ? LevelSync.lvl80 : LevelSync.lvl100),
 		...JOB_DEFAULT_FIELDS[job],
 		wd: CURRENT_BIS_WD,
 		countdown: 5,

--- a/src/Game/GameConfig.ts
+++ b/src/Game/GameConfig.ts
@@ -1,6 +1,6 @@
 import { Debug, ProcMode, LevelSync, FIXED_BASE_CASTER_TAX } from "./Common";
 import { ResourceOverride, ResourceOverrideData } from "./Resources";
-import { ShellInfo, ShellVersion } from "../Controller/Common";
+import { getCachedValue, setCachedValue, ShellInfo, ShellVersion } from "../Controller/Common";
 import { XIVMath } from "./XIVMath";
 import { ShellJob } from "./Data/Jobs";
 import { CooldownKey, COOLDOWNS, ResourceKey, RESOURCES } from "./Data";
@@ -45,10 +45,14 @@ type DynamicConfigField =
 	| "tenacity"
 	| "main";
 
+type DynamicConfigPart = {
+	[Property in DynamicConfigField]: number;
+};
+
 const TANK_MAIN = 5882;
 const OTHER_MAIN = 5925;
 
-const PRANGE_2_5_BIS = {
+const PRANGE_2_5_BIS: DynamicConfigPart = {
 	main: OTHER_MAIN,
 	spellSpeed: 420,
 	skillSpeed: 420,
@@ -61,225 +65,224 @@ const PRANGE_2_5_BIS = {
 
 // BiS sets updated for patch 7.3
 // These should only be applied the first time the user loads the site, or switches to a given job
-const JOB_DEFAULT_FIELDS: { [Property in ShellJob]: { [Property in DynamicConfigField]: number } } =
-	{
-		DRK: {
-			main: TANK_MAIN,
-			spellSpeed: 420,
-			skillSpeed: 420,
-			criticalHit: 3404,
-			directHit: 1068,
-			determination: 2883,
-			piety: 440,
-			tenacity: 794,
-		},
-		GNB: {
-			main: TANK_MAIN,
-			spellSpeed: 420,
-			skillSpeed: 420,
-			criticalHit: 3404,
-			directHit: 1068,
-			determination: 2883,
-			piety: 440,
-			tenacity: 794,
-		},
-		PLD: {
-			main: TANK_MAIN,
-			spellSpeed: 420,
-			skillSpeed: 420,
-			criticalHit: 3242,
-			directHit: 1230,
-			determination: 2883,
-			piety: 440,
-			tenacity: 794,
-		},
-		WAR: {
-			main: TANK_MAIN,
-			spellSpeed: 420,
-			skillSpeed: 420,
-			criticalHit: 3404,
-			directHit: 1068,
-			determination: 2883,
-			piety: 440,
-			tenacity: 794,
-		},
-		AST: {
-			// "2.46 Spero Dedes"
-			main: OTHER_MAIN,
-			spellSpeed: 704,
-			skillSpeed: 420,
-			criticalHit: 3427,
-			directHit: 1230,
-			determination: 2510,
-			piety: 718,
-			tenacity: 420,
-		},
-		SCH: {
-			// 2.40
-			main: OTHER_MAIN,
-			spellSpeed: 1221,
-			skillSpeed: 420,
-			criticalHit: 3484,
-			directHit: 852,
-			determination: 2314,
-			piety: 718,
-			tenacity: 420,
-		},
-		SGE: {
-			// 2.46 min piety
-			main: OTHER_MAIN,
-			spellSpeed: 704,
-			skillSpeed: 420,
-			criticalHit: 3427,
-			directHit: 1230,
-			determination: 2510,
-			piety: 718,
-			tenacity: 420,
-		},
-		WHM: {
-			// 2.46 min piety
-			main: OTHER_MAIN,
-			spellSpeed: 704,
-			skillSpeed: 420,
-			criticalHit: 3427,
-			directHit: 1230,
-			determination: 2510,
-			piety: 718,
-			tenacity: 420,
-		},
-		DRG: {
-			main: OTHER_MAIN,
-			spellSpeed: 420,
-			skillSpeed: 420,
-			criticalHit: 3425,
-			directHit: 1996,
-			determination: 2308,
-			piety: 440,
-			tenacity: 420,
-		},
-		MNK: {
-			// 1.94
-			main: OTHER_MAIN,
-			spellSpeed: 420,
-			skillSpeed: 968,
-			criticalHit: 3487,
-			directHit: 1685,
-			determination: 2009,
-			piety: 440,
-			tenacity: 420,
-		},
-		NIN: {
-			// 2.12
-			main: OTHER_MAIN,
-			spellSpeed: 420,
-			skillSpeed: 420,
-			criticalHit: 3378,
-			directHit: 1981,
-			determination: 2370,
-			piety: 440,
-			tenacity: 420,
-		},
-		RPR: {
-			// 2.49
-			main: OTHER_MAIN,
-			spellSpeed: 420,
-			skillSpeed: 474,
-			criticalHit: 3425,
-			directHit: 1942,
-			determination: 2308,
-			piety: 440,
-			tenacity: 420,
-		},
-		SAM: {
-			// 2.14
-			main: OTHER_MAIN,
-			spellSpeed: 420,
-			skillSpeed: 690,
-			criticalHit: 3425,
-			directHit: 2045,
-			determination: 1989,
-			piety: 440,
-			tenacity: 420,
-		},
-		VPR: {
-			// 2.12
-			main: OTHER_MAIN,
-			spellSpeed: 420,
-			skillSpeed: 420,
-			criticalHit: 3378,
-			directHit: 1981,
-			determination: 2370,
-			piety: 440,
-			tenacity: 420,
-		},
-		DNC: PRANGE_2_5_BIS,
-		BRD: PRANGE_2_5_BIS,
-		MCH: PRANGE_2_5_BIS,
-		BLM: {
-			main: OTHER_MAIN,
-			spellSpeed: 978,
-			skillSpeed: 420,
-			criticalHit: 3456,
-			directHit: 1764,
-			determination: 1951,
-			piety: 440,
-			tenacity: 420,
-		},
-		RDM: {
-			// 2.48
-			main: OTHER_MAIN,
-			spellSpeed: 528,
-			skillSpeed: 420,
-			criticalHit: 3399,
-			directHit: 1872,
-			determination: 2350,
-			piety: 440,
-			tenacity: 420,
-		},
-		SMN: {
-			// 2.48
-			main: OTHER_MAIN,
-			spellSpeed: 528,
-			skillSpeed: 420,
-			criticalHit: 3399,
-			directHit: 1872,
-			determination: 2350,
-			piety: 440,
-			tenacity: 420,
-		},
-		PCT: {
-			// 7.2 2.5 GCD bis https://xivgear.app/?page=sl%7Cc48f85d8-9b93-4f96-bfc4-1e0e30e98a8c
-			main: OTHER_MAIN,
-			spellSpeed: 420,
-			skillSpeed: 420,
-			criticalHit: 3399,
-			directHit: 1764,
-			determination: 2566,
-			piety: 440,
-			tenacity: 420,
-		},
-		BLU: {
-			// lv80 2.20
-			main: 1701,
-			spellSpeed: 1573,
-			skillSpeed: 380,
-			criticalHit: 1343,
-			directHit: 785,
-			determination: 676,
-			piety: 340,
-			tenacity: 380,
-		},
-		NEVER: {
-			main: OTHER_MAIN,
-			spellSpeed: 420,
-			skillSpeed: 420,
-			criticalHit: 420,
-			directHit: 420,
-			determination: 440,
-			piety: 440,
-			tenacity: 420,
-		},
-	};
+const JOB_DEFAULT_FIELDS: { [Property in ShellJob]: DynamicConfigPart } = {
+	DRK: {
+		main: TANK_MAIN,
+		spellSpeed: 420,
+		skillSpeed: 420,
+		criticalHit: 3404,
+		directHit: 1068,
+		determination: 2883,
+		piety: 440,
+		tenacity: 794,
+	},
+	GNB: {
+		main: TANK_MAIN,
+		spellSpeed: 420,
+		skillSpeed: 420,
+		criticalHit: 3404,
+		directHit: 1068,
+		determination: 2883,
+		piety: 440,
+		tenacity: 794,
+	},
+	PLD: {
+		main: TANK_MAIN,
+		spellSpeed: 420,
+		skillSpeed: 420,
+		criticalHit: 3242,
+		directHit: 1230,
+		determination: 2883,
+		piety: 440,
+		tenacity: 794,
+	},
+	WAR: {
+		main: TANK_MAIN,
+		spellSpeed: 420,
+		skillSpeed: 420,
+		criticalHit: 3404,
+		directHit: 1068,
+		determination: 2883,
+		piety: 440,
+		tenacity: 794,
+	},
+	AST: {
+		// "2.46 Spero Dedes"
+		main: OTHER_MAIN,
+		spellSpeed: 704,
+		skillSpeed: 420,
+		criticalHit: 3427,
+		directHit: 1230,
+		determination: 2510,
+		piety: 718,
+		tenacity: 420,
+	},
+	SCH: {
+		// 2.40
+		main: OTHER_MAIN,
+		spellSpeed: 1221,
+		skillSpeed: 420,
+		criticalHit: 3484,
+		directHit: 852,
+		determination: 2314,
+		piety: 718,
+		tenacity: 420,
+	},
+	SGE: {
+		// 2.46 min piety
+		main: OTHER_MAIN,
+		spellSpeed: 704,
+		skillSpeed: 420,
+		criticalHit: 3427,
+		directHit: 1230,
+		determination: 2510,
+		piety: 718,
+		tenacity: 420,
+	},
+	WHM: {
+		// 2.46 min piety
+		main: OTHER_MAIN,
+		spellSpeed: 704,
+		skillSpeed: 420,
+		criticalHit: 3427,
+		directHit: 1230,
+		determination: 2510,
+		piety: 718,
+		tenacity: 420,
+	},
+	DRG: {
+		main: OTHER_MAIN,
+		spellSpeed: 420,
+		skillSpeed: 420,
+		criticalHit: 3425,
+		directHit: 1996,
+		determination: 2308,
+		piety: 440,
+		tenacity: 420,
+	},
+	MNK: {
+		// 1.94
+		main: OTHER_MAIN,
+		spellSpeed: 420,
+		skillSpeed: 968,
+		criticalHit: 3487,
+		directHit: 1685,
+		determination: 2009,
+		piety: 440,
+		tenacity: 420,
+	},
+	NIN: {
+		// 2.12
+		main: OTHER_MAIN,
+		spellSpeed: 420,
+		skillSpeed: 420,
+		criticalHit: 3378,
+		directHit: 1981,
+		determination: 2370,
+		piety: 440,
+		tenacity: 420,
+	},
+	RPR: {
+		// 2.49
+		main: OTHER_MAIN,
+		spellSpeed: 420,
+		skillSpeed: 474,
+		criticalHit: 3425,
+		directHit: 1942,
+		determination: 2308,
+		piety: 440,
+		tenacity: 420,
+	},
+	SAM: {
+		// 2.14
+		main: OTHER_MAIN,
+		spellSpeed: 420,
+		skillSpeed: 690,
+		criticalHit: 3425,
+		directHit: 2045,
+		determination: 1989,
+		piety: 440,
+		tenacity: 420,
+	},
+	VPR: {
+		// 2.12
+		main: OTHER_MAIN,
+		spellSpeed: 420,
+		skillSpeed: 420,
+		criticalHit: 3378,
+		directHit: 1981,
+		determination: 2370,
+		piety: 440,
+		tenacity: 420,
+	},
+	DNC: PRANGE_2_5_BIS,
+	BRD: PRANGE_2_5_BIS,
+	MCH: PRANGE_2_5_BIS,
+	BLM: {
+		main: OTHER_MAIN,
+		spellSpeed: 978,
+		skillSpeed: 420,
+		criticalHit: 3456,
+		directHit: 1764,
+		determination: 1951,
+		piety: 440,
+		tenacity: 420,
+	},
+	RDM: {
+		// 2.48
+		main: OTHER_MAIN,
+		spellSpeed: 528,
+		skillSpeed: 420,
+		criticalHit: 3399,
+		directHit: 1872,
+		determination: 2350,
+		piety: 440,
+		tenacity: 420,
+	},
+	SMN: {
+		// 2.48
+		main: OTHER_MAIN,
+		spellSpeed: 528,
+		skillSpeed: 420,
+		criticalHit: 3399,
+		directHit: 1872,
+		determination: 2350,
+		piety: 440,
+		tenacity: 420,
+	},
+	PCT: {
+		// 7.2 2.5 GCD bis https://xivgear.app/?page=sl%7Cc48f85d8-9b93-4f96-bfc4-1e0e30e98a8c
+		main: OTHER_MAIN,
+		spellSpeed: 420,
+		skillSpeed: 420,
+		criticalHit: 3399,
+		directHit: 1764,
+		determination: 2566,
+		piety: 440,
+		tenacity: 420,
+	},
+	BLU: {
+		// lv80 2.20
+		main: 1701,
+		spellSpeed: 1573,
+		skillSpeed: 380,
+		criticalHit: 1343,
+		directHit: 785,
+		determination: 676,
+		piety: 340,
+		tenacity: 380,
+	},
+	NEVER: {
+		main: OTHER_MAIN,
+		spellSpeed: 420,
+		skillSpeed: 420,
+		criticalHit: 420,
+		directHit: 420,
+		determination: 440,
+		piety: 440,
+		tenacity: 420,
+	},
+};
 
 export function makeDefaultConfig(job: ShellJob): ConfigData {
 	return {
@@ -299,8 +302,24 @@ export function makeDefaultConfig(job: ShellJob): ConfigData {
 	};
 }
 
-export const DEFAULT_CONFIG: ConfigData = makeDefaultConfig("BLM"); // TODO
-Object.freeze(DEFAULT_CONFIG);
+export function getSavedConfigPart(job: ShellJob): DynamicConfigPart {
+	const blob = getCachedValue(`defaultPartialConfig: ${job}`);
+	if (blob === null) {
+		return JOB_DEFAULT_FIELDS[job];
+	}
+	const parsedBlob = JSON.parse(blob);
+	// We only store combat stats directly in localStorage so they remain independent between jobs.
+	// Remaining stats (like fps and countdown) are shared across job swap.
+	// If anything is missing, just fill it in from the default.
+	Object.entries(JOB_DEFAULT_FIELDS[job]).forEach(([key, value]) => {
+		if (parsedBlob[key] === undefined) {
+			parsedBlob[key] = value;
+		}
+	});
+	return parsedBlob as ConfigData;
+}
+
+export const DEFAULT_CONFIG = makeDefaultConfig("BLM");
 
 export type SerializedConfig = ConfigData & {
 	casterTax: number; // still want this bc don't want to break cached timelines
@@ -354,13 +373,14 @@ export class GameConfig {
 	}) {
 		this.job = props.job;
 		this.shellVersion = props.shellVersion;
-		this.level = props.level ?? DEFAULT_CONFIG.level;
+		const defaultConfig = DEFAULT_CONFIG;
+		this.level = props.level ?? defaultConfig.level;
 		this.spellSpeed = props.spellSpeed;
-		this.skillSpeed = props.skillSpeed ?? DEFAULT_CONFIG.skillSpeed;
-		this.criticalHit = props.criticalHit ?? DEFAULT_CONFIG.criticalHit;
-		this.directHit = props.directHit ?? DEFAULT_CONFIG.directHit;
-		this.determination = props.determination ?? DEFAULT_CONFIG.determination;
-		this.piety = props.piety ?? DEFAULT_CONFIG.piety;
+		this.skillSpeed = props.skillSpeed ?? defaultConfig.skillSpeed;
+		this.criticalHit = props.criticalHit ?? defaultConfig.criticalHit;
+		this.directHit = props.directHit ?? defaultConfig.directHit;
+		this.determination = props.determination ?? defaultConfig.determination;
+		this.piety = props.piety ?? defaultConfig.piety;
 		this.countdown = props.countdown;
 		this.randomSeed = props.randomSeed;
 		this.fps = props.fps;
@@ -481,6 +501,14 @@ export class GameConfig {
 		return this.initialResourceOverrides.find((override) => override.type === rsc)?.stacks;
 	}
 
+	savePartialConfig() {
+		const obj: any = {};
+		Object.keys(JOB_DEFAULT_FIELDS[this.job]).forEach((key) => {
+			obj[key] = this[key as keyof GameConfig];
+		});
+		setCachedValue(`defaultPartialConfig: ${this.job}`, JSON.stringify(obj));
+	}
+
 	serialized() {
 		return {
 			job: this.job,
@@ -503,9 +531,9 @@ export class GameConfig {
 			animationLock: this.animationLock,
 			timeTillFirstManaTick: this.timeTillFirstManaTick,
 			procMode: this.procMode,
-			initialResourceOverrides: this.initialResourceOverrides.map((override) => {
-				return override.serialized();
-			}),
+			initialResourceOverrides: this.initialResourceOverrides.map((override) =>
+				override.serialized(),
+			),
 		};
 	}
 }

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -3,6 +3,7 @@
 		"date": "9/6/25",
 		"changes": [
 			"Fixed a crash when loading xivgear/etro links from a job different from the active one.",
+			"Fixed an issue where speed effects and certain sps/sks values were displayed incorrectly at level 70 (this was only a cosmetic issue in the configuration panel).",
 			"Changing jobs now uses the last saved stats you set for that job.",
 			"Creating a new timeline with a different job will now use one of The Balance's best-in-slot gear sets for the current patch."
 		]

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,6 +1,6 @@
 [
 	{
-		"date": "9/6/25",
+		"date": "9/8/25",
 		"changes": [
 			"Fixed a crash when loading xivgear/etro links from a job different from the active one.",
 			"Fixed an issue where speed effects and certain sps/sks values were displayed incorrectly at level 70 (this was only a cosmetic issue in the configuration panel).",

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,13 @@
 [
 	{
+		"date": "9/6/25",
+		"changes": [
+			"Fixed a crash when loading xivgear/etro links from a job different from the active one.",
+			"Changing jobs now uses the last saved stats you set for that job.",
+			"Creating a new timeline with a different job will now use one of The Balance's best-in-slot gear sets for the current patch."
+		]
+	},
+	{
 		"date": "9/2/25",
 		"changes": [
 			"Added different tincture images for each job.",


### PR DESCRIPTION
## Summary
Changing jobs in the config panel now changes combat stats, since most jobs do not share stats. The stats used are either the last stats the user set for that job, or one of The Balance's recommended BiS sets for the current patch. Non-gear-related stats (FPS, countdown) are still preserved across job changes as before. The last used sets for a job are stored in the `DT.defaultPartialConfig: {job}` localStorage keys.

`PlaybackControl.tsx` also got a major facelift, and is about 200 lines shorter than before, though it's still pretty long. A lot of awkward manual state synchronization (mostly related to GCD previews) has been cleaned up as a result. Some components have also been broken up to make code easier to read.

The "apply and reset" button is now alayws visible in the config window, making it more obvious that changes to stats must be explicitly applied.

<img width="330" height="479" alt="image" src="https://github.com/user-attachments/assets/57fb7235-087f-4976-8965-a8622e0365b8" />

I manually tested the behavior with some gearset importing, file loading, and manual timeline creation.

### Incidental other changes
- Fixed a console.assert tripping when setting a non-zero active timeline, removing the active timeline slot, and refreshing the page.
- Fixed a page crash in #194 (setting overrides for a job, then swapping jobs will trigger it).
- Bump the node version in CI to 22.
- Bump @base-ui-components/react to beta.2 (I did it in my local environment already, but apparently forgot to commit the change).

Notably, this does NOT address #206. In-place stat changes is easy to implement technically, but would require a little more UX thought in how best to convey "apply and reset" vs. just "apply" without reset.