### PR TITLE
Add hierarchy to resource override widget

### DIFF
--- a/src/Components/PlaybackControl.tsx
+++ b/src/Components/PlaybackControl.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer, useContext, useState, Dispatch } from "react";
+import React, { useEffect, useReducer, useContext, useState, Dispatch, ReactElement } from "react";
 import { controller, CooldownDisplayMode } from "../Controller/Controller";
 import {
 	ButtonIndicator,
@@ -42,7 +42,13 @@ import {
 	ALL_JOBS,
 	IMPLEMENTATION_LEVELS,
 } from "../Game/Data/Jobs";
-import { ResourceKey, CooldownKey, RESOURCES } from "../Game/Data";
+import {
+	ResourceKey,
+	CooldownKey,
+	RESOURCES,
+	getResourceCategory,
+	ResourceCategory,
+} from "../Game/Data";
 import { getGameState } from "../Game/Jobs";
 
 export let updateConfigDisplay = (config: SerializedConfig) => {};
@@ -162,16 +168,64 @@ function ResourceOverrideSection(props: {
 	// TODO pass from parent as optimization
 	const S = new Set(props.initialResourceOverrides.map((rsc) => rsc.type));
 	const resourceInfos = getAllResources(props.job);
-	// <option> elements for resources that can be overridden
-	const optionEntries: { rsc: ResourceKey | CooldownKey; isCoolDown: number }[] = resourceInfos
-		.entries()
-		.flatMap(([k, info]) => (S.has(k) ? [] : [{ rsc: k, isCoolDown: info.isCoolDown ? 1 : 0 }]))
-		.toArray();
-	const resourceOptions = optionEntries
-		.sort((a, b) => a.isCoolDown - b.isCoolDown)
-		.map((opt, i) => <option key={i} value={opt.rsc}>
-			{localizeResourceType(opt.rsc)}
-		</option>);
+	const RESOURCE_CATEGORY_LABELS: Record<ResourceCategory, LocalizedContent> = {
+		tracker: { en: "Trackers", zh: "追踪" },
+		gauge: { en: "Gauges", zh: "量谱" },
+		status: { en: "Statuses", zh: "状态" },
+		cooldown: { en: "Cooldowns", zh: "CD" },
+	};
+	const trackers: ReactElement[] = [];
+	const gauges: ReactElement[] = [];
+	const statuses: ReactElement[] = [];
+	const cds: ReactElement[] = [];
+	resourceInfos
+		.keys()
+		// TODO: if ever this becomes a computational bottleneck, we can take advantage of the fact
+		// that different resource types are declared contiguously and avoid doing as many calls to
+		// getResourceCategory. Presumably this is a level of micro-optimization we don't need though.
+		.forEach((k) => {
+			if (!S.has(k)) {
+				const category = getResourceCategory(k);
+				const rscArray =
+					category === "tracker"
+						? trackers
+						: category === "gauge"
+							? gauges
+							: category === "status"
+								? statuses
+								: cds;
+				rscArray.push(
+					<option key={k} value={k}>
+						{localizeResourceType(k)}
+					</option>,
+				);
+			}
+		});
+	const resourceOptions = [
+		trackers ? (
+			<optgroup key="tracker" label={localize(RESOURCE_CATEGORY_LABELS["tracker"]) as string}>
+				{trackers}
+			</optgroup>
+		) : undefined,
+		gauges ? (
+			<optgroup key="gauge" label={localize(RESOURCE_CATEGORY_LABELS["gauge"]) as string}>
+				{gauges}
+			</optgroup>
+		) : undefined,
+		statuses ? (
+			<optgroup key="status" label={localize(RESOURCE_CATEGORY_LABELS["status"]) as string}>
+				{statuses}
+			</optgroup>
+		) : undefined,
+		cds ? (
+			<optgroup
+				key="cooldown"
+				label={localize(RESOURCE_CATEGORY_LABELS["cooldown"]) as string}
+			>
+				{cds}
+			</optgroup>
+		) : undefined,
+	];
 
 	const rscType = props.selectedOverrideResource;
 	const info = resourceInfos.get(rscType);

--- a/src/Components/PlaybackControl.tsx
+++ b/src/Components/PlaybackControl.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer, useContext, useState, Dispatch, ReactElement } from "react";
+import React, { useEffect, useReducer, useContext, useState, Dispatch } from "react";
 import { controller, CooldownDisplayMode } from "../Controller/Controller";
 import {
 	ButtonIndicator,
@@ -136,6 +136,61 @@ export function ResourceOverrideDisplay(props: {
 	</div>;
 }
 
+// The order in which different types of resource overrides get displayed.
+const OVERRIDE_RESOURCE_CATEGORY_ORDER: ResourceCategory[] = [
+	"tracker",
+	"gauge",
+	"status",
+	"cooldown",
+];
+
+const OVERRIDE_RESOURCE_CATEGORY_LABELS: Record<ResourceCategory, LocalizedContent> = {
+	tracker: { en: "Trackers", zh: "追踪" },
+	gauge: { en: "Gauges", zh: "量谱" },
+	status: { en: "Statuses", zh: "状态" },
+	cooldown: { en: "Cooldowns", zh: "CD" },
+};
+
+function getAddableOverrideResourcesByCategory(
+	job: ShellJob,
+	overridden: Set<ResourceKey | CooldownKey>,
+): Record<ResourceCategory, (ResourceKey | CooldownKey)[]> {
+	const buckets: Record<ResourceCategory, (ResourceKey | CooldownKey)[]> = {
+		tracker: [],
+		gauge: [],
+		status: [],
+		cooldown: [],
+	};
+	for (const k of getAllResources(job).keys()) {
+		if (!overridden.has(k)) {
+			buckets[getResourceCategory(k)].push(k);
+		}
+	}
+	return buckets;
+}
+
+function getAddableOverrideResourcesInDisplayOrder(
+	job: ShellJob,
+	overridden: Set<ResourceKey | CooldownKey>,
+): (ResourceKey | CooldownKey)[] {
+	const byCategory = getAddableOverrideResourcesByCategory(job, overridden);
+	return OVERRIDE_RESOURCE_CATEGORY_ORDER.flatMap((category) => byCategory[category]);
+}
+
+// By default, the InCombat resource should be shown as overridable (it exists for every job,
+// and it is very frequently set). Afterwards, pick the first resource in display order to
+// override.
+function getDefaultOverrideResource(
+	job: ShellJob,
+	overrides: ResourceOverrideData[],
+): ResourceKey | CooldownKey {
+	const overridden = new Set(overrides.map((ov) => ov.type));
+	if (!overridden.has("IN_COMBAT")) {
+		return "IN_COMBAT";
+	}
+	return getAddableOverrideResourcesInDisplayOrder(job, overridden)[0] ?? "NEVER";
+}
+
 function ResourceOverrideSection(props: {
 	job: ShellJob;
 	initialResourceOverrides: ResourceOverrideData[];
@@ -168,64 +223,23 @@ function ResourceOverrideSection(props: {
 	// TODO pass from parent as optimization
 	const S = new Set(props.initialResourceOverrides.map((rsc) => rsc.type));
 	const resourceInfos = getAllResources(props.job);
-	const RESOURCE_CATEGORY_LABELS: Record<ResourceCategory, LocalizedContent> = {
-		tracker: { en: "Trackers", zh: "追踪" },
-		gauge: { en: "Gauges", zh: "量谱" },
-		status: { en: "Statuses", zh: "状态" },
-		cooldown: { en: "Cooldowns", zh: "CD" },
-	};
-	const trackers: ReactElement[] = [];
-	const gauges: ReactElement[] = [];
-	const statuses: ReactElement[] = [];
-	const cds: ReactElement[] = [];
-	resourceInfos
-		.keys()
-		// TODO: if ever this becomes a computational bottleneck, we can take advantage of the fact
-		// that different resource types are declared contiguously and avoid doing as many calls to
-		// getResourceCategory. Presumably this is a level of micro-optimization we don't need though.
-		.forEach((k) => {
-			if (!S.has(k)) {
-				const category = getResourceCategory(k);
-				const rscArray =
-					category === "tracker"
-						? trackers
-						: category === "gauge"
-							? gauges
-							: category === "status"
-								? statuses
-								: cds;
-				rscArray.push(
-					<option key={k} value={k}>
-						{localizeResourceType(k)}
-					</option>,
-				);
-			}
-		});
-	const resourceOptions = [
-		trackers ? (
-			<optgroup key="tracker" label={localize(RESOURCE_CATEGORY_LABELS["tracker"]) as string}>
-				{trackers}
-			</optgroup>
-		) : undefined,
-		gauges ? (
-			<optgroup key="gauge" label={localize(RESOURCE_CATEGORY_LABELS["gauge"]) as string}>
-				{gauges}
-			</optgroup>
-		) : undefined,
-		statuses ? (
-			<optgroup key="status" label={localize(RESOURCE_CATEGORY_LABELS["status"]) as string}>
-				{statuses}
-			</optgroup>
-		) : undefined,
-		cds ? (
+	const byCategory = getAddableOverrideResourcesByCategory(props.job, S);
+	const resourceOptions = OVERRIDE_RESOURCE_CATEGORY_ORDER.flatMap((category) => {
+		const keys = byCategory[category];
+		if (keys.length === 0) {
+			return [];
+		}
+		return [
 			<optgroup
-				key="cooldown"
-				label={localize(RESOURCE_CATEGORY_LABELS["cooldown"]) as string}
+				key={category}
+				label={localize(OVERRIDE_RESOURCE_CATEGORY_LABELS[category]) as string}
 			>
-				{cds}
-			</optgroup>
-		) : undefined,
-	];
+				{keys.map((k) => <option key={k} value={k}>
+					{localizeResourceType(k)}
+				</option>)}
+			</optgroup>,
+		];
+	});
 
 	const rscType = props.selectedOverrideResource;
 	const info = resourceInfos.get(rscType);
@@ -1276,15 +1290,9 @@ export function Config() {
 	};
 	const [selectedOverrideResource, setSelectedOverrideResource] = useState<
 		ResourceKey | CooldownKey
-	>("NEVER");
+	>("IN_COMBAT");
 	const setFirstSelectedOverride = (overrides: ResourceOverrideData[]) => {
-		const S = new Set<ResourceKey | CooldownKey>(overrides.map((ov) => ov.type));
-		// TODO update ordering to something that's more intuitive?
-		const firstAddableRsc: ResourceKey | CooldownKey =
-			getAllResources(configFields.job)
-				.keys()
-				.find((rsc) => !S.has(rsc)) ?? "NEVER";
-		setSelectedOverrideResource(firstAddableRsc);
+		setSelectedOverrideResource(getDefaultOverrideResource(configFields.job, overrides));
 	};
 	const [jobOrLevelDirty, setJobOrLevelDirty] = useState(false);
 	// config field management
@@ -1312,13 +1320,14 @@ export function Config() {
 				// stats to whatever was stored by the controller.
 				if (action.job === controller.record.config?.job) {
 					Object.assign(newState, controller.gameConfig.serialized());
-					_setInitialResourceOverrides(controller.gameConfig.initialResourceOverrides);
+					const revertedOverrides = controller.gameConfig.initialResourceOverrides;
+					_setInitialResourceOverrides(revertedOverrides);
+					setSelectedOverrideResource(
+						getDefaultOverrideResource(action.job, revertedOverrides),
+					);
 				} else {
 					_setInitialResourceOverrides([]);
-					// need to duplicate some code to prevent a bootstrapping error
-					const firstAddableRsc: ResourceKey | CooldownKey =
-						getAllResources(action.job).keys().toArray()?.[0] ?? "NEVER";
-					setSelectedOverrideResource(firstAddableRsc);
+					setSelectedOverrideResource(getDefaultOverrideResource(action.job, []));
 					// Update stats from last saved timeline of this job.
 					Object.assign(newState, getSavedConfigPart(action.job));
 				}

--- a/src/Game/Data/index.ts
+++ b/src/Game/Data/index.ts
@@ -1,32 +1,223 @@
-import { AST_ACTIONS, AST_COOLDOWNS, AST_RESOURCES, AST_TRAITS } from "./Jobs/AST";
-import { BLM_ACTIONS, BLM_COOLDOWNS, BLM_RESOURCES, BLM_TRAITS } from "./Jobs/BLM";
-import { BRD_ACTIONS, BRD_COOLDOWNS, BRD_RESOURCES, BRD_TRAITS } from "./Jobs/BRD";
-import { DNC_ACTIONS, DNC_COOLDOWNS, DNC_RESOURCES, DNC_TRAITS } from "./Jobs/DNC";
-import { DRG_ACTIONS, DRG_COOLDOWNS, DRG_RESOURCES, DRG_TRAITS } from "./Jobs/DRG";
-import { DRK_ACTIONS, DRK_COOLDOWNS, DRK_RESOURCES, DRK_TRAITS } from "./Jobs/DRK";
-import { GNB_ACTIONS, GNB_COOLDOWNS, GNB_RESOURCES, GNB_TRAITS } from "./Jobs/GNB";
-import { MCH_ACTIONS, MCH_COOLDOWNS, MCH_RESOURCES, MCH_TRAITS } from "./Jobs/MCH";
-import { MNK_ACTIONS, MNK_COOLDOWNS, MNK_RESOURCES, MNK_TRAITS } from "./Jobs/MNK";
-import { NIN_ACTIONS, NIN_COOLDOWNS, NIN_RESOURCES, NIN_TRAITS } from "./Jobs/NIN";
-import { PCT_ACTIONS, PCT_COOLDOWNS, PCT_RESOURCES, PCT_TRAITS } from "./Jobs/PCT";
-import { PLD_ACTIONS, PLD_COOLDOWNS, PLD_RESOURCES, PLD_TRAITS } from "./Jobs/PLD";
-import { RDM_ACTIONS, RDM_COOLDOWNS, RDM_RESOURCES, RDM_TRAITS } from "./Jobs/RDM";
-import { RPR_ACTIONS, RPR_COOLDOWNS, RPR_RESOURCES, RPR_TRAITS } from "./Jobs/RPR";
-import { SAM_ACTIONS, SAM_COOLDOWNS, SAM_RESOURCES, SAM_TRAITS } from "./Jobs/SAM";
-import { SCH_ACTIONS, SCH_COOLDOWNS, SCH_RESOURCES, SCH_TRAITS } from "./Jobs/SCH";
-import { SGE_ACTIONS, SGE_COOLDOWNS, SGE_RESOURCES, SGE_TRAITS } from "./Jobs/SGE";
-import { SMN_ACTIONS, SMN_COOLDOWNS, SMN_RESOURCES, SMN_TRAITS } from "./Jobs/SMN";
-import { VPR_ACTIONS, VPR_COOLDOWNS, VPR_RESOURCES, VPR_TRAITS } from "./Jobs/VPR";
-import { WAR_ACTIONS, WAR_COOLDOWNS, WAR_RESOURCES, WAR_TRAITS } from "./Jobs/WAR";
-import { WHM_ACTIONS, WHM_COOLDOWNS, WHM_RESOURCES, WHM_TRAITS } from "./Jobs/WHM";
-import { BLU_ACTIONS, BLU_COOLDOWNS, BLU_RESOURCES, BLU_TRAITS } from "./Jobs/BLU";
-import { COMMON_ACTIONS, COMMON_COOLDOWNS, COMMON_RESOURCES, COMMON_TRAITS } from "./Shared/Common";
+import {
+	AST_ACTIONS,
+	AST_COOLDOWNS,
+	AST_GAUGES,
+	AST_STATUSES,
+	AST_TRACKERS,
+	AST_RESOURCES,
+	AST_TRAITS,
+} from "./Jobs/AST";
+import {
+	BLM_ACTIONS,
+	BLM_COOLDOWNS,
+	BLM_GAUGES,
+	BLM_STATUSES,
+	BLM_TRACKERS,
+	BLM_RESOURCES,
+	BLM_TRAITS,
+} from "./Jobs/BLM";
+import {
+	BRD_ACTIONS,
+	BRD_COOLDOWNS,
+	BRD_GAUGES,
+	BRD_STATUSES,
+	BRD_TRACKERS,
+	BRD_RESOURCES,
+	BRD_TRAITS,
+} from "./Jobs/BRD";
+import {
+	DNC_ACTIONS,
+	DNC_COOLDOWNS,
+	DNC_GAUGES,
+	DNC_STATUSES,
+	DNC_TRACKERS,
+	DNC_RESOURCES,
+	DNC_TRAITS,
+} from "./Jobs/DNC";
+import {
+	DRG_ACTIONS,
+	DRG_COOLDOWNS,
+	DRG_GAUGES,
+	DRG_STATUSES,
+	DRG_TRACKERS,
+	DRG_RESOURCES,
+	DRG_TRAITS,
+} from "./Jobs/DRG";
+import {
+	DRK_ACTIONS,
+	DRK_COOLDOWNS,
+	DRK_GAUGES,
+	DRK_STATUSES,
+	DRK_TRACKERS,
+	DRK_RESOURCES,
+	DRK_TRAITS,
+} from "./Jobs/DRK";
+import {
+	GNB_ACTIONS,
+	GNB_COOLDOWNS,
+	GNB_GAUGES,
+	GNB_STATUSES,
+	GNB_TRACKERS,
+	GNB_RESOURCES,
+	GNB_TRAITS,
+} from "./Jobs/GNB";
+import {
+	MCH_ACTIONS,
+	MCH_COOLDOWNS,
+	MCH_GAUGES,
+	MCH_STATUSES,
+	MCH_TRACKERS,
+	MCH_RESOURCES,
+	MCH_TRAITS,
+} from "./Jobs/MCH";
+import {
+	MNK_ACTIONS,
+	MNK_COOLDOWNS,
+	MNK_GAUGES,
+	MNK_STATUSES,
+	MNK_TRACKERS,
+	MNK_RESOURCES,
+	MNK_TRAITS,
+} from "./Jobs/MNK";
+import {
+	NIN_ACTIONS,
+	NIN_COOLDOWNS,
+	NIN_GAUGES,
+	NIN_STATUSES,
+	NIN_TRACKERS,
+	NIN_RESOURCES,
+	NIN_TRAITS,
+} from "./Jobs/NIN";
+import {
+	PCT_ACTIONS,
+	PCT_COOLDOWNS,
+	PCT_GAUGES,
+	PCT_STATUSES,
+	PCT_TRACKERS,
+	PCT_RESOURCES,
+	PCT_TRAITS,
+} from "./Jobs/PCT";
+import {
+	PLD_ACTIONS,
+	PLD_COOLDOWNS,
+	PLD_GAUGES,
+	PLD_STATUSES,
+	PLD_TRACKERS,
+	PLD_RESOURCES,
+	PLD_TRAITS,
+} from "./Jobs/PLD";
+import {
+	RDM_ACTIONS,
+	RDM_COOLDOWNS,
+	RDM_GAUGES,
+	RDM_STATUSES,
+	RDM_TRACKERS,
+	RDM_RESOURCES,
+	RDM_TRAITS,
+} from "./Jobs/RDM";
+import {
+	RPR_ACTIONS,
+	RPR_COOLDOWNS,
+	RPR_GAUGES,
+	RPR_STATUSES,
+	RPR_TRACKERS,
+	RPR_RESOURCES,
+	RPR_TRAITS,
+} from "./Jobs/RPR";
+import {
+	SAM_ACTIONS,
+	SAM_COOLDOWNS,
+	SAM_GAUGES,
+	SAM_STATUSES,
+	SAM_TRACKERS,
+	SAM_RESOURCES,
+	SAM_TRAITS,
+} from "./Jobs/SAM";
+import {
+	SCH_ACTIONS,
+	SCH_COOLDOWNS,
+	SCH_GAUGES,
+	SCH_STATUSES,
+	SCH_TRACKERS,
+	SCH_RESOURCES,
+	SCH_TRAITS,
+} from "./Jobs/SCH";
+import {
+	SGE_ACTIONS,
+	SGE_COOLDOWNS,
+	SGE_GAUGES,
+	SGE_STATUSES,
+	SGE_TRACKERS,
+	SGE_RESOURCES,
+	SGE_TRAITS,
+} from "./Jobs/SGE";
+import {
+	SMN_ACTIONS,
+	SMN_COOLDOWNS,
+	SMN_GAUGES,
+	SMN_STATUSES,
+	SMN_TRACKERS,
+	SMN_RESOURCES,
+	SMN_TRAITS,
+} from "./Jobs/SMN";
+import {
+	VPR_ACTIONS,
+	VPR_COOLDOWNS,
+	VPR_GAUGES,
+	VPR_STATUSES,
+	VPR_TRACKERS,
+	VPR_RESOURCES,
+	VPR_TRAITS,
+} from "./Jobs/VPR";
+import {
+	WAR_ACTIONS,
+	WAR_COOLDOWNS,
+	WAR_GAUGES,
+	WAR_STATUSES,
+	WAR_TRACKERS,
+	WAR_RESOURCES,
+	WAR_TRAITS,
+} from "./Jobs/WAR";
+import {
+	WHM_ACTIONS,
+	WHM_COOLDOWNS,
+	WHM_GAUGES,
+	WHM_STATUSES,
+	WHM_TRACKERS,
+	WHM_RESOURCES,
+	WHM_TRAITS,
+} from "./Jobs/WHM";
+import {
+	BLU_ACTIONS,
+	BLU_COOLDOWNS,
+	BLU_GAUGES,
+	BLU_STATUSES,
+	BLU_TRACKERS,
+	BLU_RESOURCES,
+	BLU_TRAITS,
+} from "./Jobs/BLU";
+import {
+	COMMON_ACTIONS,
+	COMMON_COOLDOWNS,
+	COMMON_GAUGES,
+	COMMON_STATUSES,
+	COMMON_TRACKERS,
+	COMMON_RESOURCES,
+	COMMON_TRAITS,
+} from "./Shared/Common";
 import {
 	LIMIT_BREAK_ACTIONS,
 	LIMIT_BREAK_COOLDOWNS,
 	LIMIT_BREAK_RESOURCES,
 } from "./Shared/LimitBreak";
-import { ROLE_ACTIONS, ROLE_COOLDOWNS, ROLE_RESOURCES, ROLE_TRAITS } from "./Shared/Role";
+import {
+	ROLE_ACTIONS,
+	ROLE_COOLDOWNS,
+	ROLE_STATUSES,
+	ROLE_TRACKERS,
+	ROLE_RESOURCES,
+	ROLE_TRAITS,
+} from "./Shared/Role";
 
 export const ACTIONS = {
 	...COMMON_ACTIONS,
@@ -104,6 +295,120 @@ export const COOLDOWNS = {
 	...PCT_COOLDOWNS,
 	// Limited
 	...BLU_COOLDOWNS,
+};
+
+export const GAUGES = {
+	...COMMON_GAUGES,
+
+	// Tanks
+	...PLD_GAUGES,
+	...WAR_GAUGES,
+	...DRK_GAUGES,
+	...GNB_GAUGES,
+
+	// Healers
+	...WHM_GAUGES,
+	...SCH_GAUGES,
+	...AST_GAUGES,
+	...SGE_GAUGES,
+
+	// Melee
+	...MNK_GAUGES,
+	...DRG_GAUGES,
+	...NIN_GAUGES,
+	...SAM_GAUGES,
+	...RPR_GAUGES,
+	...VPR_GAUGES,
+
+	// Ranged
+	...BRD_GAUGES,
+	...MCH_GAUGES,
+	...DNC_GAUGES,
+
+	// Casters
+	...BLM_GAUGES,
+	...SMN_GAUGES,
+	...RDM_GAUGES,
+	...PCT_GAUGES,
+	// Limited
+	...BLU_GAUGES,
+};
+
+export const STATUSES = {
+	...COMMON_STATUSES,
+	...ROLE_STATUSES,
+	...LIMIT_BREAK_RESOURCES,
+
+	// Tanks
+	...PLD_STATUSES,
+	...WAR_STATUSES,
+	...DRK_STATUSES,
+	...GNB_STATUSES,
+
+	// Healers
+	...WHM_STATUSES,
+	...SCH_STATUSES,
+	...AST_STATUSES,
+	...SGE_STATUSES,
+
+	// Melee
+	...MNK_STATUSES,
+	...DRG_STATUSES,
+	...NIN_STATUSES,
+	...SAM_STATUSES,
+	...RPR_STATUSES,
+	...VPR_STATUSES,
+
+	// Ranged
+	...BRD_STATUSES,
+	...MCH_STATUSES,
+	...DNC_STATUSES,
+
+	// Casters
+	...BLM_STATUSES,
+	...SMN_STATUSES,
+	...RDM_STATUSES,
+	...PCT_STATUSES,
+	// Limited
+	...BLU_STATUSES,
+};
+
+export const TRACKERS = {
+	...COMMON_TRACKERS,
+	...ROLE_TRACKERS,
+
+	// Tanks
+	...PLD_TRACKERS,
+	...WAR_TRACKERS,
+	...DRK_TRACKERS,
+	...GNB_TRACKERS,
+
+	// Healers
+	...WHM_TRACKERS,
+	...SCH_TRACKERS,
+	...AST_TRACKERS,
+	...SGE_TRACKERS,
+
+	// Melee
+	...MNK_TRACKERS,
+	...DRG_TRACKERS,
+	...NIN_TRACKERS,
+	...SAM_TRACKERS,
+	...RPR_TRACKERS,
+	...VPR_TRACKERS,
+
+	// Ranged
+	...BRD_TRACKERS,
+	...MCH_TRACKERS,
+	...DNC_TRACKERS,
+
+	// Casters
+	...BLM_TRACKERS,
+	...SMN_TRACKERS,
+	...RDM_TRACKERS,
+	...PCT_TRACKERS,
+	// Limited
+	...BLU_TRACKERS,
 };
 
 export const RESOURCES = {
@@ -189,8 +494,36 @@ export type ActionKey = keyof Actions;
 export type Cooldowns = typeof COOLDOWNS;
 export type CooldownKey = keyof Cooldowns;
 
+export type Gauges = typeof GAUGES;
+export type GaugeKey = keyof Gauges;
+
+export type Statuses = typeof STATUSES;
+export type StatusKey = keyof Statuses;
+
+export type Trackers = typeof TRACKERS;
+export type TrackerKey = keyof Trackers;
+
 export type Resources = typeof RESOURCES;
 export type ResourceKey = keyof Resources;
+
+export type ResourceCategory = "cooldown" | "gauge" | "status" | "tracker";
+
+export function getResourceCategory(key: ResourceKey | CooldownKey): ResourceCategory {
+	if (key in COOLDOWNS) {
+		return "cooldown";
+	}
+	if (key in GAUGES) {
+		return "gauge";
+	}
+	if (key in STATUSES) {
+		return "status";
+	}
+	if (key in TRACKERS) {
+		return "tracker";
+	}
+	console.error(`Unknown resource category for ${key}, defaulting to status`);
+	return "status";
+}
 
 export type Traits = typeof TRAITS;
 export type TraitKey = keyof Traits;

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,14 @@
 [
 	{
+		"date": "8/30/26",
+		"changes": [
+			"Separated resource overrides into separate sub-groups for trackers, gauges, statuses, and cooldowns."
+		],
+		"changes_zh": [
+			"将初始资源细分为“追踪”、“量谱”、“状态”、和“CD”四大分类。"
+		]
+	},
+	{
 		"date": "7/12/26",
 		"changes": [
 			"The skill cooldown overlay now always shows the time until the skill's next stack is available, and no longer counts animation lock time."


### PR DESCRIPTION
<img width="300" height="613" alt="image" src="https://github.com/user-attachments/assets/ffe644c2-8211-4f6d-8530-bf4bc3152f8b" />

Adds an <optgroup> to create some logical separation between different resource kinds. The default-selected resource is also now `InCombat` rather than `cd_GCD`.