### PR TITLE
Change configuration without reset

### DIFF
--- a/src/Components/PlaybackControl.tsx
+++ b/src/Components/PlaybackControl.tsx
@@ -1302,8 +1302,8 @@ export function Config() {
 				window.alert("Invalid job: " + configFields.job);
 				return;
 			}
-			// @ts-expect-error too onerous to manually specify every field in a way that type-checks with fromEntries
 			controller.setConfigAndRestart(
+				// @ts-expect-error too onerous to manually specify every field in a way that type-checks with fromEntries
 				{
 					job: configFields.job,
 					randomSeed: seed.trim(),

--- a/src/Components/PlaybackControl.tsx
+++ b/src/Components/PlaybackControl.tsx
@@ -1262,7 +1262,7 @@ export function Config() {
 	const applyConfig = (event: React.SyntheticEvent, resetRecord: boolean) => {
 		event.preventDefault();
 		if (resetRecord && jobOrLevelDirty) {
-			console.error("attempted to apply w/o reset, but joib or level changed");
+			console.error("attempted to apply w/o reset, but job or level changed");
 			return;
 		}
 		if (validateResourceOverrides(initialResourceOverrides)) {

--- a/src/Components/PlaybackControl.tsx
+++ b/src/Components/PlaybackControl.tsx
@@ -1054,6 +1054,7 @@ export function Config() {
 				.find((rsc) => !S.has(rsc)) ?? "NEVER";
 		setSelectedOverrideResource(firstAddableRsc);
 	};
+	const [jobOrLevelDirty, setJobOrLevelDirty] = useState(false);
 	// config field management
 	function configFieldReducer(
 		prevState: ConfigFields,
@@ -1097,6 +1098,10 @@ export function Config() {
 				const speedModifier = getGameState(dummyConfig).inherentSpeedModifier();
 				setjobSpeedMod(speedModifier);
 			}
+			setJobOrLevelDirty(
+				parseInt(newState.level) !== controller.gameConfig.level ||
+					newState.job !== controller.gameConfig.job,
+			);
 		}
 		return newState;
 	}
@@ -1254,7 +1259,12 @@ export function Config() {
 		</table>
 	</div>;
 
-	const handleSubmit = (event: React.SyntheticEvent) => {
+	const applyConfig = (event: React.SyntheticEvent, resetRecord: boolean) => {
+		event.preventDefault();
+		if (resetRecord && jobOrLevelDirty) {
+			console.error("attempted to apply w/o reset, but joib or level changed");
+			return;
+		}
 		if (validateResourceOverrides(initialResourceOverrides)) {
 			let seed = configFields.randomSeed;
 			if (seed.length === 0) {
@@ -1293,25 +1303,28 @@ export function Config() {
 				return;
 			}
 			// @ts-expect-error too onerous to manually specify every field in a way that type-checks with fromEntries
-			controller.setConfigAndRestart({
-				job: configFields.job,
-				randomSeed: seed.trim(),
-				procMode: configFields.procMode,
-				initialResourceOverrides, // info only
-				...Object.fromEntries(
-					numericFields.map((field) => [
-						field,
-						parseFloat(configFields[field].toString()),
-					]),
-				),
-			});
+			controller.setConfigAndRestart(
+				{
+					job: configFields.job,
+					randomSeed: seed.trim(),
+					procMode: configFields.procMode,
+					initialResourceOverrides, // info only
+					...Object.fromEntries(
+						numericFields.map((field) => [
+							field,
+							parseFloat(configFields[field].toString()),
+						]),
+					),
+				},
+				resetRecord,
+			);
 
 			setDirty(false);
+			setJobOrLevelDirty(false);
 			clearImportedFields();
 			controller.updateAllDisplay();
 			controller.scrollToTime();
 		}
-		event.preventDefault();
 	};
 
 	// Stats that use ConfigInputField directly, without any bells and whistles
@@ -1576,7 +1589,6 @@ export function Config() {
 				overflowY: "scroll",
 			}}
 		>
-			{/* intermediate child div needed to ensure background fill doesn't overlap scroll bar */}
 			<div
 				style={{
 					width: "100%",
@@ -1585,10 +1597,35 @@ export function Config() {
 					borderTop: "1px solid " + colors.bgMediumContrast,
 					paddingTop: 5,
 					paddingBottom: 5,
+					display: "flex",
+					flexDirection: "row",
+					justifyContent: "space-between",
+					gap: 5,
 				}}
 			>
 				<button
-					onClick={handleSubmit}
+					onClick={(e) => applyConfig(e, false)}
+					style={{
+						width: "100%",
+						fontWeight: !jobOrLevelDirty && configFields.dirty ? "bold" : "normal",
+						textDecoration: jobOrLevelDirty ? "line-through" : undefined,
+						backgroundColor: jobOrLevelDirty ? colors.background : undefined,
+					}}
+					disabled={jobOrLevelDirty}
+				>
+					{localize({ en: "apply", zh: "应用" })}
+					{jobOrLevelDirty && " "}
+					{jobOrLevelDirty && <Help
+						topic="applyWithoutReset"
+						content={localize({
+							en: "Must reset timeline because job or level changed.",
+							zh: "因为职业或等级有变化，必须重置时间轴。",
+						})}
+					/>}
+					{!jobOrLevelDirty && configFields.dirty ? "*" : ""}
+				</button>
+				<button
+					onClick={(e) => applyConfig(e, true)}
 					style={{
 						width: "100%",
 						fontWeight: configFields.dirty ? "bold" : "normal",

--- a/src/Components/TimelineCanvas.tsx
+++ b/src/Components/TimelineCanvas.tsx
@@ -2210,6 +2210,13 @@ export function TimelineCanvas(props: {
 			mouseDownX.current = undefined;
 			mouseDownY.current = undefined;
 			bgSelecting.current = false;
+			if (
+				activeHoverDraw.current.tip !== undefined ||
+				activeHoverDraw.current.images !== undefined
+			) {
+				activeHoverDraw.current = { tip: undefined, images: undefined };
+				redrawInteractive();
+			}
 		},
 		// ignore KB & M input when in the middle of using a skill (for simplicity)
 		onMouseUp: (e: any, x: number, y: number) => {

--- a/src/Components/TimelineEditor.tsx
+++ b/src/Components/TimelineEditor.tsx
@@ -711,56 +711,72 @@ export function TimelineEditor() {
 					defaultSize: 20,
 				},
 				{
-					content: <table
+					content: <div
 						style={{
-							position: "relative",
-							width: "100%",
-							borderCollapse: "collapse",
-							borderColor: colors.bgMediumContrast,
-							borderWidth: "1px",
-							borderStyle: "solid",
+							display: "flex",
+							flexDirection: "column",
+							gap: INDEX_TD_STYLE.paddingLeft,
 						}}
 					>
-						<thead>
-							<tr style={TR_STYLE}>
-								{includeDetails && <th
-									className="stickyTh"
-									style={{
-										...thStyle,
-										...INDEX_TD_STYLE,
-										...getBorderStyling(colors),
-									}}
-								>
-									#
-								</th>}
-								{includeDetails && <th
-									className="stickyTh"
-									style={{
-										...thStyle,
-										...TIMESTAMP_TD_STYLE,
-										...getBorderStyling(colors),
-									}}
-								>
-									{localize({ en: "Time", zh: "时间" })}
-								</th>}
-								<th
-									className="stickyTh"
-									style={{
-										...thStyle,
-										...ACTION_TD_STYLE,
-										...getBorderStyling(colors),
-									}}
-								>
-									{localize({ en: "Actions", zh: "技能" })}
-								</th>
-							</tr>
-						</thead>
-						<tbody>
-							<EditorDragContext.Provider value={dragHandlers}>
-								{actionsList}
-							</EditorDragContext.Provider>
-						</tbody>
-					</table>,
+						<table
+							style={{
+								position: "relative",
+								width: "100%",
+								borderCollapse: "collapse",
+								borderColor: colors.bgMediumContrast,
+								borderWidth: "1px",
+								borderStyle: "solid",
+							}}
+						>
+							<thead>
+								<tr style={TR_STYLE}>
+									{includeDetails && <th
+										className="stickyTh"
+										style={{
+											...thStyle,
+											...INDEX_TD_STYLE,
+											...getBorderStyling(colors),
+										}}
+									>
+										#
+									</th>}
+									{includeDetails && <th
+										className="stickyTh"
+										style={{
+											...thStyle,
+											...TIMESTAMP_TD_STYLE,
+											...getBorderStyling(colors),
+										}}
+									>
+										{localize({ en: "Time", zh: "时间" })}
+									</th>}
+									<th
+										className="stickyTh"
+										style={{
+											...thStyle,
+											...ACTION_TD_STYLE,
+											...getBorderStyling(colors),
+										}}
+									>
+										{localize({ en: "Actions", zh: "技能" })}
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								<EditorDragContext.Provider value={dragHandlers}>
+									{actionsList}
+								</EditorDragContext.Provider>
+							</tbody>
+						</table>
+						{actionCount === 0 && <span
+							style={{ paddingLeft: INDEX_TD_STYLE.paddingLeft, fontStyle: "italic" }}
+						>
+							{localize({
+								en: "No actions to display yet.",
+								zh: "暂无技能可显示。",
+							})}
+						</span>}
+					</div>,
 					defaultSize: 40,
 					fullBorder: true,
 				},

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -961,42 +961,54 @@ class Controller {
 		this.shouldLoop = false;
 	}
 
-	setConfigAndRestart(props: {
-		job: ShellJob;
-		level: LevelSync;
-		main: number;
-		wd: number;
-		spellSpeed: number;
-		skillSpeed: number;
-		criticalHit: number;
-		directHit: number;
-		determination: number;
-		piety: number;
-		tenacity: number;
-		animationLock: number;
-		fps: number;
-		gcdSkillCorrection: number;
-		timeTillFirstManaTick: number;
-		countdown: number;
-		randomSeed: string;
-		procMode: ProcMode;
-		initialResourceOverrides: any[];
-	}) {
+	setConfigAndRestart(
+		props: {
+			job: ShellJob;
+			level: LevelSync;
+			main: number;
+			wd: number;
+			spellSpeed: number;
+			skillSpeed: number;
+			criticalHit: number;
+			directHit: number;
+			determination: number;
+			piety: number;
+			tenacity: number;
+			animationLock: number;
+			fps: number;
+			gcdSkillCorrection: number;
+			timeTillFirstManaTick: number;
+			countdown: number;
+			randomSeed: string;
+			procMode: ProcMode;
+			initialResourceOverrides: any[];
+		},
+		resetRecord: boolean = true,
+	) {
 		const oldJob = this.gameConfig.job;
+		const jobChanged = oldJob !== props.job;
+		if (jobChanged && !resetRecord) {
+			console.error(
+				"attempted to apply config without reset even though job changed; forcing reset",
+			);
+			resetRecord = true;
+		}
 		updateActiveTimelineEditor(() => {
 			this.gameConfig = new GameConfig({
 				...props,
 				shellVersion: ShellInfo.version,
 			});
 
-			this.record = new Record();
+			if (resetRecord) {
+				this.record = new Record();
+			}
 			this.record.config = this.gameConfig;
 
 			this.#requestRestart();
 			this.#applyResourceOverrides(this.gameConfig);
 			// Propagate changes to the intro section (definitely not idiomatic react... maybe we
 			// should just make the text static for all jobs)
-			if (oldJob !== props.job) {
+			if (jobChanged) {
 				setJob(props.job);
 			}
 		});

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -985,8 +985,9 @@ class Controller {
 		},
 		resetRecord: boolean = true,
 	) {
-		const oldJob = this.gameConfig.job;
-		const jobChanged = oldJob !== props.job;
+		const jobChanged = this.gameConfig.job !== props.job;
+		const oldCountdown = this.gameConfig.countdown;
+		const countdownIncreased = oldCountdown < props.countdown;
 		if (jobChanged && !resetRecord) {
 			console.error(
 				"attempted to apply config without reset even though job changed; forcing reset",
@@ -1001,6 +1002,11 @@ class Controller {
 
 			if (resetRecord) {
 				this.record = new Record();
+			} else if (countdownIncreased) {
+				// If the countdown increased and we're modifying the record in-place, prepend an
+				// implicit "jump to timestamp" event so the first action's timing remains unchanged.
+				// If the countdown decreased, we don't care.
+				this.record.prependActionNode(jumpToTimestampNode(-oldCountdown));
 			}
 			this.record.config = this.gameConfig;
 

--- a/src/Controller/Record.ts
+++ b/src/Controller/Record.ts
@@ -506,6 +506,11 @@ export class Line {
 		return this.length - 1;
 	}
 
+	prependActionNode(actionNode: ActionNode) {
+		console.assert(actionNode !== undefined);
+		this.actions.unshift(actionNode);
+	}
+
 	addActionNode(actionNode: ActionNode) {
 		console.assert(actionNode !== undefined);
 		this.actions.push(actionNode);

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,14 @@
 [
 	{
+		"date": "9/12/25",
+		"changes": [
+			"Added an \"apply\" button to the configuration section, which can be used to change configuration without resetting the timeline."
+		],
+		"changes_zh": [
+			"在属性设置中增加了“应用”按钮，改变属性设置后不用重置时间轴。"
+		]
+	},
+	{
 		"date": "9/8/25",
 		"changes": [
 			"Fixed a crash when loading xivgear/etro links from a job different from the active one.",


### PR DESCRIPTION
Allows in-place adjustment of configuration stats with an "apply" button, including override resources. Changes to job/level will still force a reset. If the countdown was increased, a "jump" event is prepended to the timeline to ensure actions don't move unexpectedly.

Resolves #206.

Incidental changes:
- Fixed a bug where canvas tooltips sometimes persisted after the mouse cursor left the area.
- Added a message in the timeline editor tab for when there are no skills.