### PR TITLE
[PCT] Fix Hammer + Starry Sky motifs having recasts reduced by Hyperphantasia

### DIFF
--- a/src/Game/Jobs/PCT.ts
+++ b/src/Game/Jobs/PCT.ts
@@ -83,7 +83,14 @@ const HYPERPHANTASIA_SKILLS: PCTActionKey[] = [
 	"STAR_PRISM",
 ];
 
-const MOTIFS: ActionKey[] = ["POM_MOTIF", "WING_MOTIF", "CLAW_MOTIF", "MAW_MOTIF"];
+const MOTIFS: ActionKey[] = [
+	"POM_MOTIF",
+	"WING_MOTIF",
+	"CLAW_MOTIF",
+	"MAW_MOTIF",
+	"HAMMER_MOTIF",
+	"STARRY_SKY_MOTIF",
+];
 
 const HAMMER_COMBO: ActionKey[] = ["HAMMER_BRUSH", "HAMMER_STAMP", "POLISHING_HAMMER"];
 

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,11 @@
 [
 	{
+		"date": "6/24/26",
+		"changes": [
+			"[PCT] Fixed a bug where Hammer Motif and Starry Sky Motif had their cast time reduced by Hyperphantasia."
+		]
+	},
+	{
 		"date": "6/22/26",
 		"changes": [
 			"Added English-language tracks for P5 of DMU. I (shanzhe) still refuse to abbreviate it as UMAD."


### PR DESCRIPTION
Fixes #356

Looks like this has been broken since a 7.1 refactor (#102), but nobody noticed because people don't usually try to draw Hammer/Starry Sky under buffs.