### PR TITLE
Update Tischel CSV export to use action IDs

### DIFF
--- a/src/Components/Common.tsx
+++ b/src/Components/Common.tsx
@@ -99,7 +99,7 @@ export const enum FileFormat {
 	Png = "PNG",
 }
 
-type SaveToFileProps = {
+export type SaveToFileProps = {
 	getContentFn: () => object;
 	filename: string;
 	fileFormat: FileFormat;

--- a/src/Components/LoadSave.tsx
+++ b/src/Components/LoadSave.tsx
@@ -1,15 +1,31 @@
 import React, { useContext } from "react";
-import { Columns, FileFormat, LoadJsonFromFileOrUrl, SaveToFile } from "./Common";
+import { Columns, FileFormat, LoadJsonFromFileOrUrl, SaveToFile, SaveToFileProps } from "./Common";
 import { FflogsImportFlow } from "./FFLogs/ImportInterface";
 import { controller } from "../Controller/Controller";
 import { FileType } from "../Controller/Common";
 import { ImportTimelineFile } from "../Controller/UndoStack";
-import { localize } from "./Localization";
+import { localize, LocalizedContent } from "./Localization";
 import { ImageExport } from "./ImageExport";
 import { TIMELINE_COLUMNS_HEIGHT } from "./Timeline";
 import { getThemeField, ColorThemeContext } from "./ColorTheme";
 
 type Fixme = any;
+
+function ExportItem(props: { blurb: LocalizedContent; saveToFileProps: SaveToFileProps }) {
+	const colors = useContext(ColorThemeContext);
+	return <>
+		<p>{localize(props.blurb)}</p>
+		<div
+			style={{
+				marginLeft: 5,
+				paddingLeft: 10,
+				borderLeft: ("1px solid " + getThemeField(colors, "bgHighContrast")) as string,
+			}}
+		>
+			{SaveToFile(props.saveToFileProps)}
+		</div>
+	</>;
+}
 
 export function LoadSave() {
 	const colors = useContext(ColorThemeContext);
@@ -37,50 +53,65 @@ export function LoadSave() {
 		zh: "导出战斗到文件",
 	});
 	const textExportContent = <div>
-		<p>
-			{localize({
+		<ExportItem
+			blurb={{
 				en: "for sharing and importing:",
 				zh: "用于分享和导入：",
-			})}
-		</p>
-		<SaveToFile
-			fileFormat={FileFormat.Json}
-			getContentFn={() => {
-				return controller.record.serialized();
 			}}
-			filename={"fight"}
-			displayName={localize({
-				en: "txt format",
-				zh: "txt格式",
-			})}
+			saveToFileProps={{
+				fileFormat: FileFormat.Json,
+				getContentFn: () => {
+					return controller.record.serialized();
+				},
+				filename: "fight",
+				displayName: localize({
+					en: "txt format",
+					zh: "txt格式",
+				}),
+			}}
 		/>
-		<p>
-			{localize({
+		<ExportItem
+			blurb={{
+				en: <span>for external tools like excel:</span>,
+				zh: <span>用于excel和另外外部工具：</span>,
+			}}
+			saveToFileProps={{
+				fileFormat: FileFormat.Csv,
+				getContentFn: () => {
+					return { body: controller.getActionsLogCsv() };
+				},
+				filename: "fight",
+				displayName: localize({
+					en: "csv format",
+					zh: "csv格式",
+				}),
+			}}
+		/>
+		<ExportItem
+			blurb={{
 				en: <span>
-					for external tools such as excel and{" "}
-					<a href={"https://github.com/Tischel/BLMInTheShell"}>Tischel's plugin</a>:
+					for <a href={"https://github.com/Tischel/BLMInTheShell"}>Tischel's plugin</a>:
 				</span>,
 				zh: <span>
-					用于excel，
-					<a href={"https://github.com/Tischel/BLMInTheShell"}>Tischel的插件</a>
-					等外部工具：
+					用于
+					<a href={"https://github.com/Tischel/BLMInTheShell"}>Tischel的插件</a>：
 				</span>,
-			})}
-		</p>
-		<SaveToFile
-			fileFormat={FileFormat.Csv}
-			getContentFn={() => {
-				return { body: controller.getActionsLogCsv() };
 			}}
-			filename={"fight"}
-			displayName={localize({
-				en: "csv format",
-				zh: "csv格式",
-			})}
+			saveToFileProps={{
+				fileFormat: FileFormat.Csv,
+				getContentFn: () => {
+					return { body: controller.getActionsLogCsv(true) };
+				},
+				filename: "fight",
+				displayName: localize({
+					en: "csv format",
+					zh: "csv格式",
+				}),
+			}}
 		/>
-		<p>
-			{/* google colab probably doesn't work in China, so just link to github instead */}
-			{localize({
+		<ExportItem
+			// google colab probably doesn't work in China, so just link to github instead
+			blurb={{
 				en: <span>
 					for use with{" "}
 					<a
@@ -99,16 +130,16 @@ export function LoadSave() {
 					</a>
 					：
 				</span>,
-			})}
-		</p>
-		<SaveToFile
-			fileFormat={FileFormat.Csv}
-			getContentFn={() => controller.getAmaSimCsv()}
-			filename={"fight"}
-			displayName={localize({
-				en: "csv format",
-				zh: "csv格式",
-			})}
+			}}
+			saveToFileProps={{
+				fileFormat: FileFormat.Csv,
+				getContentFn: () => controller.getAmaSimCsv(),
+				filename: "fight",
+				displayName: localize({
+					en: "csv format",
+					zh: "csv格式",
+				}),
+			}}
 		/>
 	</div>;
 	const textImportTitle = localize({

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -147,6 +147,7 @@ class Controller {
 	#actionsLogCsv: {
 		time: number;
 		action: string;
+		actionId: number | undefined;
 		isGCD: number;
 		castTime: number;
 		targetList?: number[];
@@ -1233,6 +1234,7 @@ class Controller {
 			this.#actionsLogCsv.push({
 				time: this.game.getDisplayTime(),
 				action: ACTIONS[skillName].name,
+				actionId: ACTIONS[skillName].id,
 				isGCD: isGCD ? 1 : 0,
 				castTime: status.instantCast ? 0 : status.castTime,
 				targetList: node.targetList,
@@ -1557,6 +1559,7 @@ class Controller {
 					this.#actionsLogCsv.push({
 						time: this.game.getDisplayTime(),
 						action: skillName,
+						actionId: undefined,
 						isGCD: 0,
 						castTime: 0,
 						targetList: node.targetList,
@@ -1701,10 +1704,13 @@ class Controller {
 		return [["time", "damageSource", "potency"]].concat(csvRows as any[][]);
 	}
 
-	getActionsLogCsv(): any[][] {
-		const csvRows = this.#actionsLogCsv.map((row) => {
-			return [row.time, row.action, row.isGCD, row.castTime];
-		});
+	getActionsLogCsv(useActionID: boolean = false): any[][] {
+		const csvRows = this.#actionsLogCsv.map((row) => [
+			row.time,
+			useActionID ? (row.actionId ?? row.action) : row.action,
+			row.isGCD,
+			row.castTime,
+		]);
 		return [["time", "action", "isGCD", "castTime"]].concat(csvRows as any[][]);
 	}
 
@@ -2172,6 +2178,7 @@ class Controller {
 		this.#actionsLogCsv.push({
 			time: this.game.getDisplayTime(),
 			action: "Toggle buff: " + RESOURCES[buffName].name,
+			actionId: undefined,
 			isGCD: 0,
 			castTime: 0,
 			isDamaging: false,

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,14 @@
 [
 	{
+		"date": "3/27/26",
+		"changes": [
+			"Updated CSV export for Tischel's striking dummy plugin to use action IDs instead of names."
+		],
+		"changes_zh": [
+			"更新了Tischel的木人插件的CSV导出功能，现已改用技能ID代替技能名称。"
+		]
+	},
+	{
 		"date": "3/23/26",
 		"changes": [
 			"[MNK] Fixed a bug where Fire's Rumination fell off too early."


### PR DESCRIPTION
Also slightly rearranges the export menu to have stronger hierarchy.