### PR TITLE
[DRK] Use normal animation lock for Shadowstride

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4706,9 +4706,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/Game/Jobs/DRK.ts
+++ b/src/Game/Jobs/DRK.ts
@@ -17,7 +17,6 @@ import {
 	makeSpell,
 	makeWeaponskill,
 	MakeAbilityParams,
-	MOVEMENT_SKILL_ANIMATION_LOCK,
 	Spell,
 	StatePredicate,
 	Weaponskill,

--- a/src/Game/Jobs/DRK.ts
+++ b/src/Game/Jobs/DRK.ts
@@ -740,7 +740,8 @@ makeDRKAbility("SHADOWBRINGER", 90, "cd_SHADOWBRINGER", {
 
 makeDRKAbility("SHADOWSTRIDE", 54, "cd_SHADOWSTRIDE", {
 	applicationDelay: 0.66,
-	animationLock: MOVEMENT_SKILL_ANIMATION_LOCK,
+	// Despite being a gap-closer, Shadowstride does not have a longer animation lock than
+	// other oGCDs.
 	cooldown: 30,
 	maxCharges: 2,
 });

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,11 @@
 [
 	{
+		"date": "4/11/26",
+		"changes": [
+			"[DRK] Reduced the animation lock of Shadowstride to match in-game values."
+		]
+	},
+	{
 		"date": "4/6/26",
 		"changes": [
 			"Fixed a bug where skill images would not render after changing jobs."


### PR DESCRIPTION
resolves #342

weirdge

https://www.fflogs.com/reports/QxzR6aMWYjLt29gr?boss=0&difficulty=0&type=casts&view=events

also runs npm audit fix again